### PR TITLE
test: mock dns lookup in maps test

### DIFF
--- a/bot/tests/maps.test.ts
+++ b/bot/tests/maps.test.ts
@@ -1,26 +1,37 @@
 // Назначение: автотесты. Модули: jest, supertest.
 // Тесты сервиса maps: разворачивание ссылок и координаты
-process.env.BOT_TOKEN = 't'
-process.env.CHAT_ID = '1'
-process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db'
-process.env.JWT_SECRET = 's'
-process.env.APP_URL = 'https://localhost'
+process.env.BOT_TOKEN = 't';
+process.env.CHAT_ID = '1';
+process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
+process.env.JWT_SECRET = 's';
+process.env.APP_URL = 'https://localhost';
 
-const { expandMapsUrl, extractCoords } = require('../src/services/maps')
+jest.mock('dns/promises', () => ({
+  lookup: jest.fn().mockResolvedValue([{ address: '1.1.1.1', family: 4 }]),
+}));
 
-const { stopScheduler } = require('../src/services/scheduler')
-const { stopQueue } = require('../src/services/messageQueue')
+const { expandMapsUrl, extractCoords } = require('../src/services/maps');
+
+const { stopScheduler } = require('../src/services/scheduler');
+const { stopQueue } = require('../src/services/messageQueue');
 
 test('expandMapsUrl возвращает полный url', async () => {
-  global.fetch = jest.fn().mockResolvedValue({ url: 'https://maps.google.com/full' })
-  const res = await expandMapsUrl('https://maps.app.goo.gl/test')
-  expect(fetch).toHaveBeenCalledWith('https://maps.app.goo.gl/test', { redirect: 'follow' })
-  expect(res).toBe('https://maps.google.com/full')
-})
+  global.fetch = jest
+    .fn()
+    .mockResolvedValue({ url: 'https://maps.google.com/full' });
+  const res = await expandMapsUrl('https://maps.app.goo.gl/test');
+  expect(fetch).toHaveBeenCalledWith('https://maps.app.goo.gl/test', {
+    redirect: 'follow',
+  });
+  expect(res).toBe('https://maps.google.com/full');
+});
 
 test('extractCoords извлекает широту и долготу', () => {
-  const coords = extractCoords('https://maps.google.com/@10.1,20.2,15z')
-  expect(coords).toEqual({ lat: 10.1, lng: 20.2 })
-})
+  const coords = extractCoords('https://maps.google.com/@10.1,20.2,15z');
+  expect(coords).toEqual({ lat: 10.1, lng: 20.2 });
+});
 
-afterAll(() => { stopScheduler(); stopQueue() })
+afterAll(() => {
+  stopScheduler();
+  stopQueue();
+});


### PR DESCRIPTION
## Summary
- mock dns lookup in maps.test to avoid DNS requests

## Testing
- `pnpm lint`
- `npm --prefix bot test tests/maps.test.ts`
- `./scripts/audit_deps.sh` *(fails: pm2 RDoS vulnerability)*
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*
- `./scripts/setup_and_test.sh`


------
https://chatgpt.com/codex/tasks/task_b_689c81ee72688320afe2400baa352b12