### PR TITLE
fix: удалить устаревший тип CSP

### DIFF
--- a/bot/src/security.ts
+++ b/bot/src/security.ts
@@ -1,7 +1,7 @@
 // Назначение: middleware безопасности Helmet и CSP.
 // Основные модули: express, helmet, config
 import express from 'express';
-import helmet from 'helmet';
+import helmet, { type HelmetOptions } from 'helmet';
 import config from './config';
 
 const parseList = (env?: string): string[] =>
@@ -55,24 +55,24 @@ export default function applySecurity(app: express.Express): void {
     ...parseList(process.env.CSP_FONT_SRC_ALLOWLIST),
   ];
 
-  app.use(
-    helmet({
-      hsts: true,
-      noSniff: true,
-      referrerPolicy: { policy: 'no-referrer' },
-      frameguard: { action: 'deny' },
-      contentSecurityPolicy: {
-        useDefaults: true,
-        directives: {
-          'frame-src': ["'self'", 'https://oauth.telegram.org'],
-          'script-src': scriptSrc,
-          'style-src': styleSrc,
-          'font-src': fontSrc,
-          'img-src': imgSrc,
-          'connect-src': connectSrc,
-        },
-        reportOnly,
+  const helmetOptions: HelmetOptions = {
+    hsts: true,
+    noSniff: true,
+    referrerPolicy: { policy: 'no-referrer' },
+    frameguard: { action: 'deny' },
+    contentSecurityPolicy: {
+      useDefaults: true,
+      directives: {
+        'frame-src': ["'self'", 'https://oauth.telegram.org'],
+        'script-src': scriptSrc,
+        'style-src': styleSrc,
+        'font-src': fontSrc,
+        'img-src': imgSrc,
+        'connect-src': connectSrc,
       },
-    }),
-  );
+      reportOnly,
+    },
+  };
+
+  app.use(helmet(helmetOptions));
 }


### PR DESCRIPTION
## Summary
- заменить несуществующий тип ContentSecurityPolicyOptions на HelmetOptions
- настроить объект CSP и передавать его в helmet

## Testing
- `npx eslint bot/src/security.ts`
- `npm --prefix bot run build`
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh` *(failed: Не удалось запустить бот)*
- `./scripts/audit_deps.sh` *(1 low severity vulnerability)*

------
https://chatgpt.com/codex/tasks/task_b_689a1c8b166883208487803b9575b5f3