### PR TITLE
refactor: split api server and routes

### DIFF
--- a/bot/src/api/security.ts
+++ b/bot/src/api/security.ts
@@ -4,7 +4,7 @@ import express from 'express';
 import helmet from 'helmet';
 import type { HelmetOptions } from 'helmet';
 
-import config from './config';
+import config from '../config';
 
 type CSPConfig = NonNullable<
   Exclude<HelmetOptions['contentSecurityPolicy'], boolean>

--- a/bot/src/api/server.ts
+++ b/bot/src/api/server.ts
@@ -1,0 +1,99 @@
+// Назначение файла: сборка HTTP API.
+// Основные модули: express, security, routes
+import dotenv from 'dotenv';
+import config from '../config';
+import express from 'express';
+import compression from 'compression';
+import cookieParser from 'cookie-parser';
+import session from 'express-session';
+import MongoStore from 'connect-mongo';
+import path from 'path';
+import { promises as fs } from 'fs';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import applySecurity from './security';
+import registerRoutes from './routes';
+
+dotenv.config();
+
+process.on('unhandledRejection', (err) => {
+  console.error('Unhandled rejection in API:', err);
+});
+process.on('uncaughtException', (err) => {
+  console.error('Uncaught exception in API:', err);
+  process.exit(1);
+});
+
+const execAsync = promisify(exec);
+
+export async function buildApp(): Promise<express.Express> {
+  const { default: connect } = await import('../db/connection');
+  await connect();
+  await import('../db/model');
+
+  const app = express();
+  const ext = process.env.NODE_ENV === 'test' ? '.ts' : '.js';
+  const traceModule = await import('../middleware/trace' + ext);
+  const pinoLoggerModule = await import('../middleware/pinoLogger' + ext);
+  const metricsModule = await import('../middleware/metrics' + ext);
+  const trace = (traceModule.default || traceModule) as express.RequestHandler;
+  const pinoLogger = (pinoLoggerModule.default ||
+    pinoLoggerModule) as express.RequestHandler;
+  const metrics = (metricsModule.default ||
+    metricsModule) as express.RequestHandler;
+
+  applySecurity(app);
+  app.use(trace);
+  app.use(pinoLogger);
+  app.use(metrics);
+
+  const root = path.join(__dirname, '../..');
+  const pub = path.join(root, 'public');
+  const indexFile = path.join(pub, 'index.html');
+  let needBuild = false;
+  try {
+    const st = await fs.stat(indexFile);
+    if (st.size === 0) needBuild = true;
+  } catch {
+    needBuild = true;
+  }
+  if (needBuild) {
+    console.log('Сборка интерфейса...');
+    await execAsync('npm run build-client', { cwd: root });
+  }
+
+  app.set('trust proxy', 1);
+  app.use(express.json());
+  app.use(cookieParser());
+  app.use(compression());
+
+  const domain =
+    process.env.NODE_ENV === 'production'
+      ? config.cookieDomain || new URL(config.appUrl).hostname
+      : undefined;
+  const cookieFlags: session.CookieOptions = {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'none',
+    ...(domain ? { domain } : {}),
+  };
+  const sessionOpts: session.SessionOptions = {
+    secret: process.env.SESSION_SECRET || 'session_secret',
+    resave: false,
+    saveUninitialized: true,
+    cookie: { ...cookieFlags, maxAge: 7 * 24 * 60 * 60 * 1000 },
+  };
+  if (process.env.NODE_ENV !== 'test') {
+    sessionOpts.store = MongoStore.create({
+      mongoUrl: config.mongoUrl,
+      collectionName: 'sessions',
+    });
+  }
+  app.use(session(sessionOpts));
+
+  await registerRoutes(app, cookieFlags, pub);
+
+  return app;
+}
+
+export default buildApp;

--- a/bot/src/api/swagger.ts
+++ b/bot/src/api/swagger.ts
@@ -39,7 +39,7 @@ const options: swaggerJsdoc.Options = {
       },
     },
   },
-  apis: ['./src/api/api.ts', './src/routes/tasks.ts'],
+  apis: ['./src/api/routes.ts', './src/routes/tasks.ts'],
 };
 
 const specs = swaggerJsdoc(options);

--- a/bot/src/server.ts
+++ b/bot/src/server.ts
@@ -1,4 +1,15 @@
 // Назначение файла: стартовый скрипт API.
 // Основные модули: di, api
 import './di';
-import './api/api';
+import config from './config';
+import buildApp from './api/server';
+
+buildApp().then((app) => {
+  const port: number = config.port;
+  app.listen(port, '0.0.0.0', () => {
+    console.log(`API запущен на порту ${port}`);
+    console.log(
+      `Окружение: ${process.env.NODE_ENV || 'development'}, Node ${process.version}`,
+    );
+  });
+});

--- a/bot/tests/security.test.ts
+++ b/bot/tests/security.test.ts
@@ -7,7 +7,7 @@ process.env.APP_URL = 'https://localhost';
 
 const express = require('express');
 const request = require('supertest');
-const applySecurity = require('../src/security').default;
+const applySecurity = require('../src/api/security').default;
 const { stopScheduler } = require('../src/services/scheduler');
 const { stopQueue } = require('../src/services/messageQueue');
 


### PR DESCRIPTION
## Summary
- refactor API bootstrap into separate server, security, and routes modules
- expose buildApp for external startup
- adjust imports, swagger docs, and tests

## Testing
- `pnpm lint`
- `./scripts/setup_and_test.sh`
- `pnpm test:api`
- `pnpm test:e2e`
- `./scripts/audit_deps.sh`
- `docker compose config`


------
https://chatgpt.com/codex/tasks/task_b_689db829ba68832095f528508e65763a