### PR TITLE
feat: pre PR build script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 
 ## Качество и тесты
 - Перед коммитом запускайте `./scripts/setup_and_test.sh`.
+- Перед пулл-реквестом выполняйте `./scripts/pre_pr_check.sh`, он создаёт `.env` из `.env.example`, проверяет сборку и запуск бота, автоматически исправляя ошибки и повторяя до успеха.
 - Проверяйте зависимости командой `./scripts/audit_deps.sh` (флаг `--audit-level high` пропускает слабые уязвимости).
 - При отсутствии `.env` используйте `./scripts/create_env_from_exports.sh`.
 - Если доступна команда `docker` и есть `docker-compose.yml`, выполняйте `docker compose config`.

--- a/scripts/create_env_from_exports.sh
+++ b/scripts/create_env_from_exports.sh
@@ -7,9 +7,6 @@ set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 ENV_FILE="$DIR/.env"
 EXAMPLE="$DIR/.env.example"
-
-
-
 if [[ -f $ENV_FILE ]]; then
   echo "$ENV_FILE уже существует" >&2
   exit 0
@@ -19,11 +16,19 @@ if [[ ! -f $EXAMPLE ]]; then
   exit 1
 fi
 
+declare -A DEFAULTS=(
+  [BOT_TOKEN]="$(openssl rand -hex 16)"
+  [CHAT_ID]="$(shuf -i 100000000-999999999 -n 1)"
+  [JWT_SECRET]="$(openssl rand -hex 32)"
+  [APP_URL]="http://localhost:3000"
+  [MONGO_DATABASE_URL]="mongodb://admin:admin@localhost:27017/ermdb?authSource=admin"
+)
+
 while IFS= read -r line; do
   [[ -z $line || $line == \#* ]] && continue
   key=${line%%=*}
   def=${line#*=}
-  val="${!key:-$def}"
+  val="${!key:-${DEFAULTS[$key]:-$def}}"
   printf '%s=%q\n' "$key" "$val"
 done < "$EXAMPLE" > "$ENV_FILE"
 echo "$ENV_FILE обновлён"

--- a/scripts/pre_pr_check.sh
+++ b/scripts/pre_pr_check.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Назначение: проверка сборки и запуска бота перед пулл-реквестом.
+# Модули: bash, npm.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+./scripts/create_env_from_exports.sh >/dev/null || true
+
+until npm --prefix bot run build; do
+  echo "Сборка не удалась, устанавливаем зависимости..."
+  npm --prefix bot install
+done
+
+attempt=1
+max_attempts=5
+while [ $attempt -le $max_attempts ]; do
+  if timeout 5s npm --prefix bot run start >/tmp/bot_start.log 2>&1; then
+    echo "Проверка сборки и запуска завершена."
+    exit 0
+  fi
+  status=$?
+  if [ "$status" -eq 124 ]; then
+    echo "Проверка сборки и запуска завершена."
+    exit 0
+  fi
+  echo "Запуск не удался, пробуем ещё раз..."
+  npm --prefix bot run build || npm --prefix bot install
+  attempt=$((attempt + 1))
+done
+
+echo "Не удалось запустить бот" >&2
+exit 1


### PR DESCRIPTION
## Summary
- add pre_pr_check.sh to auto-build and attempt start before PR
- generate realistic defaults in create_env_from_exports.sh
- document pre-pr check in AGENTS

## Testing
- `npm --prefix bot run format`
- `npx eslint bot/src`
- `./scripts/audit_deps.sh --audit-level high`
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh` (fails: Не удалось запустить бот)


------
https://chatgpt.com/codex/tasks/task_b_6896116cb9c88320ad01ba25ca79855e