### PR TITLE
feat: добавить настраиваемую тему

### DIFF
--- a/bot/web/index.html
+++ b/bot/web/index.html
@@ -3,14 +3,33 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Управление задачами через Telegram" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Poppins:wght@100..900&family=Roboto:wght@100..900&display=swap" />
-  <title>agrmcs dashboard</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Управление задачами через Telegram" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Poppins:wght@100..900&family=Roboto:wght@100..900&display=swap"
+    />
+    <title>agrmcs dashboard</title>
+    <script>
+      (function () {
+        var m = document.cookie.match(/theme=([^;]+)/);
+        var t = m ? decodeURIComponent(m[1]) : "light";
+        var tokens = document.cookie.match(/theme-tokens=([^;]+)/);
+        if (tokens) {
+          try {
+            var obj = JSON.parse(decodeURIComponent(tokens[1]));
+            for (var k in obj) {
+              document.documentElement.style.setProperty("--" + k, obj[k]);
+            }
+          } catch (e) {}
+        }
+        if (t === "dark") document.documentElement.classList.add("dark");
+      })();
+    </script>
   </head>
-  <body class="min-h-screen font-sans bg-white">
+  <body class="min-h-screen bg-white font-sans">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/bot/web/src/App.tsx
+++ b/bot/web/src/App.tsx
@@ -19,11 +19,12 @@ const CodeLogin = lazy(() => import("./pages/CodeLogin"));
 const AttachmentMenu = lazy(() => import("./pages/AttachmentMenu"));
 const RoutesPage = lazy(() => import("./pages/Routes"));
 const RolesPage = lazy(() => import("./pages/Roles"));
+const ThemeSettings = lazy(() => import("./pages/ThemeSettings"));
 import Sidebar from "./layouts/Sidebar";
 import Header from "./layouts/Header";
 import { SidebarProvider } from "./context/SidebarContext";
 import { useSidebar } from "./context/useSidebar";
-import { ThemeProvider } from "@/components/theme-provider";
+import { ThemeProvider } from "./context/ThemeProvider";
 import { AuthProvider } from "./context/AuthProvider";
 import { AuthContext } from "./context/AuthContext";
 import { ToastProvider } from "./context/ToastContext";
@@ -114,6 +115,14 @@ function Content() {
               <AdminRoute>
                 <LogsPage />
               </AdminRoute>
+            }
+          />
+          <Route
+            path="/theme"
+            element={
+              <ProtectedRoute>
+                <ThemeSettings />
+              </ProtectedRoute>
             }
           />
           <Route path="*" element={<Navigate to="/tasks" />} />

--- a/bot/web/src/components/ThemePanel.tsx
+++ b/bot/web/src/components/ThemePanel.tsx
@@ -1,0 +1,41 @@
+// Панель изменения токенов темы
+// Модули: React, useTheme
+import { useState } from "react";
+import { useTheme } from "../context/useTheme";
+
+export default function ThemePanel() {
+  const { tokens, setTokens } = useTheme();
+  const [local, setLocal] = useState(tokens);
+
+  const change = (key: keyof typeof tokens, value: string) => {
+    setLocal({ ...local, [key]: value });
+  };
+
+  const save = () => {
+    setTokens(local);
+  };
+
+  return (
+    <div className="space-y-4">
+      <label className="block">
+        <span className="mr-2">Основной</span>
+        <input
+          type="color"
+          value={local.primary}
+          onChange={(e) => change("primary", e.target.value)}
+        />
+      </label>
+      <label className="block">
+        <span className="mr-2">Фон</span>
+        <input
+          type="color"
+          value={local.background}
+          onChange={(e) => change("background", e.target.value)}
+        />
+      </label>
+      <button className="btn btn-primary" onClick={save}>
+        Сохранить
+      </button>
+    </div>
+  );
+}

--- a/bot/web/src/context/ThemeContext.ts
+++ b/bot/web/src/context/ThemeContext.ts
@@ -1,0 +1,23 @@
+// Контекст токенов темы интерфейса
+// Модули: React
+import { createContext } from "react";
+
+export interface ThemeTokens {
+  primary: string;
+  background: string;
+  foreground: string;
+}
+
+interface ThemeContextType {
+  theme: string;
+  setTheme: (t: string) => void;
+  tokens: ThemeTokens;
+  setTokens: (t: ThemeTokens) => void;
+}
+
+export const ThemeContext = createContext<ThemeContextType>({
+  theme: "light",
+  setTheme: () => {},
+  tokens: { primary: "#3C50E0", background: "#FFFFFF", foreground: "#1C2434" },
+  setTokens: () => {},
+});

--- a/bot/web/src/context/ThemeProvider.tsx
+++ b/bot/web/src/context/ThemeProvider.tsx
@@ -1,0 +1,56 @@
+// Провайдер темы и токенов
+// Модули: React, next-themes, ThemeContext
+import { useState, useEffect, type ReactNode } from "react";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import { ThemeContext, type ThemeTokens } from "./ThemeContext";
+import presets from "../theme/presets.json";
+
+function getCookie(name: string): string | null {
+  const match = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`));
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+function setCookie(name: string, value: string) {
+  document.cookie = `${name}=${encodeURIComponent(value)};path=/;max-age=31536000`;
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState(() => getCookie("theme") || "light");
+  const [tokens, setTokens] = useState<ThemeTokens>(() => {
+    const saved = getCookie("theme-tokens");
+    if (saved) {
+      try {
+        return JSON.parse(saved) as ThemeTokens;
+      } catch {
+        /* ignore */
+      }
+    }
+    return (presets as Record<string, ThemeTokens>)[theme] || presets.light;
+  });
+
+  useEffect(() => {
+    const base = (presets as Record<string, ThemeTokens>)[theme];
+    if (base) setTokens((t) => ({ ...base, ...t }));
+  }, [theme]);
+
+  useEffect(() => {
+    for (const [k, v] of Object.entries(tokens)) {
+      document.documentElement.style.setProperty(`--${k}`, v);
+    }
+    document.documentElement.classList.toggle("dark", theme === "dark");
+    setCookie("theme", theme);
+    setCookie("theme-tokens", JSON.stringify(tokens));
+  }, [tokens, theme]);
+
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme={theme}
+      enableSystem={false}
+    >
+      <ThemeContext.Provider value={{ theme, setTheme, tokens, setTokens }}>
+        {children}
+      </ThemeContext.Provider>
+    </NextThemesProvider>
+  );
+}

--- a/bot/web/src/context/useTheme.ts
+++ b/bot/web/src/context/useTheme.ts
@@ -1,0 +1,8 @@
+// Хук доступа к токенам темы
+// Модули: React, ThemeContext
+import { useContext } from "react";
+import { ThemeContext } from "./ThemeContext";
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/bot/web/src/pages/ThemeSettings.tsx
+++ b/bot/web/src/pages/ThemeSettings.tsx
@@ -1,0 +1,12 @@
+// Страница настройки темы
+// Модули: React, ThemePanel
+import ThemePanel from "../components/ThemePanel";
+
+export default function ThemeSettings() {
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-xl font-semibold">Настройка темы</h1>
+      <ThemePanel />
+    </div>
+  );
+}

--- a/bot/web/src/theme/presets.json
+++ b/bot/web/src/theme/presets.json
@@ -1,0 +1,12 @@
+{
+  "light": {
+    "primary": "#3C50E0",
+    "background": "#FFFFFF",
+    "foreground": "#1C2434"
+  },
+  "dark": {
+    "primary": "#3C50E0",
+    "background": "#1C2434",
+    "foreground": "#FFFFFF"
+  }
+}


### PR DESCRIPTION
## Что сделано
- добавлен провайдер ThemeProvider с сохранением токенов в cookie
- добавлена страница `ThemeSettings` с панелью выбора цветов
- подключён скрипт инициализации темы в `index.html`

## Зачем
- единая система токенов позволяет быстро менять палитру
- хранение темы в cookie убирает мигание при SSR

## Как проверить
- `./scripts/setup_and_test.sh`
- `pnpm --dir bot/web build`
- `pnpm --dir bot/web dev`
- `pnpm --dir bot/web lint`

## Риск
- при ручном вводе некорректного цвета панель может отображаться неверно; при ошибках удалить cookie `theme-tokens`

------
https://chatgpt.com/codex/tasks/task_b_689d8064af1083208b64b77e62f4495e