### PR TITLE
fix: локальный путь для проверки контраста

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Сборка клиента
         run: npm --prefix bot run build-client
       - name: Проверка контраста
-        run: npx @axe-core/cli bot/public/index.html --tags color-contrast
+        run: npx @axe-core/cli -p bot/public/index.html --tags color-contrast

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # История изменений
 
+- Исправлена проверка контраста в CI: `@axe-core/cli` анализирует локальный файл `bot/public/index.html` через ключ `-p`.
 - Команда `pnpm a11y` запускает `vite preview` и проверяет `http://localhost:4173/index.html` через `@axe-core/cli`.
 - Команда `pnpm a11y` переписана на Playwright и проверяет `bot/web/index.html` без установки Chrome.
 - Добавлена команда `pnpm a11y` для проверки контраста `bot/public/index.html` через `@axe-core/cli`.


### PR DESCRIPTION
## Описание
- проверка контраста в CI использует локальный файл `bot/public/index.html`

## Чек-лист
- [x] `./scripts/audit_deps.sh`
- [ ] `./scripts/setup_and_test.sh` *(ошибка: Cannot find module './node_modules/ts-node/register')*


------
https://chatgpt.com/codex/tasks/task_b_68a71579f0b88320a7f2ad73386e7834