### PR TITLE
refactor: migrate routes to ts

### DIFF
--- a/bot/src/api/swagger.ts
+++ b/bot/src/api/swagger.ts
@@ -19,7 +19,7 @@ const options: swaggerJsdoc.Options = {
       },
     },
   },
-  apis: ['./src/api/api.ts', './src/routes/tasks.js'],
+  apis: ['./src/api/api.ts', './src/routes/tasks.ts'],
 };
 
 const specs = swaggerJsdoc(options);

--- a/bot/src/routes/authUser.ts
+++ b/bot/src/routes/authUser.ts
@@ -1,0 +1,97 @@
+// Роуты регистрации, входа и профиля
+// Роут только профиля пользователя
+import { Router, RequestHandler } from 'express';
+import * as authCtrl from '../auth/auth.controller';
+import { verifyToken, asyncHandler } from '../api/middleware';
+import validateDto from '../middleware/validateDto';
+import {
+  SendCodeDto,
+  VerifyCodeDto,
+  VerifyInitDto,
+  UpdateProfileDto,
+} from '../dto/auth.dto';
+
+interface SendCodeBody {
+  telegramId: number;
+}
+interface SendCodeResponse {
+  status?: string;
+  error?: string;
+}
+
+interface VerifyCodeBody {
+  telegramId: number;
+  code: string;
+  username?: string;
+}
+interface TokenResponse {
+  token?: string;
+  error?: string;
+}
+
+interface VerifyInitBody {
+  initData: string;
+}
+
+interface UpdateProfileBody {
+  name?: string;
+  phone?: string;
+  mobNumber?: string;
+}
+
+const router = Router();
+
+router.post<unknown, SendCodeResponse, SendCodeBody>(
+  '/send_code',
+  ...validateDto(SendCodeDto),
+  asyncHandler(
+    authCtrl.sendCode as RequestHandler<
+      unknown,
+      SendCodeResponse,
+      SendCodeBody
+    >,
+  ),
+);
+
+router.post<unknown, TokenResponse, VerifyCodeBody>(
+  '/verify_code',
+  ...validateDto(VerifyCodeDto),
+  asyncHandler(
+    authCtrl.verifyCode as RequestHandler<
+      unknown,
+      TokenResponse,
+      VerifyCodeBody
+    >,
+  ),
+);
+
+router.post<unknown, TokenResponse, VerifyInitBody>(
+  '/verify_init',
+  ...validateDto(VerifyInitDto),
+  asyncHandler(
+    authCtrl.verifyInitData as RequestHandler<
+      unknown,
+      TokenResponse,
+      VerifyInitBody
+    >,
+  ),
+);
+
+router.get('/profile', verifyToken, authCtrl.profile);
+router.patch<unknown, unknown, UpdateProfileBody>(
+  '/profile',
+  verifyToken,
+  ...validateDto(UpdateProfileDto),
+  asyncHandler(
+    authCtrl.updateProfile as RequestHandler<
+      unknown,
+      unknown,
+      UpdateProfileBody
+    >,
+  ),
+);
+
+export default router;
+
+// Совместимость с CommonJS
+module.exports = router;

--- a/bot/src/routes/logs.ts
+++ b/bot/src/routes/logs.ts
@@ -1,0 +1,60 @@
+// Роуты логов: просмотр и запись
+// Модули: express, express-validator, controllers/logs
+import { Router, RequestHandler } from 'express';
+import createRateLimiter from '../utils/rateLimiter';
+import { query } from 'express-validator';
+import * as ctrl from '../logs/logs.controller';
+import { verifyToken } from '../api/middleware';
+import { Roles } from '../auth/roles.decorator';
+import rolesGuard from '../auth/roles.guard';
+import { ACCESS_ADMIN } from '../utils/accessMask';
+import validateDto from '../middleware/validateDto';
+import { CreateLogDto } from '../dto/logs.dto';
+
+interface LogsQuery {
+  page?: number;
+  limit?: number;
+}
+
+interface LogsResponse {
+  logs: unknown[];
+  total?: number;
+}
+
+interface LogBody {
+  level: string;
+  message: string;
+}
+
+interface LogResponse {
+  status: string;
+}
+
+const router = Router();
+const limiter = createRateLimiter(15 * 60 * 1000, 100);
+
+router.get<unknown, LogsResponse, unknown, LogsQuery>(
+  '/',
+  limiter,
+  verifyToken,
+  Roles(ACCESS_ADMIN),
+  rolesGuard,
+  [
+    query('page').optional().isInt({ min: 1 }),
+    query('limit').optional().isInt({ min: 1 }),
+  ],
+  ctrl.list as RequestHandler<unknown, LogsResponse, unknown, LogsQuery>,
+);
+
+router.post<unknown, LogResponse, LogBody>(
+  '/',
+  limiter,
+  verifyToken,
+  ...validateDto(CreateLogDto),
+  ctrl.create as RequestHandler<unknown, LogResponse, LogBody>,
+);
+
+export default router;
+
+// Совместимость с CommonJS
+module.exports = router;

--- a/bot/src/routes/optimizer.ts
+++ b/bot/src/routes/optimizer.ts
@@ -1,0 +1,37 @@
+// Роут расчёта оптимального маршрута для нескольких машин
+// Модули: express, express-validator, controllers/optimizer
+import { Router, RequestHandler } from 'express';
+import { body } from 'express-validator';
+import validate from '../utils/validate';
+import * as ctrl from '../controllers/optimizer';
+import { verifyToken, asyncHandler } from '../api/middleware';
+
+interface OptimizeBody {
+  tasks: string[];
+  count?: number;
+  method?: 'angle' | 'trip';
+}
+
+interface OptimizeResponse {
+  routes: unknown;
+}
+
+const router = Router();
+
+router.post<unknown, OptimizeResponse, OptimizeBody>(
+  '/',
+  verifyToken,
+  validate([
+    body('tasks').isArray({ min: 1 }),
+    body('count').optional().isInt({ min: 1, max: 3 }),
+    body('method').optional().isIn(['angle', 'trip']),
+  ]),
+  asyncHandler(
+    ctrl.optimize as RequestHandler<unknown, OptimizeResponse, OptimizeBody>,
+  ),
+);
+
+export default router;
+
+// Совместимость с CommonJS
+module.exports = router;

--- a/bot/src/routes/roles.ts
+++ b/bot/src/routes/roles.ts
@@ -1,0 +1,60 @@
+// Роуты ролей: список и обновление
+// Модули: express, express-validator, controllers/roles
+import { Router, RequestHandler } from 'express';
+import createRateLimiter from '../utils/rateLimiter';
+import { param } from 'express-validator';
+import * as ctrl from '../roles/roles.controller';
+import { verifyToken } from '../api/middleware';
+import { Roles } from '../auth/roles.decorator';
+import rolesGuard from '../auth/roles.guard';
+import { ACCESS_ADMIN } from '../utils/accessMask';
+import validateDto from '../middleware/validateDto';
+import { UpdateRoleDto } from '../dto/roles.dto';
+
+interface RoleUpdateParams {
+  id: string;
+}
+
+interface RolesResponse {
+  roles: unknown[];
+}
+
+interface UpdateRoleBody {
+  access: number;
+}
+
+interface UpdateRoleResponse {
+  status: string;
+}
+
+const router = Router();
+const limiter = createRateLimiter(15 * 60 * 1000, 50);
+
+router.get<unknown, RolesResponse>(
+  '/',
+  limiter,
+  verifyToken,
+  Roles(ACCESS_ADMIN),
+  rolesGuard,
+  ctrl.list as RequestHandler<unknown, RolesResponse>,
+);
+
+router.patch<RoleUpdateParams, UpdateRoleResponse, UpdateRoleBody>(
+  '/:id',
+  limiter,
+  verifyToken,
+  Roles(ACCESS_ADMIN),
+  rolesGuard,
+  [param('id').isMongoId()],
+  ...validateDto(UpdateRoleDto),
+  ctrl.update as RequestHandler<
+    RoleUpdateParams,
+    UpdateRoleResponse,
+    UpdateRoleBody
+  >,
+);
+
+export default router;
+
+// Совместимость с CommonJS
+module.exports = router;

--- a/bot/src/routes/route.ts
+++ b/bot/src/routes/route.ts
@@ -1,0 +1,104 @@
+// Роут расчёта расстояния
+// Модули: express, express-validator, services/route
+import { Router, RequestHandler } from 'express';
+import { body, query } from 'express-validator';
+import validate from '../utils/validate';
+import {
+  getRouteDistance,
+  table,
+  nearest,
+  match,
+  trip,
+} from '../services/route';
+import { verifyToken, asyncHandler } from '../api/middleware';
+
+interface Point {
+  lat: number;
+  lng: number;
+}
+
+interface DistanceBody {
+  start: Point;
+  end: Point;
+}
+
+interface DistanceResponse {
+  distance: number;
+  route_distance_km?: number;
+  [key: string]: unknown;
+}
+
+const router = Router();
+
+router.post<unknown, DistanceResponse, DistanceBody>(
+  '/',
+  verifyToken,
+  validate([
+    body('start.lat').isFloat(),
+    body('start.lng').isFloat(),
+    body('end.lat').isFloat(),
+    body('end.lng').isFloat(),
+  ]),
+  asyncHandler((async (req, res) => {
+    const data = await getRouteDistance(req.body.start, req.body.end);
+    res.json(data);
+  }) as RequestHandler<unknown, DistanceResponse, DistanceBody>),
+);
+
+interface TableQuery {
+  points: string;
+  [key: string]: unknown;
+}
+
+router.get<unknown, unknown, unknown, TableQuery>(
+  '/table',
+  verifyToken,
+  validate([query('points').isString()]),
+  asyncHandler((async (req, res) => {
+    const { points, ...params } = req.query as TableQuery;
+    res.json(await table(points, params));
+  }) as RequestHandler<unknown, unknown, unknown, TableQuery>),
+);
+
+interface PointQuery {
+  point: string;
+  [key: string]: unknown;
+}
+router.get<unknown, unknown, unknown, PointQuery>(
+  '/nearest',
+  verifyToken,
+  validate([query('point').isString()]),
+  asyncHandler((async (req, res) => {
+    const { point, ...params } = req.query as PointQuery;
+    res.json(await nearest(point, params));
+  }) as RequestHandler<unknown, unknown, unknown, PointQuery>),
+);
+
+interface PointsQuery {
+  points: string;
+  [key: string]: unknown;
+}
+router.get<unknown, unknown, unknown, PointsQuery>(
+  '/match',
+  verifyToken,
+  validate([query('points').isString()]),
+  asyncHandler((async (req, res) => {
+    const { points, ...params } = req.query as PointsQuery;
+    res.json(await match(points, params));
+  }) as RequestHandler<unknown, unknown, unknown, PointsQuery>),
+);
+
+router.get<unknown, unknown, unknown, PointsQuery>(
+  '/trip',
+  verifyToken,
+  validate([query('points').isString()]),
+  asyncHandler((async (req, res) => {
+    const { points, ...params } = req.query as PointsQuery;
+    res.json(await trip(points, params));
+  }) as RequestHandler<unknown, unknown, unknown, PointsQuery>),
+);
+
+export default router;
+
+// Совместимость с CommonJS
+module.exports = router;

--- a/bot/src/routes/routes.ts
+++ b/bot/src/routes/routes.ts
@@ -1,0 +1,45 @@
+// Роуты для получения маршрутов
+// Модули: express, express-validator, controllers/routes
+import { Router, RequestHandler } from 'express';
+import { query, validationResult } from 'express-validator';
+import * as ctrl from '../controllers/routes';
+import { verifyToken, asyncHandler } from '../api/middleware';
+
+interface RoutesQuery {
+  from?: string;
+  to?: string;
+  status?: string;
+}
+
+interface RoutesResponse {
+  routes: unknown[];
+}
+
+const router = Router();
+
+const validate = (v: ReturnType<typeof query>[]): RequestHandler[] => [
+  ...v,
+  (req, res, next) => {
+    const errors = validationResult(req);
+    if (errors.isEmpty()) return next();
+    res.status(400).json({ errors: errors.array() });
+  },
+];
+
+router.get<unknown, RoutesResponse, unknown, RoutesQuery>(
+  '/all',
+  verifyToken,
+  validate([
+    query('from').optional().isISO8601(),
+    query('to').optional().isISO8601(),
+    query('status').optional().isString(),
+  ]),
+  asyncHandler(
+    ctrl.all as RequestHandler<unknown, RoutesResponse, unknown, RoutesQuery>,
+  ),
+);
+
+export default router;
+
+// Совместимость с CommonJS
+module.exports = router;

--- a/bot/src/routes/tasks.ts
+++ b/bot/src/routes/tasks.ts
@@ -1,0 +1,124 @@
+// Роуты задач: CRUD, время, массовые действия
+// Модули: express, express-validator, controllers/tasks
+import { Router, RequestHandler } from 'express';
+import createRateLimiter from '../utils/rateLimiter';
+import { param, query } from 'express-validator';
+import * as ctrl from '../tasks/tasks.controller';
+import { verifyToken } from '../api/middleware';
+import validateDto from '../middleware/validateDto';
+import {
+  CreateTaskDto,
+  UpdateTaskDto,
+  AddTimeDto,
+  BulkStatusDto,
+} from '../dto/tasks.dto';
+import checkTaskAccess from '../middleware/taskAccess';
+
+interface ListQuery {
+  status?: string;
+  assignees?: string[];
+  from?: string;
+  to?: string;
+  page?: number;
+  limit?: number;
+}
+
+interface TasksListResponse {
+  tasks: unknown[];
+  users: Record<string, unknown>;
+}
+
+interface TaskParams {
+  id: string;
+}
+
+interface TaskResponse {
+  task: unknown;
+  users: Record<string, unknown>;
+}
+
+interface StatusResponse {
+  status: string;
+}
+
+const router = Router();
+
+const detailLimiter = createRateLimiter(15 * 60 * 1000, 100);
+const tasksLimiter = createRateLimiter(15 * 60 * 1000, 100);
+router.use(tasksLimiter);
+
+router.get<unknown, TasksListResponse, unknown, ListQuery>(
+  '/',
+  verifyToken,
+  [
+    query('status').optional().isString(),
+    query('assignees').optional().isArray(),
+    query('from').optional().isISO8601(),
+    query('to').optional().isISO8601(),
+    query('page').optional().isInt({ min: 1 }),
+    query('limit').optional().isInt({ min: 1 }),
+  ],
+  ctrl.list as RequestHandler<unknown, TasksListResponse, unknown, ListQuery>,
+);
+
+router.get('/mentioned', verifyToken, ctrl.mentioned);
+
+router.get<unknown, unknown, unknown, { from?: string; to?: string }>(
+  '/report/summary',
+  verifyToken,
+  [query('from').optional().isISO8601(), query('to').optional().isISO8601()],
+  ctrl.summary as RequestHandler,
+);
+
+router.get<TaskParams, TaskResponse>(
+  '/:id',
+  verifyToken,
+  detailLimiter,
+  [param('id').isMongoId()],
+  ctrl.detail as RequestHandler<TaskParams, TaskResponse>,
+);
+
+router.post<unknown, unknown, CreateTaskDto>(
+  '/',
+  verifyToken,
+  ...validateDto(CreateTaskDto),
+  ctrl.create as RequestHandler<unknown, unknown, CreateTaskDto>,
+);
+
+router.patch<TaskParams, unknown, UpdateTaskDto>(
+  '/:id',
+  verifyToken,
+  [param('id').isMongoId()],
+  checkTaskAccess,
+  ...validateDto(UpdateTaskDto),
+  ctrl.update as RequestHandler<TaskParams, unknown, UpdateTaskDto>,
+);
+
+router.patch<TaskParams, unknown, AddTimeDto>(
+  '/:id/time',
+  verifyToken,
+  [param('id').isMongoId()],
+  ...validateDto(AddTimeDto),
+  checkTaskAccess,
+  ctrl.addTime as RequestHandler<TaskParams, unknown, AddTimeDto>,
+);
+
+router.delete<TaskParams>(
+  '/:id',
+  verifyToken,
+  [param('id').isMongoId()],
+  checkTaskAccess,
+  ctrl.remove as RequestHandler<TaskParams>,
+);
+
+router.post<unknown, StatusResponse, BulkStatusDto>(
+  '/bulk',
+  verifyToken,
+  ...validateDto(BulkStatusDto),
+  ctrl.bulk as RequestHandler<unknown, StatusResponse, BulkStatusDto>,
+);
+
+export default router;
+
+// Совместимость с CommonJS
+module.exports = router;

--- a/bot/src/routes/users.ts
+++ b/bot/src/routes/users.ts
@@ -1,0 +1,45 @@
+// Роуты пользователей: список и создание
+// Модули: express, express-rate-limit, controllers/users
+import { Router, RequestHandler } from 'express';
+import rateLimit from 'express-rate-limit';
+import * as ctrl from '../users/users.controller';
+import { verifyToken } from '../api/middleware';
+import { Roles } from '../auth/roles.decorator';
+import rolesGuard from '../auth/roles.guard';
+import { ACCESS_ADMIN } from '../utils/accessMask';
+import validateDto from '../middleware/validateDto';
+import { CreateUserDto } from '../dto/users.dto';
+
+interface UsersResponse {
+  users: unknown[];
+}
+
+interface CreateUserBody {
+  telegramId: number;
+  name?: string;
+  roleId?: number;
+}
+
+interface CreateUserResponse {
+  status: string;
+}
+
+const router = Router();
+const limiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 100 });
+const middlewares = [limiter, verifyToken, Roles(ACCESS_ADMIN), rolesGuard];
+
+router.get<unknown, UsersResponse>(
+  '/',
+  middlewares,
+  ctrl.list as RequestHandler<unknown, UsersResponse>,
+);
+router.post<unknown, CreateUserResponse, CreateUserBody>(
+  '/',
+  [...middlewares, ...validateDto(CreateUserDto)],
+  ctrl.create as RequestHandler<unknown, CreateUserResponse, CreateUserBody>,
+);
+
+export default router;
+
+// Совместимость с CommonJS
+module.exports = router;


### PR DESCRIPTION
## Summary
- convert API route modules from JS to TS with typed requests and responses
- update Swagger config for new task route file
- drop explicit any casts from route module exports

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/audit_deps.sh`


------
https://chatgpt.com/codex/tasks/task_b_68905a8a79dc8320b4bdab9d5bd34392