### PR TITLE
fix: update helmet CSP typing

### DIFF
--- a/bot/src/security.ts
+++ b/bot/src/security.ts
@@ -2,6 +2,7 @@
 // Основные модули: express, helmet, config
 import express from 'express';
 import helmet from 'helmet';
+import type { HelmetOptions } from 'helmet';
 import config from './config';
 
 const parseList = (env?: string): string[] =>
@@ -55,24 +56,26 @@ export default function applySecurity(app: express.Express): void {
     ...parseList(process.env.CSP_FONT_SRC_ALLOWLIST),
   ];
 
+  const csp: NonNullable<HelmetOptions['contentSecurityPolicy']> = {
+    useDefaults: true,
+    directives: {
+      'frame-src': ["'self'", 'https://oauth.telegram.org'],
+      'script-src': scriptSrc,
+      'style-src': styleSrc,
+      'font-src': fontSrc,
+      'img-src': imgSrc,
+      'connect-src': connectSrc,
+    },
+    reportOnly,
+  };
+
   app.use(
     helmet({
       hsts: true,
       noSniff: true,
       referrerPolicy: { policy: 'no-referrer' },
       frameguard: { action: 'deny' },
-      contentSecurityPolicy: {
-        useDefaults: true,
-        directives: {
-          'frame-src': ["'self'", 'https://oauth.telegram.org'],
-          'script-src': scriptSrc,
-          'style-src': styleSrc,
-          'font-src': fontSrc,
-          'img-src': imgSrc,
-          'connect-src': connectSrc,
-        },
-        reportOnly,
-      },
+      contentSecurityPolicy: csp,
     }),
   );
 }


### PR DESCRIPTION
## Summary
- remove deprecated ContentSecurityPolicyOptions usage
- derive CSP config type from HelmetOptions

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/audit_deps.sh`
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*


------
https://chatgpt.com/codex/tasks/task_b_689a1c8b166883208487803b9575b5f3