### PR TITLE
Fix build failure in Vite React client

### DIFF
--- a/bot/web/src/main.tsx
+++ b/bot/web/src/main.tsx
@@ -1,6 +1,6 @@
 // Точка входа: выбирает режим приложения (браузер или Telegram)
 import React from "react";
-import ReactDOM from "react-dom/client";
+import * as ReactDOM from "react-dom/client";
 import "./index.css";
 
 const root = document.getElementById("root");

--- a/bot/web/vite.config.js
+++ b/bot/web/vite.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
     outDir: '../public',
     chunkSizeWarningLimit: 1500,
     commonjsOptions: {
-      include: [/shared/],
+      include: [/shared/, /node_modules/],
     },
     rollupOptions: {
       output: {


### PR DESCRIPTION
## Summary
- ensure Rollup treats React DOM as commonjs
- adjust main entry to use namespace import

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/audit_deps.sh`
- `npm --prefix bot run build-client`

------
https://chatgpt.com/codex/tasks/task_b_688ba88ef7d08320bc4adfc68e3ce4a7