### PR TITLE
fix: убрать неиспользуемый тип HelmetOptions

### DIFF
--- a/bot/src/security.ts
+++ b/bot/src/security.ts
@@ -2,7 +2,7 @@
 // Основные модули: express, helmet, config
 import express from 'express';
 import helmet from 'helmet';
-import type { HelmetOptions, ContentSecurityPolicyOptions } from 'helmet';
+import type { ContentSecurityPolicyOptions } from 'helmet';
 
 import config from './config';
 


### PR DESCRIPTION
## Summary
- remove unused `HelmetOptions` type from security middleware

## Testing
- `npx eslint bot/src`
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_689a3d2b0f788320aeb14e6bad1f8c08