### PR TITLE
Handle API errors with middleware

### DIFF
--- a/bot/src/api/api.js
+++ b/bot/src/api/api.js
@@ -1,26 +1,28 @@
-// HTTP API и раздача мини-приложения. Модули: express, service, middleware
+// HTTP API и раздача мини-приложения. Модули: express, service, middleware, errorHandler
 const express = require('express')
 const path = require('path')
 const { createTask, listUserTasks, listAllTasks, updateTaskStatus } = require('../services/service')
-const { verifyToken } = require('./middleware');
+const { verifyToken, asyncHandler, errorHandler } = require('./middleware');
 const app = express()
 app.use(express.json())
 app.use(express.static(path.join(__dirname, '../../public')))
 
-app.get('/tasks', verifyToken, async (req, res) => {
+app.get('/tasks', verifyToken, asyncHandler(async (req, res) => {
   const tasks = req.query.userId ? await listUserTasks(req.query.userId) : await listAllTasks()
   res.json(tasks)
-})
+}))
 
-app.post('/tasks', verifyToken, async (req, res) => {
+app.post('/tasks', verifyToken, asyncHandler(async (req, res) => {
   const task = await createTask(req.body.description)
   res.json(task)
-})
+}))
 
-app.post('/tasks/:id/status', verifyToken, async (req, res) => {
+app.post('/tasks/:id/status', verifyToken, asyncHandler(async (req, res) => {
   await updateTaskStatus(req.params.id, req.body.status)
   res.json({ status: 'ok' })
-})
+}))
+
+app.use(errorHandler)
 
 // По умолчанию API слушает порт 3000
 app.listen(process.env.PORT || 3000)

--- a/bot/src/api/middleware.js
+++ b/bot/src/api/middleware.js
@@ -1,6 +1,21 @@
-// Middleware проверки JWT из заголовка Authorization (Bearer или токен).
+// Middleware проверки JWT и базовая обработка ошибок.
 // Модуль: jsonwebtoken
 const jwt = require('jsonwebtoken');
+
+// Обёртка для перехвата ошибок асинхронных функций
+const asyncHandler = fn => async (req, res, next) => {
+  try {
+    await fn(req, res, next);
+  } catch (e) {
+    next(e);
+  }
+};
+
+// Обработчик ошибок API
+function errorHandler(err, _req, res, _next) {
+  console.error(err);
+  res.status(500).json({ error: err.message });
+}
 
 const secretKey = process.env.JWT_SECRET;
 if (!secretKey) {
@@ -30,4 +45,4 @@ function verifyToken(req, res, next) {
   });
 }
 
-module.exports = { verifyToken };
+module.exports = { verifyToken, asyncHandler, errorHandler };


### PR DESCRIPTION
## Summary
- wrap все асинхронные обработчики `api.js` через `asyncHandler`
- добавить `asyncHandler` и `errorHandler` в middleware

## Testing
- `docker compose config` *(fails: docker not installed)*
- `node -e "require('./bot/src/api/api.js')"` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_b_685477177c1483208aee2b253072ee08