### PR TITLE
Fix build error for mapUtils imports

### DIFF
--- a/bot/web/vite.config.js
+++ b/bot/web/vite.config.js
@@ -8,6 +8,9 @@ export default defineConfig({
   build: {
     outDir: '../public',
     chunkSizeWarningLimit: 1500,
+    commonjsOptions: {
+      include: [/shared/],
+    },
     rollupOptions: {
       output: {
         manualChunks: {


### PR DESCRIPTION
## Summary
- configure Vite to treat shared utilities as commonjs

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/audit_deps.sh`
- `docker compose config`

------
https://chatgpt.com/codex/tasks/task_b_688b7741ca7083208bfd5b75b83d727d