### PR TITLE
feat(web): add i18n and language switcher

### DIFF
--- a/bot/web/package-lock.json
+++ b/bot/web/package-lock.json
@@ -15,6 +15,7 @@
         "apexcharts": "^4.7.0",
         "chart.js": "^4.5.0",
         "dompurify": "^3.2.6",
+        "i18next": "^25.3.2",
         "leaflet": "^1.9.4",
         "quill": "^2.0.3",
         "react": "^18.2.0",
@@ -22,6 +23,7 @@
         "react-chartjs-2": "^5.3.0",
         "react-datepicker": "^8.4.0",
         "react-dom": "^18.2.0",
+        "react-i18next": "^15.6.1",
         "react-quill": "^2.0.0",
         "react-router-dom": "^7.6.2",
         "validator": "^13.15.15"
@@ -3889,6 +3891,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.3.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.3.2.tgz",
+      "integrity": "sha512-JSnbZDxRVbphc5jiptxr3o2zocy5dEqpVm9qCGdJwRNO+9saUJS0/u4LnM/13C23fUEWxAylPqKU/NpMV/IjqA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -4932,6 +4974,32 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.6.1.tgz",
+      "integrity": "sha512-uGrzSsOUUe2sDBG/+FJq2J1MM+Y4368/QW8OLEKSFvnDflHBbZhSd1u3UkW0Z06rMhZmnB/AQrhCpYfE5/5XNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -5708,6 +5776,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/which": {

--- a/bot/web/package.json
+++ b/bot/web/package.json
@@ -27,6 +27,8 @@
     "react-dom": "^18.2.0",
     "react-quill": "^2.0.0",
     "react-router-dom": "^7.6.2",
+    "react-i18next": "^15.6.1",
+    "i18next": "^25.3.2",
     "validator": "^13.15.15"
   },
   "devDependencies": {

--- a/bot/web/src/App.tsx
+++ b/bot/web/src/App.tsx
@@ -1,5 +1,7 @@
 // Корневой компонент мини‑приложения agrmcs
 import React, { Suspense, lazy } from "react";
+import { useTranslation, I18nextProvider } from "react-i18next";
+import i18n from "./i18n";
 import {
   BrowserRouter as Router,
   Routes,
@@ -32,11 +34,12 @@ import TaskDialogRoute from "./components/TaskDialogRoute";
 
 function Content() {
   const { collapsed, open } = useSidebar();
+  const { t } = useTranslation();
   return (
     <main
       className={`mt-14 p-4 transition-all ${open ? (collapsed ? "md:ml-20" : "md:ml-60") : "md:ml-0"}`}
     >
-      <Suspense fallback={<div>Загрузка...</div>}>
+      <Suspense fallback={<div>{t("loading")}</div>}>
         <Routes>
           <Route path="/login" element={<CodeLogin />} />
           <Route path="/menu" element={<AttachmentMenu />} />
@@ -126,18 +129,20 @@ function Layout() {
 
 export default function App() {
   return (
-    <AuthProvider>
-      <ThemeProvider>
-        <ToastProvider>
-          <SidebarProvider>
-            <TasksProvider>
-              <Router>
-                <Layout />
-              </Router>
-            </TasksProvider>
-          </SidebarProvider>
-        </ToastProvider>
-      </ThemeProvider>
-    </AuthProvider>
+    <I18nextProvider i18n={i18n}>
+      <AuthProvider>
+        <ThemeProvider>
+          <ToastProvider>
+            <SidebarProvider>
+              <TasksProvider>
+                <Router>
+                  <Layout />
+                </Router>
+              </TasksProvider>
+            </SidebarProvider>
+          </ToastProvider>
+        </ThemeProvider>
+      </AuthProvider>
+    </I18nextProvider>
   );
 }

--- a/bot/web/src/components/NotificationDropdown.tsx
+++ b/bot/web/src/components/NotificationDropdown.tsx
@@ -1,26 +1,40 @@
 // Выпадающий список уведомлений
-import React from 'react'
+import React from "react";
+import { useTranslation } from "react-i18next";
 
-export default function NotificationDropdown({ notifications, children }: { notifications: string[]; children: React.ReactNode }) {
-  const [open, setOpen] = React.useState(false)
+export default function NotificationDropdown({
+  notifications,
+  children,
+}: {
+  notifications: string[];
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const { t } = useTranslation();
   return (
     <div className="relative" onBlur={() => setOpen(false)} tabIndex={0}>
-      <button onClick={() => setOpen(!open)} className="p-2 hover:text-accentPrimary" aria-label="Уведомления">
+      <button
+        onClick={() => setOpen(!open)}
+        className="hover:text-accentPrimary p-2"
+        aria-label={t("notifications")}
+      >
         {children}
       </button>
       {open && (
-        <ul className="absolute right-0 mt-2 w-60 rounded border border-stroke bg-white py-2 shadow-lg transition-all">
+        <ul className="border-stroke absolute right-0 mt-2 w-60 rounded border bg-white py-2 shadow-lg transition-all">
           {notifications.length ? (
             notifications.map((n, i) => (
-              <li key={i} className="px-4 py-2 text-sm text-body hover:bg-gray">
+              <li key={i} className="text-body hover:bg-gray px-4 py-2 text-sm">
                 {n}
               </li>
             ))
           ) : (
-            <li className="px-4 py-2 text-sm text-bodydark">Нет уведомлений</li>
+            <li className="text-bodydark px-4 py-2 text-sm">
+              {t("noNotifications")}
+            </li>
           )}
         </ul>
       )}
     </div>
-  )
+  );
 }

--- a/bot/web/src/i18n.ts
+++ b/bot/web/src/i18n.ts
@@ -1,0 +1,17 @@
+// Конфигурация i18next
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import ru from "./locales/ru/translation.json";
+import en from "./locales/en/translation.json";
+
+i18n.use(initReactI18next).init({
+  resources: {
+    ru: { translation: ru },
+    en: { translation: en },
+  },
+  lng: "ru",
+  fallbackLng: "ru",
+  interpolation: { escapeValue: false },
+});
+
+export default i18n;

--- a/bot/web/src/layouts/Header.tsx
+++ b/bot/web/src/layouts/Header.tsx
@@ -6,16 +6,18 @@ import { useSidebar } from "../context/useSidebar";
 import { AuthContext } from "../context/AuthContext";
 import NotificationDropdown from "../components/NotificationDropdown";
 import { Bars3Icon, BellIcon } from "@heroicons/react/24/outline";
+import { useTranslation } from "react-i18next";
 
 export default function Header() {
   const { toggle, collapsed, open } = useSidebar();
   const { user } = useContext(AuthContext);
+  const { t, i18n } = useTranslation();
   return (
     <header
       className={`border-stroke sticky top-0 z-10 flex h-14 items-center justify-between border-b bg-white px-4 transition-all ${open ? (collapsed ? "lg:ml-20" : "lg:ml-60") : "lg:ml-0"}`}
     >
       <div className="flex items-center gap-2">
-        <button onClick={toggle} className="block" aria-label="Меню">
+        <button onClick={toggle} className="block" aria-label={t("menu")}>
           <Bars3Icon className="h-6 w-6" />
         </button>
         <h1 className="font-bold">agrmcs</h1>
@@ -29,17 +31,26 @@ export default function Header() {
           </span>
           <input
             className="focus:border-brand-300 h-9 rounded-lg border border-gray-300 bg-gray-50 pr-2 pl-8 text-sm focus:outline-none"
-            placeholder="Поиск"
+            placeholder={t("search")}
           />
         </div>
+        <select
+          className="rounded border p-1 text-sm"
+          value={i18n.language}
+          onChange={(e) => i18n.changeLanguage(e.target.value)}
+          aria-label={t("language")}
+        >
+          <option value="ru">RU</option>
+          <option value="en">EN</option>
+        </select>
         {user && (
           <>
-            <NotificationDropdown notifications={["Новое сообщение"]}>
+            <NotificationDropdown notifications={[t("newMessage")]}>
               <BellIcon className="h-5 w-5" />
             </NotificationDropdown>
             {user?.role === "admin" && (
               <Link to="/cp" className="hover:text-accentPrimary rounded p-2">
-                Админка
+                {t("adminPanel")}
               </Link>
             )}
           </>

--- a/bot/web/src/locales/en/translation.json
+++ b/bot/web/src/locales/en/translation.json
@@ -1,0 +1,10 @@
+{
+  "loading": "Loading...",
+  "menu": "Menu",
+  "search": "Search",
+  "newMessage": "New message",
+  "adminPanel": "Admin panel",
+  "language": "Language",
+  "noNotifications": "No notifications",
+  "notifications": "Notifications"
+}

--- a/bot/web/src/locales/ru/translation.json
+++ b/bot/web/src/locales/ru/translation.json
@@ -1,0 +1,10 @@
+{
+  "loading": "Загрузка...",
+  "menu": "Меню",
+  "search": "Поиск",
+  "newMessage": "Новое сообщение",
+  "adminPanel": "Админка",
+  "language": "Язык",
+  "noNotifications": "Нет уведомлений",
+  "notifications": "Уведомления"
+}


### PR DESCRIPTION
## Summary
- add i18next configuration with Russian and English locales
- add language switcher to header navigation

## Testing
- `./scripts/setup_and_test.sh`
- `npm run lint --prefix bot/web`
- `npm run build --prefix bot/web`
- `timeout 5s npm run dev --prefix bot/web`
- `./scripts/audit_deps.sh`
- `./scripts/pre_pr_check.sh` *(failed to start bot)*


------
https://chatgpt.com/codex/tasks/task_b_6898488e2ac88320b704a1de25431a46