### PR TITLE
refactor: tighten CSP types and robust JS check

### DIFF
--- a/bot/src/api/security.ts
+++ b/bot/src/api/security.ts
@@ -4,6 +4,7 @@ import express from 'express';
 import helmet from 'helmet';
 import type { HelmetOptions } from 'helmet';
 import crypto from 'node:crypto';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import config from '../config';
 
@@ -46,9 +47,11 @@ export default function applySecurity(app: express.Express): void {
     ...parseList(process.env.CSP_IMG_SRC_ALLOWLIST),
   ];
 
+  type ResWithNonce = ServerResponse & { locals: { cspNonce: string } };
   const scriptSrc = [
     "'self'",
-    (_req: any, res: any) => `'nonce-${res.locals.cspNonce}'`,
+    (_req: IncomingMessage, res: ServerResponse) =>
+      `'nonce-${(res as ResWithNonce).locals.cspNonce}'`,
     "'strict-dynamic'",
     'https://telegram.org',
     ...parseList(process.env.CSP_SCRIPT_SRC_ALLOWLIST),

--- a/scripts/check_no_js.sh
+++ b/scripts/check_no_js.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 # Назначение: проверка отсутствия JavaScript-файлов в репозитории.
-# Модули: bash, ripgrep.
+# Модули: bash, ripgrep, git.
 set -euo pipefail
 cd "$(dirname "$0")/.."
-if rg --files -g '*.js' -g '!node_modules/**' -g '!dist/**' | grep -q '.'; then
-  echo 'Найдены файлы JavaScript. Используйте TypeScript.' >&2
-  exit 1
+if command -v rg >/dev/null; then
+  if rg --files -g '*.js' -g '!node_modules/**' -g '!dist/**' | grep -q '.'; then
+    echo 'Найдены файлы JavaScript. Используйте TypeScript.' >&2
+    exit 1
+  fi
+else
+  echo 'Предупреждение: ripgrep не найден, используем git ls-files.' >&2
+  if git ls-files '*.js' | grep -q '.'; then
+    echo 'Найдены файлы JavaScript. Используйте TypeScript.' >&2
+    exit 1
+  fi
 fi


### PR DESCRIPTION
## Summary
- remove `any` usage in CSP nonce generation
- fallback to `git ls-files` when ripgrep is unavailable

## Testing
- `pnpm lint`
- `./scripts/setup_and_test.sh`
- `./scripts/audit_deps.sh`
- `pnpm --dir bot build`
- `pnpm --dir bot dev` *(fails: APP_URL must start with https://)*

------
https://chatgpt.com/codex/tasks/task_b_689def5c5d588320b74a5b4c681417a6