### PR TITLE
Исправлен secure cookie в тестах

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,3 +223,4 @@
 - Сессия хранится в MongoDB, cookie передаётся только по HTTPS, маршруты задач ограничены rate limit
 - CSRF-токен передается через cookie XSRF-TOKEN и добавляется в заголовок автоматической обёрткой fetch
 - Маршруты `/api/v1/auth/send_code` и `/api/v1/auth/verify_code` не требуют CSRF-токена
+- Тесты используют secure cookie только в продакшене

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -175,3 +175,4 @@
 157. CSRF-токен находится в cookie XSRF-TOKEN и автоматически отправляется authFetch
 158. Маршруты `/api/v1/auth/send_code` и `/api/v1/auth/verify_code` не требуют CSRF-токена
 159. Сессии хранятся в MongoDB через библиотеку connect-mongo
+160. Тесты используют secure cookie только в продакшене

--- a/bot/tests/authCsrfRoute.test.js
+++ b/bot/tests/authCsrfRoute.test.js
@@ -1,49 +1,58 @@
-process.env.NODE_ENV = 'test'
-process.env.BOT_TOKEN = 't'
-process.env.CHAT_ID = '1'
-process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db'
-process.env.JWT_SECRET = 'secret'
-process.env.APP_URL = 'https://localhost'
+// Тесты проверки CSRF-маршрутов аутентификации.
+process.env.NODE_ENV = 'test';
+process.env.BOT_TOKEN = 't';
+process.env.CHAT_ID = '1';
+process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
+process.env.JWT_SECRET = 'secret';
+process.env.APP_URL = 'https://localhost';
 
-const express = require('express')
-const cookieParser = require('cookie-parser')
-const session = require('express-session')
-const lusca = require('lusca')
-const request = require('supertest')
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const session = require('express-session');
+const lusca = require('lusca');
+const request = require('supertest');
 
 jest.mock('../src/controllers/authController', () => ({
   sendCode: jest.fn((_req, res) => res.json({ status: 'ok' })),
   verifyCode: jest.fn((_req, res) => res.json({ token: 't' })),
-}))
+}));
 
-const authRouter = require('../src/routes/authUser')
-const { stopScheduler } = require('../src/services/scheduler')
-const { stopQueue } = require('../src/services/messageQueue')
+const authRouter = require('../src/routes/authUser');
+const { stopScheduler } = require('../src/services/scheduler');
+const { stopQueue } = require('../src/services/messageQueue');
 
-let app
+let app;
 beforeAll(() => {
-  app = express()
-  app.use(express.json())
-  app.use(cookieParser())
+  app = express();
+  app.use(express.json());
+  app.use(cookieParser());
   app.use(
-    session({ secret: 'test', resave: false, saveUninitialized: true })
-  )
-  const csrf = lusca.csrf({ angular: true })
+    session({
+      secret: 'test',
+      resave: false,
+      saveUninitialized: true,
+      cookie: { secure: process.env.NODE_ENV === 'production' },
+    }),
+  );
+  const csrf = lusca.csrf({ angular: true });
   app.use((req, res, next) => {
-    const url = req.originalUrl.split('?')[0]
+    const url = req.originalUrl.split('?')[0];
     if (['/api/v1/auth/send_code', '/api/v1/auth/verify_code'].includes(url)) {
-      return next()
+      return next();
     }
-    return csrf(req, res, next)
-  })
-  app.use('/api/v1/auth', authRouter)
-})
+    return csrf(req, res, next);
+  });
+  app.use('/api/v1/auth', authRouter);
+});
 
 test('send_code без CSRF возвращает 200', async () => {
   const res = await request(app)
     .post('/api/v1/auth/send_code')
-    .send({ telegramId: 1 })
-  expect(res.status).toBe(200)
-})
+    .send({ telegramId: 1 });
+  expect(res.status).toBe(200);
+});
 
-afterAll(() => { stopScheduler(); stopQueue() })
+afterAll(() => {
+  stopScheduler();
+  stopQueue();
+});


### PR DESCRIPTION
## Summary
- включён secure cookie только в продакшене для `authCsrfRoute.test.js`
- обновлены CHANGELOG и ROADMAP

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/audit_deps.sh`


------
https://chatgpt.com/codex/tasks/task_b_687e8ea642788320ac044044176fa34e