### PR TITLE
fix: validate path before deleting file

### DIFF
--- a/bot/src/services/dataStorage.ts
+++ b/bot/src/services/dataStorage.ts
@@ -4,6 +4,8 @@ import fs from 'fs';
 import path from 'path';
 import { uploadsDir } from '../routes/tasks';
 
+const uploadsDirAbs = path.resolve(uploadsDir);
+
 export interface StoredFile {
   name: string;
   size: number;
@@ -19,5 +21,10 @@ export async function listFiles(): Promise<StoredFile[]> {
 }
 
 export async function deleteFile(name: string): Promise<void> {
-  await fs.promises.unlink(path.join(uploadsDir, name));
+  // Предотвращаем выход за пределы каталога
+  const targetPath = path.resolve(uploadsDirAbs, name);
+  if (!targetPath.startsWith(uploadsDirAbs + path.sep)) {
+    throw new Error('Недопустимое имя файла');
+  }
+  await fs.promises.unlink(targetPath);
 }


### PR DESCRIPTION
## Summary
- добавить проверку пути в `deleteFile` чтобы предотвратить выход за пределы каталога загрузок

## Testing
- `pnpm install`
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(script not found)*
- `pnpm run dev` *(script not found)*
- `./scripts/setup_and_test.sh` *(падает: Operation logs.insertOne buffering timed out)*
- `./scripts/pre_pr_check.sh` *(Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68a424132448832098b70be9e199eb4f