### PR TITLE
feat: add intake rules for task creation

### DIFF
--- a/bot/src/intake/rules.ts
+++ b/bot/src/intake/rules.ts
@@ -1,0 +1,30 @@
+// Набор правил intake для автоматического дополнения задач.
+// Основные модули: db/model.
+
+import type { TaskDocument } from '../db/model';
+
+interface Rule {
+  description: string;
+  condition: (task: Partial<TaskDocument>) => boolean;
+  action: (task: Partial<TaskDocument>) => void;
+}
+
+// Простое правило: если в названии присутствует слово «срочно»,
+// приоритет задачи становится «Срочно».
+export const rules: Rule[] = [
+  {
+    description:
+      'Устанавливает высокий приоритет, если в названии есть слово «срочно».',
+    condition: (task) => /срочно/i.test(task.title || ''),
+    action: (task) => {
+      task.priority = 'Срочно';
+    },
+  },
+];
+
+// Применяет все правила к задаче.
+export function applyIntakeRules(task: Partial<TaskDocument>) {
+  for (const r of rules) {
+    if (r.condition(task)) r.action(task);
+  }
+}

--- a/bot/src/tasks/tasks.service.ts
+++ b/bot/src/tasks/tasks.service.ts
@@ -2,6 +2,7 @@
 // Основные модули: db/queries, services/route, services/maps
 import { getRouteDistance, clearRouteCache } from '../services/route';
 import { generateRouteLink } from '../services/maps';
+import { applyIntakeRules } from '../intake/rules';
 import type { TaskDocument } from '../db/model';
 import type { TaskFilters, SummaryFilters } from '../db/queries';
 
@@ -45,6 +46,7 @@ class TasksService {
   }
 
   async create(data: Partial<TaskDocument>) {
+    applyIntakeRules(data);
     if (data.due_date && !data.remind_at) data.remind_at = data.due_date;
     await this.applyRouteInfo(data);
     const task = await this.repo.createTask(data);

--- a/tests/e2e/intake.rules.spec.ts
+++ b/tests/e2e/intake.rules.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Назначение файла: e2e-тесты проверки правил intake.
+ * Основные модули: @playwright/test, express, intake/rules.
+ */
+import { test, expect } from '@playwright/test';
+import express from 'express';
+import type { Server } from 'http';
+import { applyIntakeRules } from '../../bot/src/intake/rules';
+import type { TaskDocument } from '../../bot/src/db/model';
+
+let server: Server;
+const base = 'http://localhost:3003';
+
+const app = express();
+app.use(express.json());
+
+let counter = 1;
+app.post('/tasks', (req, res) => {
+  const data = req.body as Partial<TaskDocument>;
+  applyIntakeRules(data);
+  const task = { id: counter++, ...data };
+  res.status(201).json(task);
+});
+
+test.beforeAll(() => {
+  server = app.listen(3003);
+});
+
+test.afterAll(() => {
+  server.close();
+});
+
+test.describe('Правила intake', () => {
+  test('устанавливает приоритет по ключевому слову', async ({ request }) => {
+    const res = await request.post(`${base}/tasks`, {
+      data: { title: 'Срочно доставить отчёт' },
+    });
+    expect(res.status()).toBe(201);
+    const body = await res.json();
+    expect(body.priority).toBe('Срочно');
+  });
+});


### PR DESCRIPTION
## Summary
- add intake rule system for new tasks
- apply rules when creating tasks
- cover intake rule with e2e test

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm lint`
- `pnpm test:e2e tests/e2e/intake.rules.spec.ts`


------
https://chatgpt.com/codex/tasks/task_b_689f16289f308320870b025d7d68333b