### PR TITLE
feat: вынес модалку задачи в портал

### DIFF
--- a/bot/web/src/components/Modal.tsx
+++ b/bot/web/src/components/Modal.tsx
@@ -1,0 +1,25 @@
+// Назначение: универсальная модалка с порталом в document.body
+// Основные модули: React, ReactDOM
+import React from "react";
+import { createPortal } from "react-dom";
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export default function Modal({ open, onClose, children }: ModalProps) {
+  if (!open) return null;
+  return createPortal(
+    <div className="fixed inset-0 z-[1000]" role="dialog" aria-modal="true">
+      <div className="fixed inset-0 bg-black/50" onClick={onClose} />
+      <div className="pointer-events-none fixed inset-0 flex items-center justify-center">
+        <div className="pointer-events-auto max-h-[90vh] w-[min(900px,90vw)] overflow-auto rounded-2xl bg-white p-6 shadow-xl">
+          {children}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/bot/web/src/components/TaskDialogRoute.tsx
+++ b/bot/web/src/components/TaskDialogRoute.tsx
@@ -4,13 +4,7 @@ import React from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import TaskDialog from "./TaskDialog";
 import useTasks from "../context/useTasks";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+import Modal from "./Modal";
 
 export default function TaskDialogRoute() {
   const [params] = useSearchParams();
@@ -25,21 +19,14 @@ export default function TaskDialogRoute() {
     navigate({ search: params.toString() }, { replace: true });
   };
   return (
-    <Dialog open onOpenChange={close}>
-      <DialogContent className="p-0" aria-describedby={undefined}>
-        <DialogHeader>
-          <VisuallyHidden asChild>
-            <DialogTitle>Форма задачи</DialogTitle>
-          </VisuallyHidden>
-        </DialogHeader>
-        <TaskDialog
-          id={id || undefined}
-          onClose={close}
-          onSave={() => {
-            refresh();
-          }}
-        />
-      </DialogContent>
-    </Dialog>
+    <Modal open onClose={close}>
+      <TaskDialog
+        id={id || undefined}
+        onClose={close}
+        onSave={() => {
+          refresh();
+        }}
+      />
+    </Modal>
   );
 }


### PR DESCRIPTION
## Summary
- вынес модалку задачи в отдельный портал, чтобы она не обрезалась контейнером
- подключил TaskDialogRoute к новому компоненту Modal

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/audit_deps.sh`
- `./scripts/pre_pr_check.sh` *(failed: repeated tsc build, бот не запустился)*


------
https://chatgpt.com/codex/tasks/task_b_689eeed266648320823bac2f63f19052