### PR TITLE
feat: render user tasks table in profile

### DIFF
--- a/bot/web/src/pages/Profile.tsx
+++ b/bot/web/src/pages/Profile.tsx
@@ -7,24 +7,52 @@ import { fetchTasks } from "../services/tasks";
 import { updateProfile } from "../services/auth";
 import SkeletonCard from "../components/SkeletonCard";
 import Pagination from "../components/Pagination";
+import userLink from "../utils/userLink";
 
 interface TaskItem {
   _id: string;
-  task_description: string;
+  title: string;
+  status: string;
+  priority?: string;
+  start_date?: string;
+  due_date?: string;
+  request_id: string;
+  createdAt: string;
+  assignees?: number[];
+  assigned_user_id?: number;
+}
+
+interface UserInfo {
+  telegram_id: number;
+  username: string;
+  name?: string;
+  telegram_username?: string;
+  phone?: string;
 }
 
 export default function Profile() {
   const { user, setUser } = useContext(AuthContext);
   const [tab, setTab] = useState("details");
   const [tasks, setTasks] = useState<TaskItem[]>([]);
+  const [userMap, setUserMap] = useState<Record<number, UserInfo>>({});
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(1);
+  const [sortBy, setSortBy] = useState<string>("createdAt");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
   const perPage = 10;
   const [name, setName] = useState("");
   const [mobNumber, setMobNumber] = useState("");
   useEffect(() => {
     fetchTasks().then((d: any) => {
       setTasks(d.tasks || []);
+      const list: UserInfo[] = Array.isArray(d.users)
+        ? d.users
+        : Object.values(d.users || {});
+      const map: Record<number, UserInfo> = {};
+      list.forEach((u) => {
+        map[u.telegram_id] = u;
+      });
+      setUserMap(map);
       setLoading(false);
     });
   }, []);
@@ -87,27 +115,160 @@ export default function Profile() {
             {loading ? (
               <SkeletonCard />
             ) : (
-              <>
-                <ul className="space-y-2">
-                  {tasks
-                    .slice((page - 1) * perPage, page * perPage)
-                    .map((t) => (
-                      <li
-                        key={t._id}
-                        className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm"
-                      >
-                        {t.task_description}
-                      </li>
-                    ))}
-                </ul>
-                {Math.ceil(tasks.length / perPage) > 1 && (
-                  <Pagination
-                    total={Math.ceil(tasks.length / perPage)}
-                    page={page}
-                    onChange={setPage}
-                  />
-                )}
-              </>
+              (() => {
+                const myTasks = tasks.filter((t) =>
+                  (
+                    t.assignees ||
+                    (t.assigned_user_id ? [t.assigned_user_id] : [])
+                  ).includes(user.telegram_id),
+                );
+                const sorted = [...myTasks];
+                sorted.sort((a, b) => {
+                  const v1 = a[sortBy as keyof TaskItem];
+                  const v2 = b[sortBy as keyof TaskItem];
+                  if (v1 === undefined) return 1;
+                  if (v2 === undefined) return -1;
+                  if (v1 > v2) return sortDir === "asc" ? 1 : -1;
+                  if (v1 < v2) return sortDir === "asc" ? -1 : 1;
+                  return 0;
+                });
+                const total = Math.ceil(sorted.length / perPage);
+                const handleSort = (col: string) => {
+                  if (sortBy === col) {
+                    setSortDir(sortDir === "asc" ? "desc" : "asc");
+                  } else {
+                    setSortBy(col);
+                    setSortDir("asc");
+                  }
+                };
+                return (
+                  <>
+                    <table className="min-w-full divide-y divide-gray-200 rounded-xl border border-gray-200 bg-white text-sm shadow-sm">
+                      <thead className="bg-gray-50">
+                        <tr>
+                          <th
+                            className="cursor-pointer px-4 py-2 text-left"
+                            onClick={() => handleSort("title")}
+                          >
+                            Название{" "}
+                            {sortBy === "title"
+                              ? sortDir === "asc"
+                                ? "▲"
+                                : "▼"
+                              : ""}
+                          </th>
+                          <th
+                            className="cursor-pointer px-4 py-2"
+                            onClick={() => handleSort("status")}
+                          >
+                            Статус{" "}
+                            {sortBy === "status"
+                              ? sortDir === "asc"
+                                ? "▲"
+                                : "▼"
+                              : ""}
+                          </th>
+                          <th
+                            className="cursor-pointer px-4 py-2"
+                            onClick={() => handleSort("priority")}
+                          >
+                            Приоритет{" "}
+                            {sortBy === "priority"
+                              ? sortDir === "asc"
+                                ? "▲"
+                                : "▼"
+                              : ""}
+                          </th>
+                          <th
+                            className="cursor-pointer px-4 py-2"
+                            onClick={() => handleSort("start_date")}
+                          >
+                            Дата начала{" "}
+                            {sortBy === "start_date"
+                              ? sortDir === "asc"
+                                ? "▲"
+                                : "▼"
+                              : ""}
+                          </th>
+                          <th
+                            className="cursor-pointer px-4 py-2"
+                            onClick={() => handleSort("due_date")}
+                          >
+                            Дедлайн{" "}
+                            {sortBy === "due_date"
+                              ? sortDir === "asc"
+                                ? "▲"
+                                : "▼"
+                              : ""}
+                          </th>
+                          <th
+                            className="cursor-pointer px-4 py-2"
+                            onClick={() => handleSort("assignees")}
+                          >
+                            Исполнители{" "}
+                            {sortBy === "assignees"
+                              ? sortDir === "asc"
+                                ? "▲"
+                                : "▼"
+                              : ""}
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-200">
+                        {sorted
+                          .slice((page - 1) * perPage, page * perPage)
+                          .map((t) => (
+                            <tr key={t._id}>
+                              <td className="px-4 py-2">
+                                {`${t.request_id} ${t.createdAt.slice(0, 10)} ${t.title.replace(/^ERM_\d+\s*/, "")}`}
+                              </td>
+                              <td className="px-4 py-2 text-center">
+                                {t.status}
+                              </td>
+                              <td className="px-4 py-2 text-center">
+                                {t.priority}
+                              </td>
+                              <td className="px-4 py-2 text-center">
+                                {t.start_date?.slice(0, 10)}
+                              </td>
+                              <td className="px-4 py-2 text-center">
+                                {t.due_date?.slice(0, 10)}
+                              </td>
+                              <td className="px-4 py-2">
+                                {(
+                                  t.assignees ||
+                                  (t.assigned_user_id
+                                    ? [t.assigned_user_id]
+                                    : [])
+                                ).map((id) => (
+                                  <span
+                                    key={id}
+                                    dangerouslySetInnerHTML={{
+                                      __html: userLink(
+                                        id,
+                                        userMap[id]?.name ||
+                                          userMap[id]?.telegram_username ||
+                                          userMap[id]?.username,
+                                      ),
+                                    }}
+                                    className="mr-1"
+                                  />
+                                ))}
+                              </td>
+                            </tr>
+                          ))}
+                      </tbody>
+                    </table>
+                    {total > 1 && (
+                      <Pagination
+                        total={total}
+                        page={page}
+                        onChange={setPage}
+                      />
+                    )}
+                  </>
+                );
+              })()
             )}
           </div>
         )}


### PR DESCRIPTION
## Summary
- show tasks table on profile page matching main tasks view
- filter tasks to those assigned to the current user

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*
- `./scripts/audit_deps.sh`
- `docker compose config`


------
https://chatgpt.com/codex/tasks/task_b_6899b9e2df748320b79a179718c7d12e