### PR TITLE
Fix TaskDialog hook deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,3 +81,4 @@
 - Удалены неиспользуемые состояния `roles` и `groups` в компоненте `TaskDialog`
 - Провайдер `ThemeProvider` корректно экспортируется из файла `ThemeContext.tsx`
 - Провайдеры `SidebarProvider` и `ToastProvider` экспортируются из файлов контекста
+- Исправлены зависимости `useEffect` в `TaskDialog`, предупреждения ESLint исчезли

--- a/bot/web/src/components/TaskDialog.tsx
+++ b/bot/web/src/components/TaskDialog.tsx
@@ -76,7 +76,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
       setStatuses(v)
       if (!status && v.length) setStatus(v[0])
     })
-  }, [])
+  }, [taskType, priority, transportType, paymentMethod, status])
   React.useEffect(()=>{
     if(isEdit&&id){
       authFetch(`/api/v1/tasks/${id}`).then(r=>r.ok?r.json():null).then(t=>{
@@ -130,7 +130,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
       setControllers(t.controllers||[]);
       setAttachments(t.attachments||[]);
     });
-  }, [id, isEdit]);
+  }, [id, isEdit, taskType, priority, transportType, paymentMethod, status]);
 
 
   const handleStartLink=async(v:string)=>{


### PR DESCRIPTION
## Summary
- add missing useEffect dependencies in TaskDialog
- update changelog

## Testing
- `npm run lint --prefix bot/web`
- `./scripts/setup_and_test.sh`
- `./scripts/audit_deps.sh`


------
https://chatgpt.com/codex/tasks/task_b_686a7e150ec48320b34846bd58fed977