### PR TITLE
fix: isolate task cache per user

### DIFF
--- a/bot/web/src/pages/MyTasks.tsx
+++ b/bot/web/src/pages/MyTasks.tsx
@@ -41,8 +41,9 @@ export default function MyTasks() {
   const perPage = 10;
 
   useEffect(() => {
+    if (!user) return;
     setLoading(true);
-    fetchTasks()
+    fetchTasks({}, Number((user as any).telegram_id))
       .then((d: any) => {
         const raw = Array.isArray(d) ? d : d.items || d.tasks || d.data || [];
         const listTasks = raw.map((t: any) => ({
@@ -62,7 +63,7 @@ export default function MyTasks() {
         setUserMap(map);
       })
       .finally(() => setLoading(false));
-  }, []);
+  }, [user]);
 
   if (!user) return <div>Загрузка...</div>;
 

--- a/bot/web/src/pages/Routes.tsx
+++ b/bot/web/src/pages/Routes.tsx
@@ -1,5 +1,5 @@
 // Страница отображения маршрутов на карте с фильтрами
-import React from "react";
+import React, { useContext } from "react";
 import Breadcrumbs from "../components/Breadcrumbs";
 import fetchRouteGeometry from "../services/osrm";
 import { fetchTasks } from "../services/tasks";
@@ -9,6 +9,7 @@ import createMultiRouteLink from "../utils/createMultiRouteLink";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import { useNavigate, useLocation, useSearchParams } from "react-router-dom";
+import { AuthContext } from "../context/AuthContext";
 
 interface Task {
   _id: string;
@@ -36,6 +37,7 @@ export default function RoutesPage() {
   const location = useLocation();
   const [params] = useSearchParams();
   const hasDialog = params.has("task") || params.has("newTask");
+  const { user } = useContext(AuthContext);
 
   const openTask = React.useCallback(
     (id: string) => {
@@ -47,7 +49,7 @@ export default function RoutesPage() {
   );
 
   const load = React.useCallback(() => {
-    fetchTasks().then((data: any) => {
+    fetchTasks({}, Number((user as any)?.telegram_id)).then((data: any) => {
       const raw = Array.isArray(data)
         ? data
         : data.items || data.tasks || data.data || [];
@@ -60,7 +62,7 @@ export default function RoutesPage() {
       setTasks(list);
       setSorted(list);
     });
-  }, []);
+  }, [user]);
 
   const calculate = React.useCallback(() => {
     const ids = sorted.map((t) => t._id);

--- a/bot/web/src/pages/TasksPage.tsx
+++ b/bot/web/src/pages/TasksPage.tsx
@@ -64,7 +64,7 @@ export default function TasksPage() {
 
   const load = React.useCallback(() => {
     setLoading(true);
-    fetchTasks()
+    fetchTasks({}, Number((user as any)?.telegram_id))
       .then((data) => {
         const tasks = Array.isArray(data) ? data : data.tasks || [];
         setAll(tasks);
@@ -87,7 +87,7 @@ export default function TasksPage() {
       .then(setKpi);
     setStatuses(fields.find((f) => f.name === "status")?.options || []);
     setPriorities(fields.find((f) => f.name === "priority")?.options || []);
-  }, [isAdmin]);
+  }, [isAdmin, user]);
 
   React.useEffect(load, [load, version]);
 

--- a/bot/web/src/services/tasks.ts
+++ b/bot/web/src/services/tasks.ts
@@ -50,13 +50,16 @@ export const updateTask = (id: string, data: Record<string, unknown>) =>
 export const fetchMentioned = () =>
   authFetch("/api/v1/tasks/mentioned").then((r) => (r.ok ? r.json() : []));
 
-export const fetchTasks = (params: Record<string, unknown> = {}) => {
+export const fetchTasks = (
+  params: Record<string, unknown> = {},
+  userId?: number,
+) => {
   const filtered = Object.fromEntries(
     Object.entries(params).filter(([, v]) => v),
   );
   const q = new URLSearchParams(filtered as Record<string, string>).toString();
   const url = "/api/v1/tasks" + (q ? `?${q}` : "");
-  const key = `tasks_${q}`;
+  const key = `tasks_${userId ?? "anon"}_${q}`;
   let cached: { time?: number; data?: unknown };
   try {
     cached = JSON.parse(localStorage.getItem(key) || "");


### PR DESCRIPTION
## Summary
- avoid showing empty task list after account switch by caching tasks separately per user
- pass user id to task fetches and refetch after login

## Testing
- `npx eslint bot/src`
- `./scripts/setup_and_test.sh`
- `./scripts/audit_deps.sh`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_689b06c350148320924f1a8ada668995