### PR TITLE
feat: убрать any из скрипта индексов и теста

### DIFF
--- a/scripts/db/ensureIndexes.ts
+++ b/scripts/db/ensureIndexes.ts
@@ -13,19 +13,33 @@ try {
   mongoose = require('../../bot/node_modules/mongoose');
 }
 
-function planKey(key: Record<string, number>, fields: [string, number][]) {
+type IndexKey = Record<string, 1 | -1>;
+
+function planKey(key: IndexKey, fields: [string, 1 | -1][]) {
   return fields.every(([f, order]) => key[f] === order);
 }
 
 export async function ensureTaskIndexes(conn?: mongoose.Connection) {
-  const connection = conn ?? (await mongoose.connect(process.env.MONGO_DATABASE_URL!));
+  const connection =
+    conn ?? (await mongoose.connect(process.env.MONGO_DATABASE_URL!));
   const tasks = connection.db.collection('tasks');
-  const indexes = await tasks.indexes();
+  const indexes = (await tasks.indexes()) as { key: IndexKey }[];
 
-  if (!indexes.some((i) => planKey(i.key as any, [ ['assigneeId', 1], ['status', 1], ['dueAt', 1] ]))) {
-    await tasks.createIndex({ assigneeId: 1, status: 1, dueAt: 1 }, { name: 'assignee_status_dueAt' });
+  if (
+    !indexes.some((i) =>
+      planKey(i.key, [
+        ['assigneeId', 1],
+        ['status', 1],
+        ['dueAt', 1],
+      ]),
+    )
+  ) {
+    await tasks.createIndex(
+      { assigneeId: 1, status: 1, dueAt: 1 },
+      { name: 'assignee_status_dueAt' },
+    );
   }
-  if (!indexes.some((i) => planKey(i.key as any, [['createdAt', -1]]))) {
+  if (!indexes.some((i) => planKey(i.key, [['createdAt', -1]]))) {
     await tasks.createIndex({ createdAt: -1 }, { name: 'createdAt_desc' });
   }
 


### PR DESCRIPTION
## Summary
- убрать `any` в ensureIndexes и использовать тип `IndexKey`
- типизировать план в тестах индексов MongoDB

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/audit_deps.sh`


------
https://chatgpt.com/codex/tasks/task_b_68982e0983c08320bb054b5dbed8cef9