### PR TITLE
Fix admin module import

### DIFF
--- a/bot/src/admin/admin.mjs
+++ b/bot/src/admin/admin.mjs
@@ -3,7 +3,8 @@
 import AdminJS from 'adminjs'
 import AdminJSExpress from '@adminjs/express'
 import AdminJSMongoose from '@adminjs/mongoose'
-import { Task, Archive, Group, User, Role, Department, Log } from '../db/model'
+import models from '../db/model.js'
+const { Task, Archive, Group, User, Role, Department, Log } = models
 import connect from '../db/connection.js'
 
 async function initAdmin(app) {


### PR DESCRIPTION
## Summary
- fix import path in AdminJS module

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/audit_deps.sh`


------
https://chatgpt.com/codex/tasks/task_b_6875491999d08320923441bc3c8a5a8c