### PR TITLE
feat: validate task start link

### DIFF
--- a/bot/web/src/components/TaskDialog.tsx
+++ b/bot/web/src/components/TaskDialog.tsx
@@ -273,7 +273,8 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
   const handleStartLink = async (v: string) => {
     setStartLink(v);
     const url = validateURL(v);
-    if (url) {
+    // Разрешены только ссылки с протоколом HTTP(S)
+    if (url && /^(https?:\/\/)/i.test(url)) {
       let link = url;
       if (/^https?:\/\/maps\.app\.goo\.gl\//i.test(url)) {
         const data = await expandLink(url);
@@ -287,6 +288,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
     } else {
       setStart("");
       setStartCoordinates(null);
+      setStartLink("");
     }
   };
 
@@ -611,7 +613,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               <div className="flex items-center space-x-2">
                 <div className="flex flex-col">
                   <a
-                    href={startLink}
+                    href={DOMPurify.sanitize(startLink)}
                     target="_blank"
                     rel="noopener"
                     className="text-accentPrimary underline"

--- a/bot/web/vite.config.ts
+++ b/bot/web/vite.config.ts
@@ -1,24 +1,24 @@
+/* eslint-env node */
+/* eslint-disable no-undef */
 
 /**
  * Назначение файла: конфигурация Vite для мини-приложения.
  * Основные модули: vite, @vitejs/plugin-react.
  */
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
-import { resolve } from 'path';
-
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { resolve } from "path";
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@': resolve(__dirname, 'src'),
+      "@": resolve(__dirname, "src"),
     },
   },
   build: {
-
-    outDir: '../public',
+    outDir: "../public",
 
     chunkSizeWarningLimit: 1500,
     commonjsOptions: {
@@ -27,9 +27,7 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks: {
-
-          react: ['react', 'react-dom', 'react-router-dom'],
-
+          react: ["react", "react-dom", "react-router-dom"],
         },
       },
     },


### PR DESCRIPTION
## Summary
- ensure task start link uses only http/https protocols
- sanitize start link before rendering
- fix vite config lint error

## Testing
- `pnpm lint`
- `pnpm --dir bot/web lint`
- `./scripts/setup_and_test.sh` (warnings only)
- `./scripts/audit_deps.sh` (low vulnerabilities reported)
- `./scripts/pre_pr_check.sh` *(failed: bot start check)*

------
https://chatgpt.com/codex/tasks/task_b_689c79dc21b483209994379cef9207a3