### PR TITLE
fix: корректные импорты в тестах и линтер

### DIFF
--- a/bot/eslint.config.js
+++ b/bot/eslint.config.js
@@ -1,0 +1,4 @@
+// Конфигурация ESLint для сервера бота
+// Модуль: импорт root конфигурации
+import config from '../eslint.config.js';
+export default config;

--- a/bot/package.json
+++ b/bot/package.json
@@ -12,7 +12,8 @@
     "check:mongo": "node ../scripts/check_mongo.mjs",
     "chaos": "ts-node ../../scripts/chaos.ts",
     "test:types": "tsd --cwd bot --project tsconfig.json --files tests/requestWithUser.test-d.ts",
-    "stress": "locust -f ../loadtest/locustfile.py --host http://localhost:3000 --users 300 --spawn-rate 30"
+    "stress": "locust -f ../loadtest/locustfile.py --host http://localhost:3000 --users 300 --spawn-rate 30",
+    "lint": "eslint \"src/**/*.ts\""
   },
   "postinstall": "npm --prefix web install && npm run build-client && husky install",
   "author": "",

--- a/bot/tests/authCsrfRoute.test.ts
+++ b/bot/tests/authCsrfRoute.test.ts
@@ -20,7 +20,7 @@ jest.mock('../src/auth/auth.controller.ts', () => ({
   updateProfile: jest.fn((_req, res) => res.json({ ok: true })),
 }));
 
-const authRouter = require('../src/routes/authUser');
+const authRouter = require('../src/routes/authUser').default;
 const { stopScheduler } = require('../src/services/scheduler');
 const { stopQueue } = require('../src/services/messageQueue');
 

--- a/bot/tests/authService.test.ts
+++ b/bot/tests/authService.test.ts
@@ -25,7 +25,7 @@ jest.mock('../src/services/userInfoService', () => ({
 jest.mock('../src/services/service', () => ({ writeLog: jest.fn() }));
 jest.mock('../src/utils/verifyInitData', () => jest.fn(() => true));
 
-const service = require('../src/auth/auth.service.ts');
+const service = require('../src/auth/auth.service.ts').default;
 const queries = require('../src/db/queries');
 const otp = require('../src/services/otp');
 const verifyInit = require('../src/utils/verifyInitData');

--- a/bot/tests/loginFlow.test.ts
+++ b/bot/tests/loginFlow.test.ts
@@ -25,7 +25,7 @@ jest.mock('../src/db/queries', () => ({
   updateUser: jest.fn(async () => ({})),
 }));
 
-const authRouter = require('../src/routes/authUser');
+const authRouter = require('../src/routes/authUser').default;
 const { verifyToken, errorHandler } = require('../src/api/middleware');
 const { codes } = require('../src/services/otp');
 const { stopScheduler } = require('../src/services/scheduler');

--- a/bot/tests/loginRouteFlow.test.ts
+++ b/bot/tests/loginRouteFlow.test.ts
@@ -27,8 +27,8 @@ jest.mock('../src/services/route', () => ({
   getRouteDistance: jest.fn(async () => ({ distance: 100, waypoints: [] })),
 }));
 
-const authRouter = require('../src/routes/authUser');
-const routeRouter = require('../src/routes/route');
+const authRouter = require('../src/routes/authUser').default;
+const routeRouter = require('../src/routes/route').default;
 const { verifyToken, errorHandler } = require('../src/api/middleware');
 const { codes } = require('../src/services/otp');
 const { stopScheduler } = require('../src/services/scheduler');

--- a/bot/tests/loginTasksFlow.test.ts
+++ b/bot/tests/loginTasksFlow.test.ts
@@ -1,26 +1,26 @@
 // Назначение: автотесты. Модули: jest, supertest.
 // Тест полного цикла логина и создания задачи
 // Модули: express, cookie-parser, express-session, lusca, supertest
-process.env.NODE_ENV = 'test'
-process.env.BOT_TOKEN = 't'
-process.env.CHAT_ID = '1'
-process.env.JWT_SECRET = 'secret'
-process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db'
-process.env.APP_URL = 'https://localhost'
+process.env.NODE_ENV = 'test';
+process.env.BOT_TOKEN = 't';
+process.env.CHAT_ID = '1';
+process.env.JWT_SECRET = 'secret';
+process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
+process.env.APP_URL = 'https://localhost';
 
-const express = require('express')
-const cookieParser = require('cookie-parser')
-const session = require('express-session')
-const lusca = require('lusca')
-const https = require('https')
-const fs = require('fs')
-const request = require('supertest')
-jest.unmock('jsonwebtoken')
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const session = require('express-session');
+const lusca = require('lusca');
+const https = require('https');
+const fs = require('fs');
+const request = require('supertest');
+jest.unmock('jsonwebtoken');
 
-jest.mock('../src/services/telegramApi', () => ({ call: jest.fn() }))
+jest.mock('../src/services/telegramApi', () => ({ call: jest.fn() }));
 jest.mock('../src/services/userInfoService', () => ({
   getMemberStatus: jest.fn(async () => 'member'),
-}))
+}));
 
 jest.mock('../src/services/tasks', () => ({
   create: jest.fn(async (d) => ({ _id: '1', ...d })),
@@ -32,94 +32,108 @@ jest.mock('../src/services/tasks', () => ({
   remove: jest.fn(),
   summary: jest.fn(),
   mentioned: jest.fn(),
-}))
+}));
 
-jest.mock('../src/middleware/taskAccess', () => (_req,_res,next)=> next())
+jest.mock('../src/middleware/taskAccess', () => (_req, _res, next) => next());
 
 jest.mock('../src/db/queries', () => ({
   getUser: jest.fn(async () => null),
   createUser: jest.fn(async () => ({ username: 'u' })),
   updateUser: jest.fn(async () => ({})),
-}))
+}));
 
-const authRouter = require('../src/routes/authUser')
-const tasksRouter = require('../src/routes/tasks')
-const { verifyToken, errorHandler } = require('../src/api/middleware')
-const { codes } = require('../src/services/otp')
-const { stopScheduler } = require('../src/services/scheduler')
-const { stopQueue } = require('../src/services/messageQueue')
+const authRouter = require('../src/routes/authUser').default;
+const tasksRouter = require('../src/routes/tasks').default;
+const { verifyToken, errorHandler } = require('../src/api/middleware');
+const { codes } = require('../src/services/otp');
+const { stopScheduler } = require('../src/services/scheduler');
+const { stopQueue } = require('../src/services/messageQueue');
 
-const key = fs.readFileSync(__dirname + '/test-key.pem')
-const cert = fs.readFileSync(__dirname + '/test-cert.pem')
+const key = fs.readFileSync(__dirname + '/test-key.pem');
+const cert = fs.readFileSync(__dirname + '/test-cert.pem');
 
-let app
-let server
-let baseUrl
+let app;
+let server;
+let baseUrl;
 beforeAll(
   () =>
     new Promise((res) => {
-      app = express()
-  app.use(express.json())
-  app.use(cookieParser())
-  app.set('trust proxy', 1)
-  app.use(
-    session({
-      secret: 'test',
-      resave: false,
-      saveUninitialized: true,
-      cookie: {
-        secure: true,
-        sameSite: 'none',
-        domain: 'localhost',
-        maxAge: 7 * 24 * 60 * 60 * 1000,
-      },
-    }),
-  )
-  const csrf = lusca.csrf({ angular: true, cookie: { options: { sameSite: 'none', domain: 'localhost' } } })
-  app.use((req, res, next) => {
-    const url = req.originalUrl.split('?')[0]
-    if (['/api/v1/auth/send_code', '/api/v1/auth/verify_code', '/api/v1/csrf'].includes(url)) {
-      return next()
-    }
-    if (req.headers.authorization) return next()
-    return csrf(req, res, next)
-  })
-  app.get('/api/v1/csrf', csrf, (req, res) => {
-    res.json({ csrfToken: req.csrfToken() })
-  })
-  app.use('/api/v1/auth', authRouter)
-  app.use('/api/v1/tasks', tasksRouter)
-  app.use(errorHandler)
-      server = https.createServer({ key, cert }, app)
+      app = express();
+      app.use(express.json());
+      app.use(cookieParser());
+      app.set('trust proxy', 1);
+      app.use(
+        session({
+          secret: 'test',
+          resave: false,
+          saveUninitialized: true,
+          cookie: {
+            secure: true,
+            sameSite: 'none',
+            domain: 'localhost',
+            maxAge: 7 * 24 * 60 * 60 * 1000,
+          },
+        }),
+      );
+      const csrf = lusca.csrf({
+        angular: true,
+        cookie: { options: { sameSite: 'none', domain: 'localhost' } },
+      });
+      app.use((req, res, next) => {
+        const url = req.originalUrl.split('?')[0];
+        if (
+          [
+            '/api/v1/auth/send_code',
+            '/api/v1/auth/verify_code',
+            '/api/v1/csrf',
+          ].includes(url)
+        ) {
+          return next();
+        }
+        if (req.headers.authorization) return next();
+        return csrf(req, res, next);
+      });
+      app.get('/api/v1/csrf', csrf, (req, res) => {
+        res.json({ csrfToken: req.csrfToken() });
+      });
+      app.use('/api/v1/auth', authRouter);
+      app.use('/api/v1/tasks', tasksRouter);
+      app.use(errorHandler);
+      server = https.createServer({ key, cert }, app);
       server.listen(0, 'localhost', () => {
-        baseUrl = `https://localhost:${server.address().port}`
-        res()
-      })
+        baseUrl = `https://localhost:${server.address().port}`;
+        res();
+      });
     }),
-)
+);
 
 afterAll(() => {
-  server.close()
-  stopScheduler()
-  stopQueue()
-})
+  server.close();
+  stopScheduler();
+  stopQueue();
+});
 
 test('полный цикл логина и создания задачи', async () => {
-  const agent = request.agent(baseUrl, { ca: cert })
-  const csrfRes = await agent.get('/api/v1/csrf').set('X-Forwarded-Proto', 'https')
-  const token = csrfRes.body.csrfToken
-  expect(token).toBeDefined()
-  await agent.post('/api/v1/auth/send_code').set('X-Forwarded-Proto', 'https').send({ telegramId: 1 })
-  const code = codes.get('1').code
+  const agent = request.agent(baseUrl, { ca: cert });
+  const csrfRes = await agent
+    .get('/api/v1/csrf')
+    .set('X-Forwarded-Proto', 'https');
+  const token = csrfRes.body.csrfToken;
+  expect(token).toBeDefined();
+  await agent
+    .post('/api/v1/auth/send_code')
+    .set('X-Forwarded-Proto', 'https')
+    .send({ telegramId: 1 });
+  const code = codes.get('1').code;
   const verifyRes = await agent
     .post('/api/v1/auth/verify_code')
     .set('X-Forwarded-Proto', 'https')
     .set('X-XSRF-TOKEN', token)
-    .send({ telegramId: 1, code, username: 'u' })
+    .send({ telegramId: 1, code, username: 'u' });
   const res = await agent
     .post('/api/v1/tasks')
     .set('X-Forwarded-Proto', 'https')
     .set('Authorization', `Bearer ${verifyRes.body.token}`)
-    .send({ title: 'T' })
-  expect(res.status).toBe(201)
-})
+    .send({ title: 'T' });
+  expect(res.status).toBe(201);
+});

--- a/bot/tests/mapsRoute.test.ts
+++ b/bot/tests/mapsRoute.test.ts
@@ -1,39 +1,47 @@
 // Назначение: автотесты. Модули: jest, supertest.
 // Тест маршрута /api/maps/expand
-process.env.NODE_ENV='test'
-process.env.BOT_TOKEN='t'
-process.env.CHAT_ID='1'
-process.env.JWT_SECRET='s'
-process.env.MONGO_DATABASE_URL='mongodb://localhost/db'
-process.env.APP_URL='https://localhost'
+process.env.NODE_ENV = 'test';
+process.env.BOT_TOKEN = 't';
+process.env.CHAT_ID = '1';
+process.env.JWT_SECRET = 's';
+process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
+process.env.APP_URL = 'https://localhost';
 
-const express=require('express')
-const request=require('supertest')
-const { stopScheduler } = require('../src/services/scheduler')
-const { stopQueue } = require('../src/services/messageQueue')
+const express = require('express');
+const request = require('supertest');
+const { stopScheduler } = require('../src/services/scheduler');
+const { stopQueue } = require('../src/services/messageQueue');
 
-jest.mock('../src/services/maps',()=>({
-  expandMapsUrl: jest.fn(async()=> 'https://maps.google.com/full'),
-  extractCoords: jest.fn(()=> ({lat:1,lng:2}))
-}))
+jest.mock('../src/services/maps', () => ({
+  expandMapsUrl: jest.fn(async () => 'https://maps.google.com/full'),
+  extractCoords: jest.fn(() => ({ lat: 1, lng: 2 })),
+}));
 
-jest.mock('../src/api/middleware',()=>({ verifyToken:(_req,_res,next)=>next(), asyncHandler:fn=>fn, errorHandler:(err,_req,res,_next)=>res.status(500).json({error:err.message}) }))
+jest.mock('../src/api/middleware', () => ({
+  verifyToken: (_req, _res, next) => next(),
+  asyncHandler: (fn) => fn,
+  errorHandler: (err, _req, res, _next) =>
+    res.status(500).json({ error: err.message }),
+}));
 
-const router=require('../src/routes/maps')
-const { expandMapsUrl } = require('../src/services/maps')
+const router = require('../src/routes/maps').default;
+const { expandMapsUrl } = require('../src/services/maps');
 
-let app
-beforeAll(()=>{
-  app=express();
+let app;
+beforeAll(() => {
+  app = express();
   app.use(express.json());
   app.use('/api/v1/maps', router);
-})
+});
 
-test('POST /api/v1/maps/expand возвращает url и coords', async()=>{
-  const res=await request(app).post('/api/v1/maps/expand').send({url:'u'})
-  expect(res.body.url).toBe('https://maps.google.com/full')
-  expect(res.body.coords).toEqual({lat:1,lng:2})
-  expect(expandMapsUrl).toHaveBeenCalledWith('u')
-})
+test('POST /api/v1/maps/expand возвращает url и coords', async () => {
+  const res = await request(app).post('/api/v1/maps/expand').send({ url: 'u' });
+  expect(res.body.url).toBe('https://maps.google.com/full');
+  expect(res.body.coords).toEqual({ lat: 1, lng: 2 });
+  expect(expandMapsUrl).toHaveBeenCalledWith('u');
+});
 
-afterAll(()=>{ stopScheduler(); stopQueue() })
+afterAll(() => {
+  stopScheduler();
+  stopQueue();
+});

--- a/bot/tests/optimizer.test.ts
+++ b/bot/tests/optimizer.test.ts
@@ -1,35 +1,47 @@
 // Назначение: автотесты. Модули: jest, supertest.
 // Тест оптимизации маршрута /api/v1/optimizer
-process.env.NODE_ENV='test'
-process.env.BOT_TOKEN='t'
-process.env.CHAT_ID='1'
-process.env.JWT_SECRET='s'
-process.env.MONGO_DATABASE_URL='mongodb://localhost/db'
-process.env.APP_URL='https://localhost'
+process.env.NODE_ENV = 'test';
+process.env.BOT_TOKEN = 't';
+process.env.CHAT_ID = '1';
+process.env.JWT_SECRET = 's';
+process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
+process.env.APP_URL = 'https://localhost';
 
-const express=require('express')
-const request=require('supertest')
-const { stopScheduler } = require('../src/services/scheduler')
-const { stopQueue } = require('../src/services/messageQueue')
+const express = require('express');
+const request = require('supertest');
+const { stopScheduler } = require('../src/services/scheduler');
+const { stopQueue } = require('../src/services/messageQueue');
 
-jest.mock('../src/api/middleware',()=>({ verifyToken:(_req,_res,next)=>next(), asyncHandler:fn=>fn, errorHandler:(err,_req,res,_next)=>res.status(500).json({error:err.message}) }))
+jest.mock('../src/api/middleware', () => ({
+  verifyToken: (_req, _res, next) => next(),
+  asyncHandler: (fn) => fn,
+  errorHandler: (err, _req, res, _next) =>
+    res.status(500).json({ error: err.message }),
+}));
 
-const { optimize } = require('../src/services/optimizer')
-jest.mock('../src/services/optimizer',()=>({ optimize: jest.fn(async()=>[['1']]) }))
-const router=require('../src/routes/optimizer')
+const { optimize } = require('../src/services/optimizer');
+jest.mock('../src/services/optimizer', () => ({
+  optimize: jest.fn(async () => [['1']]),
+}));
+const router = require('../src/routes/optimizer').default;
 
-let app
-beforeAll(()=>{
-  app=express();
+let app;
+beforeAll(() => {
+  app = express();
   app.use(express.json());
-  app.use('/api/v1/optimizer',router);
-})
+  app.use('/api/v1/optimizer', router);
+});
 
-test('POST /api/v1/optimizer возвращает маршрут', async()=>{
-  const res=await request(app).post('/api/v1/optimizer').send({ tasks:['1'], count:1 })
-  expect(res.status).toBe(200)
-  expect(Array.isArray(res.body.routes)).toBe(true)
-  expect(optimize).toHaveBeenCalledWith(['1'],1,undefined)
-})
+test('POST /api/v1/optimizer возвращает маршрут', async () => {
+  const res = await request(app)
+    .post('/api/v1/optimizer')
+    .send({ tasks: ['1'], count: 1 });
+  expect(res.status).toBe(200);
+  expect(Array.isArray(res.body.routes)).toBe(true);
+  expect(optimize).toHaveBeenCalledWith(['1'], 1, undefined);
+});
 
-afterAll(()=>{ stopScheduler(); stopQueue() })
+afterAll(() => {
+  stopScheduler();
+  stopQueue();
+});

--- a/bot/tests/rateLimit.test.ts
+++ b/bot/tests/rateLimit.test.ts
@@ -1,29 +1,44 @@
 // Назначение: автотесты. Модули: jest, supertest.
-process.env.NODE_ENV='test'
-process.env.BOT_TOKEN = 't'
-process.env.CHAT_ID = '1'
-process.env.JWT_SECRET = 's'
-process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db'
-process.env.APP_URL = 'https://localhost'
+process.env.NODE_ENV = 'test';
+process.env.BOT_TOKEN = 't';
+process.env.CHAT_ID = '1';
+process.env.JWT_SECRET = 's';
+process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
+process.env.APP_URL = 'https://localhost';
 
-const express = require('express')
-const request = require('supertest')
-const router = require('../src/routes/tasks.ts')
-const { stopScheduler } = require('../src/services/scheduler')
-const { stopQueue } = require('../src/services/messageQueue')
+const express = require('express');
+const request = require('supertest');
+const router = require('../src/routes/tasks.ts').default;
+const { stopScheduler } = require('../src/services/scheduler');
+const { stopQueue } = require('../src/services/messageQueue');
 
 jest.mock('../src/db/model', () => ({
-  Task: { find: jest.fn(async()=>[]), findById: jest.fn(), findByIdAndUpdate: jest.fn(), create: jest.fn(), updateMany: jest.fn(), aggregate: jest.fn() }
-}))
+  Task: {
+    find: jest.fn(async () => []),
+    findById: jest.fn(),
+    findByIdAndUpdate: jest.fn(),
+    create: jest.fn(),
+    updateMany: jest.fn(),
+    aggregate: jest.fn(),
+  },
+}));
 
-jest.mock('../src/api/middleware', () => ({ verifyToken: (_req,_res,next)=>next(), errorHandler: (err,_req,res,_next)=>res.status(500).json({error:err.message}), checkRole: () => (_req,_res,next)=>next() }))
+jest.mock('../src/api/middleware', () => ({
+  verifyToken: (_req, _res, next) => next(),
+  errorHandler: (err, _req, res, _next) =>
+    res.status(500).json({ error: err.message }),
+  checkRole: () => (_req, _res, next) => next(),
+}));
 
 test('лимитер detailLimiter возвращает 429', async () => {
-  const app = express()
-  app.use('/api/v1/tasks', router)
-  for (let i=0; i<100; i++) await request(app).get('/api/v1/tasks/1')
-  const res = await request(app).get('/api/v1/tasks/1')
-  expect(res.status).toBe(429)
-})
+  const app = express();
+  app.use('/api/v1/tasks', router);
+  for (let i = 0; i < 100; i++) await request(app).get('/api/v1/tasks/1');
+  const res = await request(app).get('/api/v1/tasks/1');
+  expect(res.status).toBe(429);
+});
 
-afterAll(() => { stopScheduler(); stopQueue() })
+afterAll(() => {
+  stopScheduler();
+  stopQueue();
+});

--- a/bot/tests/route.test.ts
+++ b/bot/tests/route.test.ts
@@ -1,71 +1,83 @@
 // Назначение: автотесты. Модули: jest, supertest.
 // Тесты маршрута /api/route и сервиса
-process.env.NODE_ENV='test'
-process.env.BOT_TOKEN='t'
-process.env.CHAT_ID='1'
-process.env.JWT_SECRET='s'
-process.env.MONGO_DATABASE_URL='mongodb://localhost/db'
-process.env.APP_URL='https://localhost'
-process.env.ROUTING_URL='http://localhost:8000/route'
+process.env.NODE_ENV = 'test';
+process.env.BOT_TOKEN = 't';
+process.env.CHAT_ID = '1';
+process.env.JWT_SECRET = 's';
+process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
+process.env.APP_URL = 'https://localhost';
+process.env.ROUTING_URL = 'http://localhost:8000/route';
 
-const express=require('express')
-const request=require('supertest')
-const { stopScheduler } = require('../src/services/scheduler')
-const { stopQueue } = require('../src/services/messageQueue')
+const express = require('express');
+const request = require('supertest');
+const { stopScheduler } = require('../src/services/scheduler');
+const { stopQueue } = require('../src/services/messageQueue');
 
-jest.mock('../src/api/middleware',()=>({ verifyToken:(_req,_res,next)=>next(), asyncHandler:fn=>fn, errorHandler:(err,_req,res,_next)=>res.status(500).json({error:err.message}) }))
+jest.mock('../src/api/middleware', () => ({
+  verifyToken: (_req, _res, next) => next(),
+  asyncHandler: (fn) => fn,
+  errorHandler: (err, _req, res, _next) =>
+    res.status(500).json({ error: err.message }),
+}));
 
-const srv = require('../src/services/route')
-jest.mock('../src/services/route',()=>({
-  getRouteDistance: jest.fn(async()=>({ distance:100, waypoints:[] })),
-  table: jest.fn(async()=>({})),
-  nearest: jest.fn(async()=>({})),
-  match: jest.fn(async()=>({})),
-  trip: jest.fn(async()=>({}))
-}))
+const srv = require('../src/services/route');
+jest.mock('../src/services/route', () => ({
+  getRouteDistance: jest.fn(async () => ({ distance: 100, waypoints: [] })),
+  table: jest.fn(async () => ({})),
+  nearest: jest.fn(async () => ({})),
+  match: jest.fn(async () => ({})),
+  trip: jest.fn(async () => ({})),
+}));
 const {
   getRouteDistance,
   table,
   nearest,
   match,
-  trip
-} = require('../src/services/route')
+  trip,
+} = require('../src/services/route');
 
-const router=require('../src/routes/route')
+const router = require('../src/routes/route').default;
 
-let app
-beforeAll(()=>{
-  app=express();
+let app;
+beforeAll(() => {
+  app = express();
   app.use(express.json());
   app.use('/api/v1/route', router);
-})
+});
 
-test('POST /api/v1/route возвращает данные маршрута', async()=>{
-  const res=await request(app).post('/api/v1/route').send({ start:{lat:1,lng:2}, end:{lat:3,lng:4} })
-  expect(res.body.distance).toBe(100)
-  expect(Array.isArray(res.body.waypoints)).toBe(true)
-  expect(getRouteDistance).toHaveBeenCalledWith({lat:1,lng:2},{lat:3,lng:4})
-})
+test('POST /api/v1/route возвращает данные маршрута', async () => {
+  const res = await request(app)
+    .post('/api/v1/route')
+    .send({ start: { lat: 1, lng: 2 }, end: { lat: 3, lng: 4 } });
+  expect(res.body.distance).toBe(100);
+  expect(Array.isArray(res.body.waypoints)).toBe(true);
+  expect(getRouteDistance).toHaveBeenCalledWith(
+    { lat: 1, lng: 2 },
+    { lat: 3, lng: 4 },
+  );
+});
 
-test('GET /api/v1/route/table вызывает сервис table', async()=>{
-  await request(app).get('/api/v1/route/table?points=1,1;2,2')
-  expect(table).toHaveBeenCalledWith('1,1;2,2',{})
-})
+test('GET /api/v1/route/table вызывает сервис table', async () => {
+  await request(app).get('/api/v1/route/table?points=1,1;2,2');
+  expect(table).toHaveBeenCalledWith('1,1;2,2', {});
+});
 
-test('GET /api/v1/route/nearest вызывает сервис nearest', async()=>{
-  await request(app).get('/api/v1/route/nearest?point=1,1')
-  expect(nearest).toHaveBeenCalledWith('1,1',{})
-})
+test('GET /api/v1/route/nearest вызывает сервис nearest', async () => {
+  await request(app).get('/api/v1/route/nearest?point=1,1');
+  expect(nearest).toHaveBeenCalledWith('1,1', {});
+});
 
-test('GET /api/v1/route/match вызывает сервис match', async()=>{
-  await request(app).get('/api/v1/route/match?points=1,1;2,2')
-  expect(match).toHaveBeenCalledWith('1,1;2,2',{})
-})
+test('GET /api/v1/route/match вызывает сервис match', async () => {
+  await request(app).get('/api/v1/route/match?points=1,1;2,2');
+  expect(match).toHaveBeenCalledWith('1,1;2,2', {});
+});
 
-test('GET /api/v1/route/trip вызывает сервис trip', async()=>{
-  await request(app).get('/api/v1/route/trip?points=1,1;2,2')
-  expect(trip).toHaveBeenCalledWith('1,1;2,2',{})
-})
+test('GET /api/v1/route/trip вызывает сервис trip', async () => {
+  await request(app).get('/api/v1/route/trip?points=1,1;2,2');
+  expect(trip).toHaveBeenCalledWith('1,1;2,2', {});
+});
 
-afterAll(()=>{ stopScheduler(); stopQueue() })
-
+afterAll(() => {
+  stopScheduler();
+  stopQueue();
+});

--- a/bot/tests/routeCsrf.test.ts
+++ b/bot/tests/routeCsrf.test.ts
@@ -15,7 +15,7 @@ const https = require('https');
 const fs = require('fs');
 const request = require('supertest');
 
-const routeRouter = require('../src/routes/route');
+const routeRouter = require('../src/routes/route').default;
 const { stopScheduler } = require('../src/services/scheduler');
 const { stopQueue } = require('../src/services/messageQueue');
 

--- a/bot/tests/routes.test.ts
+++ b/bot/tests/routes.test.ts
@@ -1,55 +1,64 @@
 // Назначение: автотесты. Модули: jest, supertest.
 // Тест эндпойнта /api/v1/routes/all
-process.env.NODE_ENV='test'
-process.env.BOT_TOKEN='t'
-process.env.CHAT_ID='1'
-process.env.JWT_SECRET='s'
-process.env.MONGO_DATABASE_URL='mongodb://localhost/db'
-process.env.APP_URL='https://localhost'
+process.env.NODE_ENV = 'test';
+process.env.BOT_TOKEN = 't';
+process.env.CHAT_ID = '1';
+process.env.JWT_SECRET = 's';
+process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
+process.env.APP_URL = 'https://localhost';
 
-const request = require('supertest')
-const express = require('express')
-const { stopScheduler } = require('../src/services/scheduler')
-const { stopQueue } = require('../src/services/messageQueue')
+const request = require('supertest');
+const express = require('express');
+const { stopScheduler } = require('../src/services/scheduler');
+const { stopQueue } = require('../src/services/messageQueue');
 
 jest.mock('../src/db/queries', () => ({
   listRoutes: jest.fn(async () => [{ _id: '1' }]),
-  getUser: jest.fn(async () => ({}))
-}))
+  getUser: jest.fn(async () => ({})),
+}));
 
-const { listRoutes } = require('../src/db/queries')
+const { listRoutes } = require('../src/db/queries');
 jest.mock('../src/api/middleware', () => ({
-  verifyToken: (req, _res, next) => { req.user = { id: 1 }; next(); },
-  asyncHandler: fn => fn,
-  errorHandler: (err, _req, res, _next) => res.status(500).json({ error: err.message })
-}))
-const { errorHandler } = require('../src/api/middleware')
-const routesRouter = require('../src/routes/routes')
+  verifyToken: (req, _res, next) => {
+    req.user = { id: 1 };
+    next();
+  },
+  asyncHandler: (fn) => fn,
+  errorHandler: (err, _req, res, _next) =>
+    res.status(500).json({ error: err.message }),
+}));
+const { errorHandler } = require('../src/api/middleware');
+const routesRouter = require('../src/routes/routes').default;
 
-let app
+let app;
 beforeAll(() => {
-  app = express()
-  app.use(express.json())
-  app.use('/api/v1/routes', routesRouter)
-  app.use(errorHandler)
-})
+  app = express();
+  app.use(express.json());
+  app.use('/api/v1/routes', routesRouter);
+  app.use(errorHandler);
+});
 
-afterAll(() => { jest.clearAllMocks(); stopScheduler(); stopQueue() })
+afterAll(() => {
+  jest.clearAllMocks();
+  stopScheduler();
+  stopQueue();
+});
 
 test('GET /api/v1/routes/all возвращает массив', async () => {
-  const res = await request(app)
-    .get('/api/v1/routes/all')
-  expect(res.status).toBe(200)
-  expect(Array.isArray(res.body)).toBe(true)
-  expect(listRoutes).toHaveBeenCalled()
-})
+  const res = await request(app).get('/api/v1/routes/all');
+  expect(res.status).toBe(200);
+  expect(Array.isArray(res.body)).toBe(true);
+  expect(listRoutes).toHaveBeenCalled();
+});
 
 test('GET /api/v1/routes/all отклоняет массив в статусе', async () => {
-  const res = await request(app).get('/api/v1/routes/all?status=a&status=b')
-  expect(res.status).toBe(400)
-})
+  const res = await request(app).get('/api/v1/routes/all?status=a&status=b');
+  expect(res.status).toBe(400);
+});
 
 test('GET /api/v1/routes/all передаёт статус строкой', async () => {
-  await request(app).get('/api/v1/routes/all?status=Выполнена')
-  expect(listRoutes).toHaveBeenLastCalledWith(expect.objectContaining({ status: 'Выполнена' }))
-})
+  await request(app).get('/api/v1/routes/all?status=Выполнена');
+  expect(listRoutes).toHaveBeenLastCalledWith(
+    expect.objectContaining({ status: 'Выполнена' }),
+  );
+});

--- a/bot/tests/tasks.test.ts
+++ b/bot/tests/tasks.test.ts
@@ -1,128 +1,167 @@
 // Назначение: автотесты. Модули: jest, supertest.
 // Интеграционные тесты маршрутов /api/tasks с моками модели
-process.env.NODE_ENV='test'
-process.env.BOT_TOKEN='t'
-process.env.CHAT_ID='1'
-process.env.JWT_SECRET='s'
-process.env.MONGO_DATABASE_URL='mongodb://localhost/db'
-process.env.APP_URL='https://localhost'
-const request = require('supertest')
-const express = require('express')
-const { stopScheduler } = require('../src/services/scheduler')
-const { stopQueue } = require('../src/services/messageQueue')
+process.env.NODE_ENV = 'test';
+process.env.BOT_TOKEN = 't';
+process.env.CHAT_ID = '1';
+process.env.JWT_SECRET = 's';
+process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
+process.env.APP_URL = 'https://localhost';
+const request = require('supertest');
+const express = require('express');
+const { stopScheduler } = require('../src/services/scheduler');
+const { stopQueue } = require('../src/services/messageQueue');
 
-jest.mock('../src/services/route',()=>({ getRouteDistance: jest.fn(async()=>({ distance:1000 })) }))
-jest.mock('../src/services/maps',()=>({ generateRouteLink: jest.fn(()=> 'g'), expandMapsUrl: jest.fn(), extractCoords: jest.fn() }))
+jest.mock('../src/services/route', () => ({
+  getRouteDistance: jest.fn(async () => ({ distance: 1000 })),
+}));
+jest.mock('../src/services/maps', () => ({
+  generateRouteLink: jest.fn(() => 'g'),
+  expandMapsUrl: jest.fn(),
+  extractCoords: jest.fn(),
+}));
 
 jest.mock('../src/db/model', () => ({
   Task: {
-    create: jest.fn(async d => ({
+    create: jest.fn(async (d) => ({
       _id: '1',
       request_id: 'ERM_000001',
       ...d,
       title: `ERM_000001 ${d.title}`,
       status: 'Новая',
-      time_spent: 0
+      time_spent: 0,
     })),
-    findByIdAndUpdate: jest.fn(async (_id,d)=>({ _id, ...d })),
-    findById: jest.fn(async () => ({ time_spent:0, save: jest.fn() })),
-    findByIdAndDelete: jest.fn(async ()=>({ _id:'1', request_id:'ERM_000001', toObject(){ return { _id:'1', request_id:'ERM_000001' } } })),
-    updateMany: jest.fn(async ()=>null),
-    aggregate: jest.fn(async ()=>[{ count:2, time:30 }]),
-    find: jest.fn(async ()=>[])
+    findByIdAndUpdate: jest.fn(async (_id, d) => ({ _id, ...d })),
+    findById: jest.fn(async () => ({ time_spent: 0, save: jest.fn() })),
+    findByIdAndDelete: jest.fn(async () => ({
+      _id: '1',
+      request_id: 'ERM_000001',
+      toObject() {
+        return { _id: '1', request_id: 'ERM_000001' };
+      },
+    })),
+    updateMany: jest.fn(async () => null),
+    aggregate: jest.fn(async () => [{ count: 2, time: 30 }]),
+    find: jest.fn(async () => []),
   },
-  Archive: { create: jest.fn(async()=>({})) }
-}))
+  Archive: { create: jest.fn(async () => ({})) },
+}));
 
-jest.mock('../src/services/service', () => ({ writeLog: jest.fn() }))
+jest.mock('../src/services/service', () => ({ writeLog: jest.fn() }));
 
-const queries = require('../src/db/queries')
-jest.spyOn(queries, 'getUsersMap').mockResolvedValue({ 1: { telegram_id: 1, name: 'User' } })
+const queries = require('../src/db/queries');
+jest
+  .spyOn(queries, 'getUsersMap')
+  .mockResolvedValue({ 1: { telegram_id: 1, name: 'User' } });
 
 jest.mock('../src/api/middleware', () => ({
-  verifyToken: (req,_res,next)=>{ req.user = { role: 'admin', id: 1, access: 2 }; next() },
-  asyncHandler: fn=>fn,
-  errorHandler: (err,_req,res,_next)=>res.status(500).json({error:err.message}),
-  checkRole: () => (_req,_res,next)=>next(),
-  checkTaskAccess: (_req,_res,next)=>next()
-}))
+  verifyToken: (req, _res, next) => {
+    req.user = { role: 'admin', id: 1, access: 2 };
+    next();
+  },
+  asyncHandler: (fn) => fn,
+  errorHandler: (err, _req, res, _next) =>
+    res.status(500).json({ error: err.message }),
+  checkRole: () => (_req, _res, next) => next(),
+  checkTaskAccess: (_req, _res, next) => next(),
+}));
 
-jest.mock('../src/middleware/taskAccess', () => (_req,_res,next)=> next())
+jest.mock('../src/middleware/taskAccess', () => (_req, _res, next) => next());
 
-const router = require('../src/routes/tasks')
-const { Task, Archive } = require('../src/db/model')
+const router = require('../src/routes/tasks').default;
+const { Task, Archive } = require('../src/db/model');
 
-let app
+let app;
 beforeAll(() => {
-  app = express()
-  app.use(express.json())
-  app.use('/api/v1/tasks', router)
-})
+  app = express();
+  app.use(express.json());
+  app.use('/api/v1/tasks', router);
+});
 
 test('создание задачи возвращает 201', async () => {
-  const res = await request(app).post('/api/v1/tasks').send({
-    title: 'T',
-    start_location_link: 'https://maps.google.com',
-    end_location_link: 'https://maps.google.com',
-    startCoordinates: { lat: 1, lng: 2 },
-    finishCoordinates: { lat: 3, lng: 4 },
-    start_date: '2025-01-01T10:00'
-  })
-  expect(res.status).toBe(201)
-  expect(res.body.title).toBe('ERM_000001 T')
-  expect(Task.create).toHaveBeenCalledWith(expect.objectContaining({ start_date: '2025-01-01T10:00', google_route_url: 'g', route_distance_km: 1 }))
-})
+  const res = await request(app)
+    .post('/api/v1/tasks')
+    .send({
+      title: 'T',
+      start_location_link: 'https://maps.google.com',
+      end_location_link: 'https://maps.google.com',
+      startCoordinates: { lat: 1, lng: 2 },
+      finishCoordinates: { lat: 3, lng: 4 },
+      start_date: '2025-01-01T10:00',
+    });
+  expect(res.status).toBe(201);
+  expect(res.body.title).toBe('ERM_000001 T');
+  expect(Task.create).toHaveBeenCalledWith(
+    expect.objectContaining({
+      start_date: '2025-01-01T10:00',
+      google_route_url: 'g',
+      route_distance_km: 1,
+    }),
+  );
+});
 
 test('создание задачи с неверными данными', async () => {
-  const res = await request(app).post('/api/v1/tasks').send({ title: 1 })
-  expect(res.status).toBe(400)
-})
+  const res = await request(app).post('/api/v1/tasks').send({ title: 1 });
+  expect(res.status).toBe(400);
+});
 
-const id = '507f191e810c19729de860ea'
+const id = '507f191e810c19729de860ea';
 
 test('обновление задачи', async () => {
-  const res = await request(app).patch(`/api/v1/tasks/${id}`).send({ status:'Выполнена' })
-  expect(res.body.status).toBe('Выполнена')
-})
+  const res = await request(app)
+    .patch(`/api/v1/tasks/${id}`)
+    .send({ status: 'Выполнена' });
+  expect(res.body.status).toBe('Выполнена');
+});
 
 test('добавление времени', async () => {
-  await request(app).patch(`/api/v1/tasks/${id}/time`).send({ minutes:15 })
-  expect(Task.findById).toHaveBeenCalled()
-})
+  await request(app).patch(`/api/v1/tasks/${id}/time`).send({ minutes: 15 });
+  expect(Task.findById).toHaveBeenCalled();
+});
 
 test('ошибка валидации времени', async () => {
-  const res = await request(app).patch(`/api/v1/tasks/${id}/time`).send({})
-  expect(res.status).toBe(400)
-})
+  const res = await request(app).patch(`/api/v1/tasks/${id}/time`).send({});
+  expect(res.status).toBe(400);
+});
 
 test('bulk update статуса', async () => {
-  await request(app).post('/api/v1/tasks/bulk').send({ ids:[id,id], status:'Выполнена' })
-  expect(Task.updateMany).toHaveBeenCalled()
-})
+  await request(app)
+    .post('/api/v1/tasks/bulk')
+    .send({ ids: [id, id], status: 'Выполнена' });
+  expect(Task.updateMany).toHaveBeenCalled();
+});
 
 test('получение списка задач возвращает пользователей', async () => {
-  Task.find.mockResolvedValueOnce([{ _id:'1', assignees:[1], controllers:[], created_by:1 }])
-  const res = await request(app).get('/api/v1/tasks')
-  expect(res.body.users['1'].name).toBe('User')
-  expect(Array.isArray(res.body.tasks)).toBe(true)
-})
+  Task.find.mockResolvedValueOnce([
+    { _id: '1', assignees: [1], controllers: [], created_by: 1 },
+  ]);
+  const res = await request(app).get('/api/v1/tasks');
+  expect(res.body.users['1'].name).toBe('User');
+  expect(Array.isArray(res.body.tasks)).toBe(true);
+});
 
 test('summary report возвращает метрики', async () => {
-  const res = await request(app).get('/api/v1/tasks/report/summary')
-  expect(res.body.count).toBe(2)
-  expect(res.body.time).toBe(30)
-})
+  const res = await request(app).get('/api/v1/tasks/report/summary');
+  expect(res.body.count).toBe(2);
+  expect(res.body.time).toBe(30);
+});
 
 test('summary report c фильтром дат', async () => {
-  const res = await request(app).get('/api/v1/tasks/report/summary?from=2024-01-01&to=2024-12-31')
-  expect(res.body.count).toBe(2)
-  expect(res.body.time).toBe(30)
-})
+  const res = await request(app).get(
+    '/api/v1/tasks/report/summary?from=2024-01-01&to=2024-12-31',
+  );
+  expect(res.body.count).toBe(2);
+  expect(res.body.time).toBe(30);
+});
 
 test('удаление задачи', async () => {
-  const res = await request(app).delete(`/api/v1/tasks/${id}`)
-  expect(res.status).toBe(204)
-  expect(Archive.create).toHaveBeenCalledWith(expect.objectContaining({ request_id: 'ERM_000001-DEL' }))
-})
+  const res = await request(app).delete(`/api/v1/tasks/${id}`);
+  expect(res.status).toBe(204);
+  expect(Archive.create).toHaveBeenCalledWith(
+    expect.objectContaining({ request_id: 'ERM_000001-DEL' }),
+  );
+});
 
-afterAll(() => { stopScheduler(); stopQueue() })
+afterAll(() => {
+  stopScheduler();
+  stopQueue();
+});

--- a/bot/tests/tasksService.test.ts
+++ b/bot/tests/tasksService.test.ts
@@ -15,7 +15,7 @@ jest.mock('../src/services/maps', () => ({
 
 const route = require('../src/services/route');
 const maps = require('../src/services/maps');
-const TasksService = require('../src/tasks/tasks.service.ts');
+const TasksService = require('../src/tasks/tasks.service.ts').default;
 
 function createRepo() {
   return {

--- a/bot/tests/users.test.ts
+++ b/bot/tests/users.test.ts
@@ -44,7 +44,7 @@ const {
   checkRole,
   asyncHandler,
 } = require('../src/api/middleware');
-const validateDto = require('../src/middleware/validateDto.ts');
+const validateDto = require('../src/middleware/validateDto.ts').default;
 const { CreateUserDto } = require('../src/dto/users.dto.ts');
 
 const app = express();

--- a/bot/tests/verifyInitData.test.ts
+++ b/bot/tests/verifyInitData.test.ts
@@ -1,12 +1,12 @@
 // Назначение: автотесты. Модули: jest, supertest.
 // Тест проверки функции verifyInitData
 process.env.BOT_TOKEN = 'x';
-process.env.CHAT_ID='1'
-process.env.JWT_SECRET='s'
-process.env.MONGO_DATABASE_URL='mongodb://localhost/db'
-process.env.APP_URL='https://localhost'
+process.env.CHAT_ID = '1';
+process.env.JWT_SECRET = 's';
+process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
+process.env.APP_URL = 'https://localhost';
 const crypto = require('crypto');
-const verify = require('../src/utils/verifyInitData');
+const verify = require('../src/utils/verifyInitData').default;
 
 test('корректная строка возвращает true', () => {
   const data = { query_id: '1', user: JSON.stringify({ id: 1 }) };


### PR DESCRIPTION
## Summary
- исправлен импорт роутеров и сервисов в тестах через default-экспорт
- добавлен скрипт `lint` и локальная конфигурация ESLint

## Testing
- `npm --prefix bot run lint`
- `npm --prefix bot test`
- `./scripts/setup_and_test.sh`


------
https://chatgpt.com/codex/tasks/task_b_6894ca20bb94832088da0aaeda1aada4