### PR TITLE
test: set APP_URL in storage test

### DIFF
--- a/bot/tests/storage.test.ts
+++ b/bot/tests/storage.test.ts
@@ -1,6 +1,7 @@
 // Назначение: тесты роутов управления файлами. Модули: jest, supertest.
 process.env.NODE_ENV = 'test';
 process.env.JWT_SECRET = 's';
+process.env.APP_URL = 'https://localhost';
 
 import express from 'express';
 import request from 'supertest';


### PR DESCRIPTION
## Summary
- fix storage route tests by defining APP_URL for config

## Testing
- `pnpm lint`
- `./scripts/audit_deps.sh`
- `npm test --prefix bot -- --detectOpenHandles` *(fails: Cannot find module './node_modules/ts-node/register')*

------
https://chatgpt.com/codex/tasks/task_b_68a429555f1083208bf3466ecb22bfdc