### PR TITLE
Add IPv6 Redis support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,8 @@ HOST_PORT=3000
 LOCALE=ru
 
 # REDIS_URL — адрес сервера Redis.
+# Для Railway требуется указать параметр `family=0`:
+# REDIS_URL=redis://user:pass@redis.railway.internal:6379?family=0
 REDIS_URL=redis://localhost:6379
 
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@
 ```bash
 docker run -d --name redis -p 6379:6379 redis:alpine
 ```
+Если используете Redis на Railway, добавьте `?family=0` в `REDIS_URL`,
+например:
+
+```bash
+REDIS_URL=redis://user:pass@redis.railway.internal:6379?family=0
+```
 
 ## Быстрый старт
 

--- a/bot/src/services/cache.js
+++ b/bot/src/services/cache.js
@@ -7,7 +7,8 @@ if (process.env.NODE_ENV === 'test') {
   const RedisMock = require('ioredis-mock');
   client = new RedisMock();
 } else {
-  client = new Redis(process.env.REDIS_URL || 'redis://localhost:6379');
+  const url = process.env.REDIS_URL || 'redis://localhost:6379';
+  client = new Redis(`${url}?family=0`);
 }
 client.on('error', (err) => {
   console.error('Ошибка Redis:', err);

--- a/docs/technical_manual.md
+++ b/docs/technical_manual.md
@@ -93,6 +93,11 @@ docker run -d --name redis -p 6379:6379 redis:alpine
 ```
 
 При необходимости укажите адрес в переменной `REDIS_URL`.
+Если сервер Redis запущен на Railway, добавьте `?family=0`:
+
+```bash
+REDIS_URL=redis://user:pass@redis.railway.internal:6379?family=0
+```
 
 ### Railway
 


### PR DESCRIPTION
## Summary
- append `family=0` when connecting to Redis
- document internal Railway connection for Redis
- clarify `REDIS_URL` example

## Testing
- `docker compose config`
- `./scripts/audit_deps.sh`
- `./scripts/setup_and_test.sh`


------
https://chatgpt.com/codex/tasks/task_b_68808a140cc083209194b13b71fc0326