### PR TITLE
Fix route CSRF flow

### DIFF
--- a/bot/tests/fetchRouteService.test.js
+++ b/bot/tests/fetchRouteService.test.js
@@ -1,0 +1,26 @@
+// Тест сервиса fetchRoute
+process.env.NODE_ENV='test'
+process.env.BOT_TOKEN='t'
+process.env.CHAT_ID='1'
+process.env.JWT_SECRET='s'
+process.env.MONGO_DATABASE_URL='mongodb://localhost/db'
+process.env.APP_URL='https://localhost'
+
+const { stopScheduler } = require('../src/services/scheduler')
+const { stopQueue } = require('../src/services/messageQueue')
+
+jest.mock('../web/src/utils/authFetch')
+const authFetch = require('../web/src/utils/authFetch').default
+
+const { fetchRoute } = require('../web/src/services/route')
+
+afterEach(()=>{ jest.resetAllMocks() })
+afterAll(()=>{ stopScheduler(); stopQueue() })
+
+test('fetchRoute предварительно запрашивает CSRF', async()=>{
+  global.fetch = jest.fn().mockResolvedValue({})
+  authFetch.mockResolvedValue({ ok:true, json: async()=>({d:1}) })
+  await fetchRoute({lat:1,lng:2},{lat:3,lng:4})
+  expect(global.fetch).toHaveBeenCalledWith('/api/v1/csrf', { credentials:'include' })
+  expect(authFetch).toHaveBeenCalledWith('/api/v1/route', expect.objectContaining({ method:'POST' }))
+})

--- a/bot/web/src/services/route.js
+++ b/bot/web/src/services/route.js
@@ -2,12 +2,14 @@
 // Модули: authFetch
 import authFetch from "../utils/authFetch";
 
-export const fetchRoute = (start, end) =>
-  authFetch("/api/v1/route", {
+export const fetchRoute = async (start, end) => {
+  await fetch("/api/v1/csrf", { credentials: "include" }).catch(() => {});
+  const res = await authFetch("/api/v1/route", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ start, end })
-  }).then((r) => (r.ok ? r.json() : null));
-
+  });
+  return res.ok ? res.json() : null;
+};
 export default fetchRoute;
 


### PR DESCRIPTION
## Summary
- fetch new CSRF token before requesting `/api/v1/route`
- test that `fetchRoute` requests CSRF token first

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/audit_deps.sh`


------
https://chatgpt.com/codex/tasks/task_b_68836bfd3d808320840b5704011c2f5b