### PR TITLE
feat: добавить authMiddleware и заменить verifyToken

### DIFF
--- a/bot/src/admin/customAdmin.ts
+++ b/bot/src/admin/customAdmin.ts
@@ -1,9 +1,9 @@
 // Назначение: кастомный бекенд админки без базовой аутентификации
-// Модули: express, path
+// Модули: express, path, middleware/auth
 import path from 'path';
 import express, { Express, NextFunction, Response } from 'express';
 import createRateLimiter from '../utils/rateLimiter';
-import { verifyToken } from '../api/middleware';
+import authMiddleware from '../middleware/auth';
 import type { RequestWithUser } from '../types/request';
 
 export default function initCustomAdmin(app: Express): void {
@@ -26,7 +26,7 @@ export default function initCustomAdmin(app: Express): void {
     next();
   });
 
-  router.use(verifyToken);
+  router.use(authMiddleware());
   router.use((req: RequestWithUser, res: Response, next: NextFunction) => {
     if (req.user?.role === 'admin') return next();
     res.sendFile(path.join(pub, 'admin-placeholder.html'));

--- a/bot/src/middleware/auth.ts
+++ b/bot/src/middleware/auth.ts
@@ -1,0 +1,9 @@
+// Middleware авторизации: обёртка verifyToken
+// Модули: express, api/middleware
+import type { RequestHandler } from 'express';
+import { verifyToken } from '../api/middleware';
+import type { RequestWithUser } from '../types/request';
+
+export default function authMiddleware(): RequestHandler {
+  return (req, res, next) => verifyToken(req as RequestWithUser, res, next);
+}

--- a/bot/src/routes/authUser.ts
+++ b/bot/src/routes/authUser.ts
@@ -1,8 +1,10 @@
 // Роуты регистрации, входа и профиля
 // Роут только профиля пользователя
+// Модули: express, auth.controller, middleware/auth
 import { Router, RequestHandler } from 'express';
 import * as authCtrl from '../auth/auth.controller';
-import { verifyToken, asyncHandler } from '../api/middleware';
+import { asyncHandler } from '../api/middleware';
+import authMiddleware from '../middleware/auth';
 import createRateLimiter from '../utils/rateLimiter';
 import { rateLimits } from '../rateLimits';
 import validateDto from '../middleware/validateDto';
@@ -37,12 +39,12 @@ router.post(
 
 router.get(
   '/profile',
-  verifyToken as RequestHandler,
+  authMiddleware(),
   authCtrl.profile as unknown as RequestHandler,
 );
 router.patch(
   '/profile',
-  verifyToken as RequestHandler,
+  authMiddleware(),
   ...(validateDto(UpdateProfileDto) as RequestHandler[]),
   asyncHandler(authCtrl.updateProfile),
 );

--- a/bot/src/routes/logs.ts
+++ b/bot/src/routes/logs.ts
@@ -1,11 +1,11 @@
 // Роуты логов: просмотр и запись
-// Модули: express, express-validator, controllers/logs
+// Модули: express, express-validator, controllers/logs, middleware/auth
 import { Router, RequestHandler } from 'express';
 import createRateLimiter from '../utils/rateLimiter';
 import { query } from 'express-validator';
 import container from '../di';
 import LogsController from '../logs/logs.controller';
-import { verifyToken } from '../api/middleware';
+import authMiddleware from '../middleware/auth';
 import { Roles } from '../auth/roles.decorator';
 import rolesGuard from '../auth/roles.guard';
 import { ACCESS_ADMIN } from '../utils/accessMask';
@@ -23,7 +23,7 @@ const ctrl = container.resolve(LogsController);
 router.get(
   '/',
   limiter as RequestHandler,
-  verifyToken as RequestHandler,
+  authMiddleware(),
   Roles(ACCESS_ADMIN) as unknown as RequestHandler,
   rolesGuard as unknown as RequestHandler,
   query('page').optional().isInt({ min: 1 }) as unknown as RequestHandler,
@@ -34,7 +34,7 @@ router.get(
 router.post(
   '/',
   limiter as RequestHandler,
-  verifyToken as RequestHandler,
+  authMiddleware(),
   ...(validateDto(CreateLogDto) as RequestHandler[]),
   ctrl.create as unknown as RequestHandler,
 );

--- a/bot/src/routes/maps.ts
+++ b/bot/src/routes/maps.ts
@@ -1,16 +1,17 @@
 // Роут карт: разворачивание ссылок Google Maps
-// Модули: express, express-validator, services/maps
+// Модули: express, express-validator, services/maps, middleware/auth
 import { Router } from 'express';
 import { body } from 'express-validator';
 import validate from '../utils/validate';
 import { expand } from '../controllers/maps';
-import { verifyToken, asyncHandler } from '../api/middleware';
+import { asyncHandler } from '../api/middleware';
+import authMiddleware from '../middleware/auth';
 
 const router = Router();
 
 router.post(
   '/expand',
-  verifyToken,
+  authMiddleware(),
   validate([body('url').isString().notEmpty()]),
   asyncHandler(expand),
 );

--- a/bot/src/routes/optimizer.ts
+++ b/bot/src/routes/optimizer.ts
@@ -1,16 +1,17 @@
 // Роут расчёта оптимального маршрута для нескольких машин
-// Модули: express, express-validator, controllers/optimizer
-import { Router, RequestHandler } from 'express';
+// Модули: express, express-validator, controllers/optimizer, middleware/auth
+import { Router } from 'express';
 import { body } from 'express-validator';
 import validate from '../utils/validate';
 import * as ctrl from '../controllers/optimizer';
-import { verifyToken, asyncHandler } from '../api/middleware';
+import { asyncHandler } from '../api/middleware';
+import authMiddleware from '../middleware/auth';
 
 const router = Router();
 
 router.post(
   '/',
-  verifyToken as RequestHandler,
+  authMiddleware(),
   ...validate([
     body('tasks').isArray({ min: 1 }),
     body('count').optional().isInt({ min: 1, max: 3 }),

--- a/bot/src/routes/roles.ts
+++ b/bot/src/routes/roles.ts
@@ -1,11 +1,11 @@
 // Роуты ролей: список и обновление
-// Модули: express, express-validator, controllers/roles
+// Модули: express, express-validator, controllers/roles, middleware/auth
 import { Router, RequestHandler } from 'express';
 import createRateLimiter from '../utils/rateLimiter';
 import { param } from 'express-validator';
 import container from '../di';
 import RolesController from '../roles/roles.controller';
-import { verifyToken } from '../api/middleware';
+import authMiddleware from '../middleware/auth';
 import { Roles } from '../auth/roles.decorator';
 import rolesGuard from '../auth/roles.guard';
 import { ACCESS_ADMIN } from '../utils/accessMask';
@@ -39,7 +39,7 @@ const ctrl = container.resolve(RolesController);
 router.get(
   '/',
   limiter as unknown as RequestHandler,
-  verifyToken as unknown as RequestHandler,
+  authMiddleware(),
   Roles(ACCESS_ADMIN) as unknown as RequestHandler,
   rolesGuard as unknown as RequestHandler,
   ctrl.list as RequestHandler,
@@ -48,7 +48,7 @@ router.get(
 router.patch(
   '/:id',
   limiter as unknown as RequestHandler,
-  verifyToken as unknown as RequestHandler,
+  authMiddleware(),
   Roles(ACCESS_ADMIN) as unknown as RequestHandler,
   rolesGuard as unknown as RequestHandler,
   param('id').isMongoId(),

--- a/bot/src/routes/route.ts
+++ b/bot/src/routes/route.ts
@@ -1,5 +1,5 @@
 // Роут расчёта расстояния
-// Модули: express, express-validator, services/route
+// Модули: express, express-validator, services/route, middleware/auth
 import { Router, RequestHandler } from 'express';
 import { body, query } from 'express-validator';
 import validate from '../utils/validate';
@@ -10,7 +10,8 @@ import {
   match,
   trip,
 } from '../services/route';
-import { verifyToken, asyncHandler } from '../api/middleware';
+import { asyncHandler } from '../api/middleware';
+import authMiddleware from '../middleware/auth';
 import createRateLimiter from '../utils/rateLimiter';
 import { rateLimits } from '../rateLimits';
 
@@ -37,7 +38,7 @@ const tableLimiter = createRateLimiter(rateLimits.table);
 router.post(
   '/',
   routeLimiter as unknown as RequestHandler,
-  verifyToken as unknown as RequestHandler,
+  authMiddleware(),
   validate([
     body('start.lat').isFloat(),
     body('start.lng').isFloat(),
@@ -57,7 +58,7 @@ interface TableQuery extends Record<string, string> {
 router.get(
   '/table',
   tableLimiter as unknown as RequestHandler,
-  verifyToken as unknown as RequestHandler,
+  authMiddleware(),
   validate([query('points').isString()]),
   asyncHandler(async (req, res) => {
     const { points, ...params } = req.query as TableQuery;
@@ -77,7 +78,7 @@ interface PointQuery extends Record<string, string> {
 router.get(
   '/nearest',
   routeLimiter as unknown as RequestHandler,
-  verifyToken as unknown as RequestHandler,
+  authMiddleware(),
   validate([query('point').isString()]),
   asyncHandler(async (req, res) => {
     const { point, ...params } = req.query as PointQuery;
@@ -91,7 +92,7 @@ interface PointsQuery extends Record<string, string> {
 router.get(
   '/match',
   routeLimiter as unknown as RequestHandler,
-  verifyToken as unknown as RequestHandler,
+  authMiddleware(),
   validate([query('points').isString()]),
   asyncHandler(async (req, res) => {
     const { points, ...params } = req.query as PointsQuery;
@@ -102,7 +103,7 @@ router.get(
 router.get(
   '/trip',
   routeLimiter as unknown as RequestHandler,
-  verifyToken as unknown as RequestHandler,
+  authMiddleware(),
   validate([query('points').isString()]),
   asyncHandler(async (req, res) => {
     const { points, ...params } = req.query as PointsQuery;

--- a/bot/src/routes/routes.ts
+++ b/bot/src/routes/routes.ts
@@ -1,9 +1,10 @@
 // Роуты для получения маршрутов
-// Модули: express, express-validator, controllers/routes
+// Модули: express, express-validator, controllers/routes, middleware/auth
 import { Router, RequestHandler } from 'express';
 import { query, validationResult } from 'express-validator';
 import * as ctrl from '../controllers/routes';
-import { verifyToken, asyncHandler } from '../api/middleware';
+import { asyncHandler } from '../api/middleware';
+import authMiddleware from '../middleware/auth';
 import { sendProblem } from '../utils/problem';
 
 export interface RoutesQuery {
@@ -34,7 +35,7 @@ const validate = (v: ReturnType<typeof query>[]): RequestHandler[] => [
 
 router.get(
   '/all',
-  verifyToken as unknown as RequestHandler,
+  authMiddleware(),
   validate([
     query('from').optional().isISO8601(),
     query('to').optional().isISO8601(),

--- a/bot/src/routes/tasks.ts
+++ b/bot/src/routes/tasks.ts
@@ -1,11 +1,11 @@
 // Роуты задач: CRUD, время, массовые действия
-// Модули: express, express-validator, controllers/tasks
+// Модули: express, express-validator, controllers/tasks, middleware/auth
 import { Router, RequestHandler } from 'express';
 import createRateLimiter from '../utils/rateLimiter';
 import { param, query } from 'express-validator';
 import container from '../di';
 import TasksController from '../tasks/tasks.controller';
-import { verifyToken } from '../api/middleware';
+import authMiddleware from '../middleware/auth';
 import validateDto from '../middleware/validateDto';
 import {
   CreateTaskDto,
@@ -32,7 +32,7 @@ router.use(tasksLimiter);
 
 router.get(
   '/',
-  verifyToken as unknown as RequestHandler,
+  authMiddleware(),
   [
     query('status').optional().isString(),
     query('assignees').optional().isArray(),
@@ -44,18 +44,18 @@ router.get(
   ctrl.list as RequestHandler,
 );
 
-router.get('/mentioned', verifyToken, ctrl.mentioned);
+router.get('/mentioned', authMiddleware(), ctrl.mentioned);
 
 router.get(
   '/report/summary',
-  verifyToken as unknown as RequestHandler,
+  authMiddleware(),
   [query('from').optional().isISO8601(), query('to').optional().isISO8601()],
   ctrl.summary as RequestHandler,
 );
 
 router.get(
   '/:id',
-  verifyToken as unknown as RequestHandler,
+  authMiddleware(),
   detailLimiter,
   param('id').isMongoId(),
   ctrl.detail as RequestHandler,
@@ -63,14 +63,14 @@ router.get(
 
 router.post(
   '/',
-  verifyToken as unknown as RequestHandler,
+  authMiddleware(),
   ...(validateDto(CreateTaskDto) as RequestHandler[]),
   ...(ctrl.create as RequestHandler[]),
 );
 
 router.patch(
   '/:id',
-  verifyToken as unknown as RequestHandler,
+  authMiddleware(),
   param('id').isMongoId(),
   checkTaskAccess as unknown as RequestHandler,
   ...(validateDto(UpdateTaskDto) as RequestHandler[]),
@@ -79,7 +79,7 @@ router.patch(
 
 router.patch(
   '/:id/time',
-  verifyToken as unknown as RequestHandler,
+  authMiddleware(),
   param('id').isMongoId(),
   ...(validateDto(AddTimeDto) as RequestHandler[]),
   checkTaskAccess as unknown as RequestHandler,
@@ -88,7 +88,7 @@ router.patch(
 
 router.delete(
   '/:id',
-  verifyToken as unknown as RequestHandler,
+  authMiddleware(),
   param('id').isMongoId(),
   checkTaskAccess as unknown as RequestHandler,
   ctrl.remove as RequestHandler,
@@ -96,7 +96,7 @@ router.delete(
 
 router.post(
   '/bulk',
-  verifyToken as unknown as RequestHandler,
+  authMiddleware(),
   ...(validateDto(BulkStatusDto) as RequestHandler[]),
   ...(ctrl.bulk as RequestHandler[]),
 );

--- a/bot/src/routes/users.ts
+++ b/bot/src/routes/users.ts
@@ -1,10 +1,10 @@
 // Роуты пользователей: список и создание
-// Модули: express, express-rate-limit, controllers/users
+// Модули: express, express-rate-limit, controllers/users, middleware/auth
 import { Router, RequestHandler } from 'express';
 import rateLimit from 'express-rate-limit';
 import container from '../di';
 import UsersController from '../users/users.controller';
-import { verifyToken } from '../api/middleware';
+import authMiddleware from '../middleware/auth';
 import { Roles } from '../auth/roles.decorator';
 import rolesGuard from '../auth/roles.guard';
 import { ACCESS_ADMIN } from '../utils/accessMask';
@@ -15,7 +15,7 @@ const router = Router();
 const limiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 100 });
 const middlewares = [
   limiter,
-  verifyToken,
+  authMiddleware(),
   Roles(ACCESS_ADMIN),
   rolesGuard,
 ] as RequestHandler[];

--- a/bot/tests/authMiddleware.test.ts
+++ b/bot/tests/authMiddleware.test.ts
@@ -1,0 +1,22 @@
+// Тесты middleware authMiddleware
+// Модули: jest, express
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 's';
+
+jest.mock('../src/api/middleware', () => ({
+  verifyToken: jest.fn((_req: unknown, _res: unknown, next: () => void) =>
+    next(),
+  ),
+}));
+
+const { default: authMiddleware } = require('../src/middleware/auth');
+const { verifyToken } = require('../src/api/middleware');
+
+test('authMiddleware вызывает verifyToken', () => {
+  const req = {};
+  const res = {};
+  const next = jest.fn();
+  const mw = authMiddleware();
+  mw(req, res, next);
+  expect(verifyToken).toHaveBeenCalledWith(req, res, next);
+});


### PR DESCRIPTION
## Summary
- обёртка verifyToken в виде authMiddleware
- роутеры используют новый middleware без двойных приведений
- unit‑тест для authMiddleware

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm lint`
- `./scripts/pre_pr_check.sh` *(failed: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_689d9ea228c48320bf4fa1f61323e23a