### PR TITLE
fix: run all tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # История изменений
 
+- Исправлен запуск тестов в `setup_and_test.sh`: удалён лишний `--`, из-за чего Jest не находил тесты.
 - `pre_pr_check.sh` запускает `audit_deps.sh`; в CI добавлен job `audit-deps` и документирован обход ложных срабатываний `audit-ci`.
 - `install_bot_deps.sh` использует pnpm и обеспечивает наличие pnpm в CI, `audit_deps.sh` проверяет все пакеты через `audit-ci`.
 - Удалён скрипт `postinstall` из `bot/package.json`, добавлена команда `npm run prepare-client` и сборка клиента вынесена в CI.

--- a/bot/tests/mongoIndexes.test.ts
+++ b/bot/tests/mongoIndexes.test.ts
@@ -7,6 +7,7 @@ import {
   ensureUploadIndexes,
 } from '../../scripts/db/ensureIndexes';
 
+jest.setTimeout(20000);
 interface Plan {
   stage?: string;
   inputStage?: Plan;

--- a/scripts/setup_and_test.sh
+++ b/scripts/setup_and_test.sh
@@ -9,7 +9,8 @@ if [ ! -f .env ]; then
   ./scripts/create_env_from_exports.sh
 fi
 
-# Устанавливаем зависимости бота и клиента
+# Устанавливаем зависимости корня, бота и клиента
+pnpm install --frozen-lockfile || pnpm install
 pnpm install --dir bot --frozen-lockfile || pnpm install --dir bot
 pnpm install --dir bot/web --frozen-lockfile || pnpm install --dir bot/web
 
@@ -17,7 +18,7 @@ pnpm install --dir bot/web --frozen-lockfile || pnpm install --dir bot/web
 ./scripts/check_no_js.sh
 
 # Запускаем тесты и линтеры
-pnpm --dir bot test -- --detectOpenHandles
+pnpm --dir bot test --detectOpenHandles
 pnpm --dir bot test tests/csrf.test.ts
 pnpm --dir bot run test:types
 pnpm --dir bot run lint


### PR DESCRIPTION
## Summary
- run full test suite in setup script without filtering by mistaken pattern
- ensure root, bot and client dependencies installed before testing
- prevent mongo index tests timing out by extending Jest timeout

## Testing
- `./scripts/setup_and_test.sh`

------
https://chatgpt.com/codex/tasks/task_b_68a8a62269488320aff7ee3047ecd110