### PR TITLE
Fix ESLint plugin install

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 ```bash
 docker run -d --name redis -p 6379:6379 redis:alpine
 ```
+
 Если используете Redis на Railway, добавьте `?family=0` в `REDIS_URL`,
 например:
 
@@ -42,7 +43,7 @@ REDIS_URL=redis://user:pass@redis.railway.internal:6379?family=0
 git clone https://github.com/AgroxOD/agrmcs.git
 cd agrmcs
 ./scripts/create_env_from_exports.sh
-./scripts/install_bot_deps.sh
+./scripts/install_bot_deps.sh # устанавливает зависимости сервера и клиента
 npm --prefix bot run dev
 ```
 

--- a/docs/technical_manual.md
+++ b/docs/technical_manual.md
@@ -90,7 +90,7 @@ API использует middleware `lusca.csrf`. Токен хранится в
 ## Развёртывание и запуск
 
 - Локальная разработка начинается с создания `.env` через `./scripts/create_env_from_exports.sh`.
-- Зависимости устанавливаются скриптом `./scripts/install_bot_deps.sh`.
+- Зависимости сервера и клиента устанавливаются скриптом `./scripts/install_bot_deps.sh`.
 - Тесты и статический анализ запускаются `./scripts/setup_and_test.sh`.
 - Для проверки зависимостей выполните `./scripts/audit_deps.sh`.
 
@@ -98,7 +98,7 @@ API использует middleware `lusca.csrf`. Токен хранится в
 
 ```bash
 ./scripts/create_env_from_exports.sh
-./scripts/install_bot_deps.sh
+./scripts/install_bot_deps.sh # устанавливает все зависимости
 npm --prefix bot run dev
 ```
 

--- a/scripts/install_bot_deps.sh
+++ b/scripts/install_bot_deps.sh
@@ -4,7 +4,10 @@
 set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 
+# Устанавливаем зависимости сервера
 npm ci --prefix "$DIR/bot" || npm --prefix "$DIR/bot" install
+# Устанавливаем зависимости веб-клиента
+npm ci --prefix "$DIR/bot/web" || npm --prefix "$DIR/bot/web" install
 # Слабые уязвимости не блокируют установку
 npm audit fix --prefix "$DIR/bot" || npm audit fix --force --prefix "$DIR/bot" || true
 # Проверяем наличие серьёзных проблем


### PR DESCRIPTION
## Summary
- install client deps with install_bot_deps.sh
- clarify docs about installing all dependencies

## Testing
- `./scripts/audit_deps.sh`
- `./scripts/setup_and_test.sh`


------
https://chatgpt.com/codex/tasks/task_b_68824f3dce0483209aeb6cb60c2cf8f8