### PR TITLE
feat: overlay for sidebar

### DIFF
--- a/bot/web/src/App.tsx
+++ b/bot/web/src/App.tsx
@@ -134,9 +134,21 @@ function Content() {
 
 function Layout() {
   const { user } = React.useContext(AuthContext);
+  const { open, toggle } = useSidebar();
   return (
     <>
       {user && <Sidebar />}
+      {user && open && (
+        <div
+          className="fixed inset-0 z-40 bg-black/40"
+          tabIndex={-1}
+          ref={(el) => el?.focus()}
+          onClick={() => {
+            (document.activeElement as HTMLElement | null)?.blur();
+            toggle();
+          }}
+        />
+      )}
       {user && <Header />}
       <Toasts />
       <Content />

--- a/bot/web/src/layouts/Sidebar.tsx
+++ b/bot/web/src/layouts/Sidebar.tsx
@@ -39,7 +39,7 @@ export default function Sidebar() {
   }, [role]);
   return (
     <aside
-      className={`fixed top-0 left-0 z-30 h-full ${collapsed ? "w-20" : "w-60"} border-stroke border-r bg-white p-4 transition-all ${open ? "translate-x-0" : "-translate-x-full"}`}
+      className={`fixed top-0 left-0 z-50 h-full ${collapsed ? "w-20" : "w-60"} border-stroke border-r bg-white p-4 transition-all ${open ? "translate-x-0" : "-translate-x-full"}`}
     >
       <div className="flex items-center justify-between">
         <button onClick={toggle} className="p-1" aria-label="Закрыть меню">


### PR DESCRIPTION
## Summary
- add backdrop overlay toggling sidebar and blurring focus
- raise Sidebar z-index above overlay

## Testing
- `pnpm install`
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68a054eee6e483209f3b64ae3a80222e