### PR TITLE
fix: корректный тип возврата getTasks

### DIFF
--- a/bot/src/db/queries.ts
+++ b/bot/src/db/queries.ts
@@ -90,7 +90,7 @@ export async function getTasks(
   if (filters.kanban) {
     const res = Task.find({}) as unknown;
     if (isQuery(res)) {
-      return res.sort('-createdAt').lean().exec();
+      return res.sort('-createdAt').exec();
     }
     return res as TaskDocument[];
   }
@@ -114,7 +114,7 @@ export async function getTasks(
       const l = Number(limit) || 20;
       query = query.skip((p - 1) * l).limit(l);
     }
-    return query.lean().exec();
+    return query.exec();
   }
   return res as TaskDocument[];
 }


### PR DESCRIPTION
## Summary
- устранена ошибка TypeScript: удалён `lean()` из `getTasks`, возвращается `exec()`

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/audit_deps.sh`


------
https://chatgpt.com/codex/tasks/task_b_6894ee769a9483209b42a20f7adb209e