### PR TITLE
fix: корректная загрузка задач в профиле

### DIFF
--- a/bot/web/src/pages/Profile.tsx
+++ b/bot/web/src/pages/Profile.tsx
@@ -43,19 +43,23 @@ export default function Profile() {
   const [name, setName] = useState("");
   const [mobNumber, setMobNumber] = useState("");
   useEffect(() => {
-    fetchTasks().then((d: any) => {
-      setTasks(d.tasks || []);
-      const list: UserInfo[] = Array.isArray(d.users)
-        ? d.users
-        : Object.values(d.users || {});
-      const map: Record<number, UserInfo> = {};
-      list.forEach((u) => {
-        map[u.telegram_id] = u;
-      });
-      setUserMap(map);
-      setLoading(false);
-    });
-  }, []);
+    if (tab === "tasks" && user && tasks.length === 0) {
+      setLoading(true);
+      fetchTasks()
+        .then((d: any) => {
+          setTasks(d.tasks || []);
+          const list: UserInfo[] = Array.isArray(d.users)
+            ? d.users
+            : Object.values(d.users || {});
+          const map: Record<number, UserInfo> = {};
+          list.forEach((u) => {
+            map[u.telegram_id] = u;
+          });
+          setUserMap(map);
+        })
+        .finally(() => setLoading(false));
+    }
+  }, [tab, user, tasks.length]);
   useEffect(() => {
     if (user) {
       setName(user.name || user.telegram_username || "");


### PR DESCRIPTION
## Что сделано
- загружаем задачи в профиле только при открытии вкладки и наличии пользователя

## Зачем
- предотвращает бесконечные запросы без токена

## Как проверить
- `./scripts/setup_and_test.sh`
- `npx eslint bot/src`
- `npm --prefix bot/web run lint`
- `npm --prefix bot/web run build`
- `npm --prefix bot/web run dev` (остановить Ctrl+C)
- `./scripts/audit_deps.sh`
- `./scripts/pre_pr_check.sh` *(падает: Не удалось запустить бот)*


------
https://chatgpt.com/codex/tasks/task_b_6899c701cbb48320945700508f3fa08e