### PR TITLE
feat: default mongo url from example and fix input props

### DIFF
--- a/bot/web/src/components/ui/input.tsx
+++ b/bot/web/src/components/ui/input.tsx
@@ -6,8 +6,7 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type = "text", ...props }, ref) => (


### PR DESCRIPTION
## Summary
- fallback to .env.example in MongoDB check
- simplify InputProps type for lint compliance

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm lint`
- `npm --prefix bot/web run lint`
- `docker compose config`


------
https://chatgpt.com/codex/tasks/task_b_68a46ece43bc8320a074d75e5fe071b2