### PR TITLE
Add DigitalOcean App Platform guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,23 @@
 
    gcloud run deploy admin-service \
      --source ./admin \
-     --set-env-vars ADMIN_EMAIL=$ADMIN_EMAIL,ADMIN_PASSWORD=$ADMIN_PASSWORD,MONGODB_URI=$MONGODB_URI \
-     --allow-unauthenticated
+    --set-env-vars ADMIN_EMAIL=$ADMIN_EMAIL,ADMIN_PASSWORD=$ADMIN_PASSWORD,MONGODB_URI=$MONGODB_URI \
+    --allow-unauthenticated
+  ```
+
+### Развертывание на DigitalOcean App Platform
+1. Соберите образы и загрузите их в DigitalOcean Container Registry:
+   ```bash
+   doctl registry login
+   docker build -t registry.digitalocean.com/<REGISTRY_NAME>/bot ./bot
+   docker build -t registry.digitalocean.com/<REGISTRY_NAME>/admin ./admin
+   docker push registry.digitalocean.com/<REGISTRY_NAME>/bot
+   docker push registry.digitalocean.com/<REGISTRY_NAME>/admin
    ```
+2. Создайте приложение с двумя сервисами: бот в роли Worker и панель как Web Service.
+3. В настройках обоих сервисов укажите переменные окружения:
+   `TELEGRAM_BOT_TOKEN`, `JWT_SECRET`, `MONGODB_URI`, `ADMIN_EMAIL`, `ADMIN_PASSWORD`.
+4. Подробности описаны в [официальном руководстве DigitalOcean](https://docs.digitalocean.com/products/app-platform/).
 
 ## Структура проекта
 ```


### PR DESCRIPTION
## Summary
- document how to deploy bot and admin to DigitalOcean App Platform

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6852b46acc448320959f20e09cad1d80