### PR TITLE
refactor: use shared types

### DIFF
--- a/apps/api/src/controllers/maps.ts
+++ b/apps/api/src/controllers/maps.ts
@@ -1,7 +1,8 @@
 // Розвёртывание коротких ссылок Google Maps
-// Модули: express, services/maps
+// Модули: express, services/maps, shared
 import { Request, Response } from 'express';
-import { expandMapsUrl, extractCoords } from '../services/maps';
+import { expandMapsUrl } from '../services/maps';
+import { extractCoords } from 'shared';
 import { sendProblem } from '../utils/problem';
 
 export async function expand(req: Request, res: Response): Promise<void> {

--- a/apps/api/src/services/tasks.ts
+++ b/apps/api/src/services/tasks.ts
@@ -1,10 +1,10 @@
 // Сервисные функции задач используют общие запросы к MongoDB
-// Модули: db/queries, services/route, services/maps
+// Модули: db/queries, services/route, shared
 import * as q from '../db/queries';
 import { getRouteDistance, Point } from './route';
-import { generateRouteLink } from './maps';
+import { generateRouteLink, type Task } from 'shared';
 
-export interface TaskData {
+export type TaskData = Partial<Task> & {
   startCoordinates?: Point;
   finishCoordinates?: Point;
   google_route_url?: string;
@@ -12,7 +12,7 @@ export interface TaskData {
   due_date?: Date;
   remind_at?: Date;
   [key: string]: unknown;
-}
+};
 
 async function applyRouteInfo(data: TaskData = {}): Promise<void> {
   if (data.startCoordinates && data.finishCoordinates) {

--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -1,7 +1,7 @@
 // Сервис задач через репозиторий.
-// Основные модули: db/queries, services/route, services/maps
+// Основные модули: db/queries, services/route, shared
 import { getRouteDistance, clearRouteCache } from '../services/route';
-import { generateRouteLink } from '../services/maps';
+import { generateRouteLink } from 'shared';
 import { applyIntakeRules } from '../intake/rules';
 import type { TaskDocument } from '../db/model';
 import type { TaskFilters, SummaryFilters } from '../db/queries';

--- a/apps/api/src/types/request.ts
+++ b/apps/api/src/types/request.ts
@@ -2,22 +2,11 @@
 // Основные модули: express
 import { Request, ParamsDictionary } from 'express-serve-static-core';
 import type { ParsedQs } from 'qs';
+import type { User, Task } from 'shared';
 
-export interface UserInfo {
-  id?: number;
-  telegram_id?: number;
-  username?: string;
-  role?: string;
-  access?: number;
-}
+export type UserInfo = Partial<User> & { id?: number; access?: number };
 
-export interface TaskInfo {
-  created_by?: number;
-  assigned_user_id?: number;
-  controller_user_id?: number;
-  assignees?: number[];
-  controllers?: number[];
-}
+export type TaskInfo = Partial<Task>;
 
 export type RequestWithUser<
   P = ParamsDictionary,

--- a/apps/api/src/utils/formatTask.ts
+++ b/apps/api/src/utils/formatTask.ts
@@ -17,15 +17,13 @@ function stripTags(html: unknown): string {
 }
 
 import userLink from './userLink';
+import type { Task, User } from 'shared';
 
-interface UsersIndex {
-  [id: string]: { name?: string; username?: string };
-}
+type UsersIndex = Record<number | string, Pick<User, 'name' | 'username'>>;
 
-interface TaskData {
+type TaskData = Task & {
   request_id?: string;
   task_number?: string;
-  title?: string;
   task_type?: string;
   due_date?: string | Date;
   start_date?: string | Date;
@@ -38,12 +36,11 @@ interface TaskData {
   priority?: string;
   status?: string;
   route_distance_km?: number;
-  assignees?: number[];
   controllers?: number[];
   created_by?: number;
   comments?: { author_id?: number; text?: string }[];
   task_description?: string;
-}
+};
 
 export default function formatTask(
   task: TaskData,

--- a/apps/api/src/utils/formatUser.ts
+++ b/apps/api/src/utils/formatUser.ts
@@ -1,11 +1,11 @@
 // Назначение файла: унифицированный вывод данных пользователя в API
 // Основные модули: отсутствуют
-export interface UserLike {
-  telegram_id?: number | string | null;
-  username?: string | null;
+import type { User } from 'shared';
+
+export type UserLike = Partial<User> & {
   telegram_username?: string | null;
   toObject?: () => UserLike;
-}
+};
 
 export default function formatUser(user: UserLike | null): UserLike | null {
   if (!user) return null;

--- a/apps/web/src/columns/taskColumns.tsx
+++ b/apps/web/src/columns/taskColumns.tsx
@@ -2,28 +2,14 @@
 // Модули: ag-grid, userLink
 import type { ColDef } from "ag-grid-community";
 import userLink from "../utils/userLink";
+import type { Task } from "shared";
 
-type Task = {
-  _id: string;
-  task_number?: string;
-  title: string;
-  status?: string;
-  priority?: string;
-  start_date?: string;
-  due_date?: string;
-  task_type?: string;
-  assignees?: number[];
-  assigned_user_id?: number;
-  startCoordinates?: { lat: number; lng: number };
-  finishCoordinates?: { lat: number; lng: number };
-  route_distance_km?: number;
-  createdAt?: string;
-};
+type TaskRow = Task & Record<string, any>;
 
 export default function taskColumns(
   _selectable: boolean,
   users: Record<number, any>,
-): ColDef<Task>[] {
+): ColDef<TaskRow>[] {
   return [
     { headerName: "Номер", field: "task_number" },
     {

--- a/apps/web/src/components/RecentTasks.tsx
+++ b/apps/web/src/components/RecentTasks.tsx
@@ -5,17 +5,16 @@ import { AgGridReact } from "ag-grid-react";
 import authFetch from "../utils/authFetch";
 import useGrid from "../hooks/useGrid";
 import recentTaskColumns from "../columns/recentTaskColumns";
+import type { Task } from "shared";
 
-interface Task {
-  _id: string;
-  title: string;
+type RecentTask = Task & {
   status: string;
   task_number: string;
   createdAt: string;
-}
+};
 
 export default function RecentTasks() {
-  const [tasks, setTasks] = useState<Task[]>([]);
+  const [tasks, setTasks] = useState<RecentTask[]>([]);
   const [loading, setLoading] = useState(true);
   const { defaultColDef, gridOptions } = useGrid({ paginationPageSize: 5 });
   useEffect(() => {
@@ -25,7 +24,7 @@ export default function RecentTasks() {
         const list = Array.isArray(data)
           ? data
           : data.tasks || data.items || [];
-        setTasks(list);
+        setTasks(list as RecentTask[]);
         setLoading(false);
       })
       .catch(() => {

--- a/apps/web/src/components/TaskCard.tsx
+++ b/apps/web/src/components/TaskCard.tsx
@@ -1,13 +1,9 @@
 // Карточка задачи в канбане
 import React from "react";
-
-interface Task {
-  title: string;
-  dueDate?: string;
-}
+import type { Task } from "shared";
 
 interface TaskCardProps {
-  task: Task;
+  task: Task & { dueDate?: string };
 }
 
 export default function TaskCard({ task }: TaskCardProps) {

--- a/apps/web/src/components/TaskRangeList.tsx
+++ b/apps/web/src/components/TaskRangeList.tsx
@@ -1,14 +1,10 @@
 // Список задач для выбранного диапазона дат
 import React from "react";
+import type { Task } from "shared";
 
-interface Task {
-  _id: string;
-  title: string;
-  task_number: string;
-  createdAt: string;
-}
+type RangeTask = Task & { task_number: string; createdAt: string };
 
-export default function TaskRangeList({ tasks }: { tasks: Task[] }) {
+export default function TaskRangeList({ tasks }: { tasks: RangeTask[] }) {
   if (!tasks.length) {
     return <p className="text-sm text-gray-500">Нет задач</p>;
   }

--- a/apps/web/src/components/TaskTable.tsx
+++ b/apps/web/src/components/TaskTable.tsx
@@ -9,31 +9,15 @@ import type {
 } from "ag-grid-community";
 import useGrid from "../hooks/useGrid";
 import taskColumns from "../columns/taskColumns";
+import type { Task } from "shared";
 
-type Coords = { lat: number; lng: number };
-
-interface Task {
-  _id: string;
-  task_number?: string;
-  title: string;
-  status?: string;
-  priority?: string;
-  start_date?: string;
-  due_date?: string;
-  task_type?: string;
-  assignees?: number[];
-  assigned_user_id?: number;
-  startCoordinates?: Coords;
-  finishCoordinates?: Coords;
-  route_distance_km?: number;
-  createdAt?: string;
-}
+type TaskRow = Task & Record<string, any>;
 
 interface TaskTableProps {
-  tasks: Task[];
+  tasks: TaskRow[];
   users?: Record<number, any>;
   onSelectionChange?: (ids: string[]) => void;
-  onDataChange?: (rows: Task[]) => void;
+  onDataChange?: (rows: TaskRow[]) => void;
   quickFilterText?: string;
   selectable?: boolean;
   onRowClick?: (id: string) => void;
@@ -57,7 +41,7 @@ export default function TaskTable({
 
   const updateData = React.useCallback(() => {
     if (!apiRef.current || !onDataChange) return;
-    const rows: Task[] = [];
+    const rows: TaskRow[] = [];
     apiRef.current.forEachNodeAfterFilterAndSort((n) => rows.push(n.data));
     onDataChange(rows);
   }, [onDataChange]);
@@ -72,7 +56,7 @@ export default function TaskTable({
 
   const onSel = React.useCallback(() => {
     if (!apiRef.current || !onSelectionChange) return;
-    const ids = apiRef.current.getSelectedRows().map((r: Task) => r._id);
+    const ids = apiRef.current.getSelectedRows().map((r: TaskRow) => r._id);
     onSelectionChange(ids);
   }, [onSelectionChange]);
 

--- a/apps/web/src/pages/AttachmentMenu.tsx
+++ b/apps/web/src/pages/AttachmentMenu.tsx
@@ -1,21 +1,19 @@
 // Страница выбора задачи для Attachment Menu
 import React, { useEffect, useState } from "react";
 import authFetch from "../utils/authFetch";
+import type { Task } from "shared";
 
-interface Task {
-  _id: string;
-  title: string;
-  task_number: string;
-  createdAt: string;
-}
+type MenuTask = Task & { task_number: string; createdAt: string };
 
 export default function AttachmentMenu() {
-  const [tasks, setTasks] = useState<Task[]>([]);
+  const [tasks, setTasks] = useState<MenuTask[]>([]);
 
   useEffect(() => {
     authFetch("/api/v1/tasks?limit=10")
       .then((r) => (r.ok ? r.json() : []))
-      .then((data) => setTasks(Array.isArray(data) ? data : data.tasks || []));
+      .then((data) =>
+        setTasks((Array.isArray(data) ? data : data.tasks || []) as MenuTask[]),
+      );
   }, []);
 
   function select(id: string) {

--- a/apps/web/src/pages/Routes.tsx
+++ b/apps/web/src/pages/Routes.tsx
@@ -10,24 +10,13 @@ import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import { useNavigate, useLocation, useSearchParams } from "react-router-dom";
 import { AuthContext } from "../context/AuthContext";
+import type { Task } from "shared";
 
-interface Task {
-  _id: string;
-  title: string;
-  task_number: string;
-  createdAt: string;
-  status?: string;
-  priority?: string;
-  task_type?: string;
-  due_date?: string;
-  startCoordinates?: { lat: number; lng: number };
-  finishCoordinates?: { lat: number; lng: number };
-  route_distance_km?: number;
-}
+type RouteTask = Task & Record<string, any>;
 
 export default function RoutesPage() {
-  const [tasks, setTasks] = React.useState<Task[]>([]);
-  const [sorted, setSorted] = React.useState<Task[]>([]);
+  const [tasks, setTasks] = React.useState<RouteTask[]>([]);
+  const [sorted, setSorted] = React.useState<RouteTask[]>([]);
   const [vehicles, setVehicles] = React.useState(1);
   const [method, setMethod] = React.useState("angle");
   const [links, setLinks] = React.useState<string[]>([]);

--- a/apps/web/src/pages/Tasks.tsx
+++ b/apps/web/src/pages/Tasks.tsx
@@ -7,14 +7,12 @@ import Spinner from "../components/Spinner";
 import SkeletonCard from "../components/SkeletonCard";
 import Pagination from "../components/Pagination";
 import Breadcrumbs from "../components/Breadcrumbs";
+import type { Task } from "shared";
 
-interface Task {
-  _id: string;
-  task_description: string;
-}
+type TaskWithDesc = Task & { task_description: string };
 
 export default function Tasks() {
-  const [tasks, setTasks] = React.useState<Task[]>([]);
+  const [tasks, setTasks] = React.useState<TaskWithDesc[]>([]);
   const [text, setText] = React.useState("");
   const [loading, setLoading] = React.useState(true);
   const [posting, setPosting] = React.useState(false);

--- a/apps/web/src/pages/TasksPage.tsx
+++ b/apps/web/src/pages/TasksPage.tsx
@@ -7,32 +7,13 @@ import { useToast } from "../context/useToast";
 import useTasks from "../context/useTasks";
 import { fetchTasks } from "../services/tasks";
 import authFetch from "../utils/authFetch";
-import { taskFields as fields } from "shared";
+import { taskFields as fields, type Task, type User } from "shared";
 import { AuthContext } from "../context/AuthContext";
 
-interface Task {
-  _id: string;
-  title: string;
-  status: string;
-  task_number: string;
-  createdAt: string;
-  start_date?: string;
-  due_date?: string;
-  priority?: string;
-  assigned_user_id?: number;
-  assignees?: number[];
-  attachments?: { name: string; url: string }[];
-}
-
-interface User {
-  telegram_id: number;
-  username: string;
-  name?: string;
-  phone?: string;
-}
+type TaskExtra = Task & Record<string, any>;
 
 export default function TasksPage() {
-  const [all, setAll] = React.useState<Task[]>([]);
+  const [all, setAll] = React.useState<TaskExtra[]>([]);
   const [users, setUsers] = React.useState<User[]>([]);
   const [statuses, setStatuses] = React.useState<string[]>([]);
   const [selected, setSelected] = React.useState<string[]>([]);
@@ -50,7 +31,9 @@ export default function TasksPage() {
     setLoading(true);
     fetchTasks({}, Number((user as any)?.telegram_id))
       .then((data) => {
-        const tasks = Array.isArray(data) ? data : data.tasks || [];
+        const tasks = (
+          Array.isArray(data) ? data : data.tasks || []
+        ) as TaskExtra[];
         const filteredTasks = isAdmin
           ? tasks
           : tasks.filter((t) => {
@@ -63,8 +46,8 @@ export default function TasksPage() {
             });
         setAll(filteredTasks);
         const list = Array.isArray((data as any).users)
-          ? (data as any).users
-          : Object.values((data as any).users || {});
+          ? ((data as any).users as User[])
+          : (Object.values((data as any).users || {}) as User[]);
         setUsers(list);
       })
       .finally(() => setLoading(false));


### PR DESCRIPTION
## Summary
- replace relative map import with shared
- use Task and User types from shared across web and api
- remove duplicate Task/User interfaces

## Testing
- `pnpm format`
- `./scripts/setup_and_test.sh` (failed: tests)
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68a984f3e56883208d50c695cf772d02