### PR TITLE
feat: добавить глобальный лимитер запросов

### DIFF
--- a/bot/src/api/api.ts
+++ b/bot/src/api/api.ts
@@ -43,6 +43,7 @@ import {
 } from '../services/service';
 import { verifyToken, asyncHandler, requestLogger } from './middleware';
 import errorMiddleware from '../middleware/errorMiddleware';
+import globalLimiter from '../middleware/globalLimiter';
 import { sendProblem } from '../utils/problem';
 import usersRouter from '../routes/users';
 import rolesRouter from '../routes/roles';
@@ -174,6 +175,7 @@ const validate = (validations: ValidationChain[]): RequestHandler[] => [
   const prefix = '/api/v1';
   app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(specs));
   app.use(requestLogger);
+  app.use(globalLimiter);
 
   const taskStatusRateLimiter = createRateLimiter({
     windowMs: 15 * 60 * 1000,

--- a/bot/src/middleware/globalLimiter.ts
+++ b/bot/src/middleware/globalLimiter.ts
@@ -1,0 +1,12 @@
+// Назначение: глобальный лимитер запросов
+// Основные модули: express-rate-limit
+import rateLimit from 'express-rate-limit';
+
+const globalLimiter = rateLimit({
+  windowMs: 60_000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+export default globalLimiter;


### PR DESCRIPTION
## Что сделано
- добавлен глобальный `express-rate-limit` middleware
- подключён глобальный лимитер в API до всех роутов

## Зачем
- защита от избыточного числа запросов ко всему API

## Проверки
- `pnpm install`
- `./scripts/setup_and_test.sh`
- `pnpm lint`
- `pnpm test:unit`
- `pnpm build` *(ошибка: Command "build" not found)*
- `pnpm run dev` *(ошибка: Missing script: dev)*


------
https://chatgpt.com/codex/tasks/task_b_689ca26d247083208873c6f14a1e908c