### PR TITLE
feat: add ETag caching and rate limit logging

### DIFF
--- a/bot/src/controllers/routes.ts
+++ b/bot/src/controllers/routes.ts
@@ -4,6 +4,7 @@ import { Request, Response } from 'express';
 import { validationResult } from 'express-validator';
 import * as service from '../services/routes';
 import { sendProblem } from '../utils/problem';
+import { sendCached } from '../utils/sendCached';
 
 export async function all(req: Request, res: Response): Promise<void> {
   const errors = validationResult(req);
@@ -21,5 +22,6 @@ export async function all(req: Request, res: Response): Promise<void> {
     to: req.query.to as string | undefined,
     status: typeof req.query.status === 'string' ? req.query.status : undefined,
   };
-  res.json(await service.list(filters));
+  const data = await service.list(filters);
+  sendCached(req, res, data);
 }

--- a/bot/src/logs/logs.controller.ts
+++ b/bot/src/logs/logs.controller.ts
@@ -6,6 +6,7 @@ import { handleValidation } from '../utils/validate';
 import { TOKENS } from '../di/tokens';
 import type LogsService from './logs.service';
 import { ListLogParams } from '../services/wgLogEngine';
+import { sendCached } from '../utils/sendCached';
 
 @injectable()
 export default class LogsController {
@@ -15,7 +16,12 @@ export default class LogsController {
     req: Request<unknown, unknown, unknown, ListLogParams>,
     res: Response,
   ): Promise<void> => {
-    res.json(await this.service.list(req.query));
+    const data = await this.service.list(req.query);
+    sendCached(
+      req as Request<Record<string, unknown>, unknown, unknown, ListLogParams>,
+      res,
+      data,
+    );
   };
 
   create = [

--- a/bot/src/roles/roles.controller.ts
+++ b/bot/src/roles/roles.controller.ts
@@ -6,13 +6,14 @@ import { handleValidation } from '../utils/validate';
 import { TOKENS } from '../di/tokens';
 import type RolesService from './roles.service';
 import { sendProblem } from '../utils/problem';
+import { sendCached } from '../utils/sendCached';
 
 @injectable()
 export default class RolesController {
   constructor(@inject(TOKENS.RolesService) private service: RolesService) {}
 
-  list = async (_req: Request, res: Response) => {
-    res.json(await this.service.list());
+  list = async (req: Request, res: Response) => {
+    sendCached(req, res, await this.service.list());
   };
 
   update = [

--- a/bot/src/tasks/tasks.controller.ts
+++ b/bot/src/tasks/tasks.controller.ts
@@ -10,6 +10,7 @@ import { getUsersMap } from '../db/queries';
 import type { RequestWithUser } from '../types/request';
 import type { TaskDocument } from '../db/model';
 import { sendProblem } from '../utils/problem';
+import { sendCached } from '../utils/sendCached';
 
 interface Task {
   assignees?: number[];
@@ -41,7 +42,7 @@ export default class TasksController {
       if (t.created_by) ids.add(t.created_by);
     });
     const users = await getUsersMap(Array.from(ids));
-    res.json({ tasks, users });
+    sendCached(req, res, { tasks, users });
   };
 
   detail = async (req: Request, res: Response) => {

--- a/bot/src/users/users.controller.ts
+++ b/bot/src/users/users.controller.ts
@@ -6,6 +6,7 @@ import { handleValidation } from '../utils/validate';
 import { TOKENS } from '../di/tokens';
 import type UsersService from './users.service';
 import formatUser from '../utils/formatUser';
+import { sendCached } from '../utils/sendCached';
 
 interface CreateUserBody {
   id: string;
@@ -17,9 +18,13 @@ interface CreateUserBody {
 export default class UsersController {
   constructor(@inject(TOKENS.UsersService) private service: UsersService) {}
 
-  list = async (_req: Request, res: Response): Promise<void> => {
+  list = async (req: Request, res: Response): Promise<void> => {
     const users = await this.service.list();
-    res.json(users.map((u) => formatUser(u)));
+    sendCached(
+      req,
+      res,
+      users.map((u) => formatUser(u)),
+    );
   };
 
   create = [

--- a/bot/src/utils/rateLimiter.ts
+++ b/bot/src/utils/rateLimiter.ts
@@ -41,8 +41,15 @@ export default function createRateLimiter({
         res.setHeader('Retry-After', retryAfter.toString());
       }
       const key = req.user?.id ?? req.ip;
+      const limit = req.rateLimit?.limit;
+      const remaining = req.rateLimit?.remaining;
+      const resetTime =
+        req.rateLimit?.resetTime instanceof Date
+          ? req.rateLimit.resetTime.getTime()
+          : req.rateLimit?.resetTime;
       writeLog(
-        `Превышен лимит ${req.method} ${req.originalUrl} key:${key}`,
+        `Превышен лимит ${req.method} ${req.originalUrl} key:${key} ` +
+          `limit:${limit} remaining:${remaining} reset:${resetTime}`,
         'warn',
       ).catch(() => {});
       sendProblem(req, res, {

--- a/bot/src/utils/sendCached.ts
+++ b/bot/src/utils/sendCached.ts
@@ -1,0 +1,25 @@
+// Назначение файла: отправка JSON с ETag и заголовками кеширования
+// Основные модули: crypto, express
+import { createHash } from 'crypto';
+import type { Request, Response } from 'express';
+
+export function sendCached<
+  P extends Record<string, unknown>,
+  ResBody = unknown,
+  ReqBody = unknown,
+  ReqQuery = unknown,
+>(
+  req: Request<P, ResBody, ReqBody, ReqQuery>,
+  res: Response,
+  data: unknown,
+): void {
+  const body = JSON.stringify(data);
+  const etag = createHash('sha256').update(body).digest('hex');
+  res.setHeader('Cache-Control', 'max-age=60, stale-while-revalidate=120');
+  res.setHeader('ETag', etag);
+  if (req.headers['if-none-match'] === etag) {
+    res.status(304).end();
+    return;
+  }
+  res.json(data);
+}


### PR DESCRIPTION
## Summary
- cache list responses with ETag and handle If-None-Match
- log rate-limit key and headers for observability

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm --dir bot build`
- `pnpm --dir bot run dev` (fails: Missing script or exits immediately)
- `./scripts/audit_deps.sh` (fails: APP_URL должен начинаться с https://)


------
https://chatgpt.com/codex/tasks/task_b_689edac20ba883209b48061647f715df