### PR TITLE
feat: async file stats

### DIFF
--- a/bot/src/services/dataStorage.ts
+++ b/bot/src/services/dataStorage.ts
@@ -13,11 +13,18 @@ export interface StoredFile {
 }
 
 export async function listFiles(): Promise<StoredFile[]> {
-  const files = await fs.promises.readdir(uploadsDir);
-  return files.map((name) => {
-    const stat = fs.statSync(path.join(uploadsDir, name));
-    return { name, size: stat.size, url: `/uploads/${name}` };
-  });
+  try {
+    const names = await fs.promises.readdir(uploadsDir);
+    const files = await Promise.all(
+      names.map(async (name) => {
+        const stat = await fs.promises.stat(path.join(uploadsDir, name));
+        return { name, size: stat.size, url: `/uploads/${name}` };
+      }),
+    );
+    return files;
+  } catch {
+    return [];
+  }
 }
 
 export async function deleteFile(name: string): Promise<void> {


### PR DESCRIPTION
## Summary
- fetch file sizes in parallel with `fs.promises.stat`
- return empty list on errors

## Testing
- `NODE_ENV=development ./scripts/setup_and_test.sh` *(fails: rateLimit.test, pinoLogger.test, messageQueue.test, globalLimiter.test)*
- `NODE_ENV=development ./scripts/pre_pr_check.sh` *(fails: bot build/start)*

------
https://chatgpt.com/codex/tasks/task_b_68a6b614235883208e1ebcfbc3c2bacd