### PR TITLE
fix: install pnpm automatically in audit script

### DIFF
--- a/scripts/audit_deps.sh
+++ b/scripts/audit_deps.sh
@@ -4,7 +4,19 @@
 set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 
-npx audit-ci --package-manager pnpm --audit-level high
+# Проверяем наличие pnpm и устанавливаем через corepack при отсутствии
+if ! command -v pnpm >/dev/null; then
+  if command -v corepack >/dev/null; then
+    echo "Устанавливаем pnpm через corepack..."
+    corepack enable >/dev/null
+    corepack prepare pnpm@latest --activate >/dev/null
+  else
+    echo "Не найден pnpm и corepack; установите pnpm вручную." >&2
+    exit 1
+  fi
+fi
+
+npx --yes audit-ci --package-manager pnpm --audit-level high
 npm audit --prefix "$DIR/bot" --audit-level high
 npm audit --prefix "$DIR/bot/web" --audit-level high
 npm ls --prefix "$DIR/bot/web" >/dev/null


### PR DESCRIPTION
## Summary
- ensure audit_deps.sh installs pnpm via corepack when missing
- run audit-ci non-interactively with npx --yes

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/audit_deps.sh`


------
https://chatgpt.com/codex/tasks/task_b_689700e7a8b083209f3ac75653d10cb3