### PR TITLE
fix(web): add hidden dialog title for accessibility

### DIFF
--- a/bot/web/package-lock.json
+++ b/bot/web/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.12",
+        "@radix-ui/react-visually-hidden": "^1.1.2",
         "@telegram-apps/sdk-react": "^3.3.6",
         "@telegram-apps/telegram-ui": "^2.1.8",
         "ag-grid-community": "^32.3.2",
@@ -1907,6 +1908,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/bot/web/package.json
+++ b/bot/web/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.12",
+    "@radix-ui/react-visually-hidden": "^1.1.2",
     "@telegram-apps/sdk-react": "^3.3.6",
     "@telegram-apps/telegram-ui": "^2.1.8",
     "ag-grid-community": "^32.3.2",

--- a/bot/web/src/components/TaskDialogRoute.tsx
+++ b/bot/web/src/components/TaskDialogRoute.tsx
@@ -4,7 +4,13 @@ import React from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import TaskDialog from "./TaskDialog";
 import useTasks from "../context/useTasks";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 
 export default function TaskDialogRoute() {
   const [params] = useSearchParams();
@@ -20,7 +26,12 @@ export default function TaskDialogRoute() {
   };
   return (
     <Dialog open onOpenChange={close}>
-      <DialogContent className="p-0">
+      <DialogContent className="p-0" aria-describedby={undefined}>
+        <DialogHeader>
+          <VisuallyHidden asChild>
+            <DialogTitle>Форма задачи</DialogTitle>
+          </VisuallyHidden>
+        </DialogHeader>
         <TaskDialog
           id={id || undefined}
           onClose={close}


### PR DESCRIPTION
## Summary
- add hidden title for Task dialog to meet Radix requirements
- include @radix-ui/react-visually-hidden dependency

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/audit_deps.sh`
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_689ccd084bdc8320a7cfa61fdd320b76