### PR TITLE
Удаление skip-build для yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY bot/package*.json ./bot/
 COPY admin/package.json ./admin/
 COPY admin/yarn.lock ./admin/
 COPY admin/.yarnrc.yml ./admin/
-RUN cd admin && corepack enable && corepack prepare yarn@stable --activate && yarn install --immutable --mode=skip-build && cd .. && cd bot && npm install && cd ..
+RUN cd admin && corepack enable && corepack prepare yarn@stable --activate && yarn install --immutable && cd .. && cd bot && npm install && cd ..
 
 # Копирование исходников
 COPY bot ./bot

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -12,7 +12,7 @@ COPY yarn.lock ./
 COPY .yarnrc.yml ./
 
 RUN corepack enable && corepack prepare yarn@stable --activate
-RUN yarn install --immutable --mode=skip-build
+RUN yarn install --immutable
 COPY . .
 
 RUN npx prisma generate


### PR DESCRIPTION
## Изменения
- убран параметр `--mode=skip-build` в обоих Dockerfile
- проверена сборка панели и установка зависимостей

## Проверка
- `yarn install --immutable` в каталоге `admin` успешно собирает `argon2`
- `yarn build` выполняется без ошибок

Docker недоступен, поэтому сборка контейнеров не проверена.

------
https://chatgpt.com/codex/tasks/task_b_6853f9cc2ff48320a54badd38e2fa2f1