### PR TITLE
fix: simplify task form and modernize AG Grid

### DIFF
--- a/bot/web/src/columns/taskColumns.tsx
+++ b/bot/web/src/columns/taskColumns.tsx
@@ -21,15 +21,13 @@ type Task = {
 };
 
 export default function taskColumns(
-  selectable: boolean,
+  _selectable: boolean,
   users: Record<number, any>,
 ): ColDef<Task>[] {
   return [
     {
       headerName: "Задача",
       field: "title",
-      checkboxSelection: selectable,
-      headerCheckboxSelection: selectable,
       valueGetter: (p) =>
         `${p.data.request_id || ""} ${p.data.createdAt?.slice(0, 10) || ""} ${
           p.data.title?.replace(/^ERM_\d+\s*/, "") || ""
@@ -43,18 +41,12 @@ export default function taskColumns(
     {
       headerName: "Старт",
       field: "startCoordinates",
-      valueGetter: (p) =>
-        p.data.startCoordinates
-          ? `${p.data.startCoordinates.lat}, ${p.data.startCoordinates.lng}`
-          : "",
+      valueFormatter: (p) => (p.value ? `${p.value.lat}, ${p.value.lng}` : ""),
     },
     {
       headerName: "Финиш",
       field: "finishCoordinates",
-      valueGetter: (p) =>
-        p.data.finishCoordinates
-          ? `${p.data.finishCoordinates.lat}, ${p.data.finishCoordinates.lng}`
-          : "",
+      valueFormatter: (p) => (p.value ? `${p.value.lat}, ${p.value.lng}` : ""),
     },
     { headerName: "Км", field: "route_distance_km" },
     {

--- a/bot/web/src/components/TaskTable.tsx
+++ b/bot/web/src/components/TaskTable.tsx
@@ -90,7 +90,11 @@ export default function TaskTable({
           rowData={tasks}
           columnDefs={columnDefs}
           defaultColDef={defaultColDef}
-          rowSelection={selectable ? "multiple" : undefined}
+          rowSelection={
+            selectable
+              ? { mode: "multiRow", checkboxes: true, headerCheckbox: true }
+              : undefined
+          }
           onSelectionChanged={onSel}
           onGridReady={onGridReady}
           onSortChanged={updateData}

--- a/bot/web/src/hooks/useGrid.ts
+++ b/bot/web/src/hooks/useGrid.ts
@@ -17,7 +17,12 @@ export default function useGrid<T = any>(options: GridOptions<T> = {}) {
   );
 
   const gridOptions = React.useMemo<GridOptions<T>>(
-    () => ({ pagination: true, paginationPageSize: 25, ...options }),
+    () => ({
+      pagination: true,
+      paginationPageSize: 25,
+      paginationPageSizeSelector: [25, 50, 100],
+      ...options,
+    }),
     [options],
   );
 


### PR DESCRIPTION
## Summary
- remove Edit and Cancel actions from task dialog and make form compact
- update AG Grid usage to new rowSelection and pagination APIs

## Testing
- `./scripts/setup_and_test.sh`
- `node -r ./bot/node_modules/ts-node/register bot/node_modules/eslint/bin/eslint.js bot/src`
- `npm run lint --prefix bot/web`
- `./scripts/audit_deps.sh`
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_689ce995fcdc83209fa0783b21e61e3a