### PR TITLE
feat: асинхронное получение размеров файлов

### DIFF
--- a/bot/src/services/dataStorage.ts
+++ b/bot/src/services/dataStorage.ts
@@ -14,12 +14,22 @@ export interface StoredFile {
 
 export async function listFiles(): Promise<StoredFile[]> {
   try {
-    const names = await fs.promises.readdir(uploadsDir);
+    const entries = await fs.promises.readdir(uploadsDir, {
+      withFileTypes: true,
+    });
     const files = await Promise.all(
-      names.map(async (name) => {
-        const stat = await fs.promises.stat(path.join(uploadsDir, name));
-        return { name, size: stat.size, url: `/uploads/${name}` };
-      }),
+      entries
+        .filter((entry) => entry.isFile())
+        .map(async (entry) => {
+          const stat = await fs.promises.stat(
+            path.join(uploadsDir, entry.name),
+          );
+          return {
+            name: entry.name,
+            size: stat.size,
+            url: `/uploads/${entry.name}`,
+          };
+        }),
     );
     return files;
   } catch {


### PR DESCRIPTION
## Summary
- параллельное чтение размеров файлов через `readdir` с `withFileTypes`
- обработка ошибок в `listFiles`

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(script missing)*
- `pnpm run dev` *(script missing)*
- `npm --prefix bot run dev` *(timeout 5s)*
- `./scripts/setup_and_test.sh` *(MongoDB connection refused)*
- `./scripts/pre_pr_check.sh` *(tsc build failed)*

------
https://chatgpt.com/codex/tasks/task_b_68a7406260b8832087fd2c83d569875f