### PR TITLE
test: cover global limiter, pino logs, and initData validation

### DIFF
--- a/bot/tests/authService.test.ts
+++ b/bot/tests/authService.test.ts
@@ -68,3 +68,10 @@ test('verifyInitData создаёт пользователя и возвраща
   expect(queries.createUser).toHaveBeenCalled();
   expect(typeof token).toBe('string');
 });
+
+test('verifyInitData выбрасывает ошибку при неверных данных', async () => {
+  verifyInit.mockImplementationOnce(() => {
+    throw new Error('bad');
+  });
+  await expect(service.verifyInitData('bad')).rejects.toThrow('invalid initData');
+});

--- a/bot/tests/globalLimiter.test.ts
+++ b/bot/tests/globalLimiter.test.ts
@@ -1,0 +1,25 @@
+// Назначение: автотесты. Модули: jest, supertest.
+// Тест глобального лимитера запросов
+const express = require('express');
+const request = require('supertest');
+const globalLimiter = require('../src/middleware/globalLimiter').default;
+
+test('первый запрос проходит', async () => {
+  const app = express();
+  app.use(globalLimiter);
+  app.get('/', (_req, res) => res.send('ok'));
+  const res = await request(app).get('/');
+  expect(res.status).toBe(200);
+});
+
+test('превышение лимита возвращает 429', async () => {
+  const app = express();
+  app.use(globalLimiter);
+  app.get('/', (_req, res) => res.send('ok'));
+  for (let i = 0; i < 100; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await request(app).get('/');
+  }
+  const res = await request(app).get('/');
+  expect(res.status).toBe(429);
+});

--- a/bot/tests/pinoLogger.test.ts
+++ b/bot/tests/pinoLogger.test.ts
@@ -1,0 +1,34 @@
+// Назначение: автотесты. Модули: jest, supertest.
+// Тесты middleware pinoLogger
+const express = require('express');
+const request = require('supertest');
+
+const info = jest.fn();
+const mockLogger = { info, error: jest.fn(), child: () => mockLogger };
+jest.mock('pino', () => () => mockLogger);
+jest.mock('pino-http', () => (o) => (req, _res, next) => {
+  const id = o.genReqId(req);
+  const props = o.customProps(req);
+  mockLogger.info({ req: { id }, ...props });
+  next();
+});
+
+const pinoLogger = require('../src/middleware/pinoLogger').default;
+
+test('pinoLogger пишет ip, ua и reqId из traceparent', async () => {
+  const app = express();
+  app.use(pinoLogger);
+  app.get('/', (_req, res) => res.send('ok'));
+  await request(app)
+    .get('/')
+    .set(
+      'traceparent',
+      '00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-00',
+    )
+    .set('User-Agent', 'jest')
+    .expect(200);
+  const log = info.mock.calls[0][0];
+  expect(log.ip).toBe('::ffff:127.0.0.1');
+  expect(log.ua).toBe('jest');
+  expect(log.req.id).toBe('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb');
+});


### PR DESCRIPTION
## Summary
- add global limiter test ensuring 429 after threshold
- verify pino logger logs IP, UA, and traceparent-based reqId
- check auth service rejects invalid initData

## Testing
- `pnpm --dir bot lint`
- `pnpm --dir bot test`
- `pnpm --dir bot build`
- `timeout 5 pnpm --dir bot dev` *(fails: APP_URL must start with https://)*
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_689cc4b5b8ec832096d584bac7aaae8c