### PR TITLE
docs: clarify axe-core cli usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ pnpm --dir bot dev
 pnpm a11y
 ```
 
+При прямом запуске `@axe-core/cli` указывайте путь с `file://`, иначе возможна ошибка `net::ERR_NAME_NOT_RESOLVED`.
+Пример: `npx @axe-core/cli file://$PWD/bot/public/index.html --tags color-contrast`.
+
 ## Структура пакетов
 
 - `bot` — Telegram‑бот, REST API и мини‑приложение React.


### PR DESCRIPTION
## Summary
- explain that @axe-core/cli needs file:// paths to avoid net::ERR_NAME_NOT_RESOLVED

## Testing
- `pnpm format` *(fails to exit cleanly; had to interrupt but README unaffected)*
- `./scripts/setup_and_test.sh` *(failed: long running, aborted after dependency installation)*

------
https://chatgpt.com/codex/tasks/task_b_68a586b1be548320b51e9c7174e39548