### PR TITLE
feat: добавить базовый tsconfig и ссылки на shared

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,7 @@
     "test": "node -r ./node_modules/ts-node/register ./node_modules/jest/bin/jest.js --coverage",
     "start": "node dist/server.js",
     "dev": "ts-node src/server.ts",
-    "build": "tsc -p ../..",
+    "build": "tsc -b",
     "build-client": "pnpm --dir ../web run build",
     "format": "prettier --config ../prettier.config.cjs \"src/**/*.{js,ts}\"",
     "check:mongo": "node ../../scripts/check_mongo.mjs",

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,9 +1,23 @@
 {
   // Назначение файла: конфигурация TypeScript для проверки типов в подкаталоге api
   // Основные модули: typescript
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src"
+    "target": "es2019",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "useUnknownInCatchVariables": false,
+    "useDefineForClassFields": false,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "typeRoots": ["./node_modules/@types", "../../node_modules/@types"],
+    "composite": true,
+    "paths": {
+      "shared": ["../../packages/shared/src"],
+      "shared/*": ["../../packages/shared/src/*"]
+    }
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "references": [{ "path": "../../packages/shared" }]
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  // Назначение файла: конфигурация TypeScript для веб-клиента
+  // Основные модули: typescript
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ESNext",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
@@ -16,9 +19,12 @@
     "jsx": "react-jsx",
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
-    }
+      "@/*": ["src/*"],
+      "shared": ["../../packages/shared/src"],
+      "shared/*": ["../../packages/shared/src/*"]
+    },
+    "composite": true
   },
   "include": ["src"],
-  "references": []
+  "references": [{ "path": "../../packages/shared" }]
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": resolve(__dirname, "src"),
+      shared: resolve(__dirname, "../../packages/shared/src"),
     },
   },
   build: {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "private": true,
   "description": "Вспомогательные зависимости для запуска ESLint и тестов.",
   "scripts": {
+    "build": "pnpm -r build",
+    "dev": "pnpm -r dev",
     "lint": "eslint apps/api/src",
     "a11y": "ts-node scripts/a11y.ts",
     "test:e2e": "playwright test tests/e2e",

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,13 +1,14 @@
 {
   // Назначение: конфигурация TypeScript для пакета shared
+  // Основные модули: typescript
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2019",
     "module": "commonjs",
     "rootDir": "src",
     "outDir": "dist",
-    "esModuleInterop": true,
-    "strict": true,
     "declaration": true,
+    "composite": true,
     "types": []
   },
   "include": ["src/**/*"]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,13 @@
+{
+  // Назначение файла: базовая конфигурация TypeScript для пакетов монорепозитория
+  // Основные модули: typescript
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noImplicitAny": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,24 +1,10 @@
 {
-  // Назначение файла: конфигурация TypeScript для серверной части
-  "compilerOptions": {
-    "target": "es2019",
-    "module": "commonjs",
-    "rootDir": "apps/api/src",
-    "outDir": "dist",
-    "allowJs": false,
-    "moduleResolution": "node",
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noImplicitAny": true,
-    "useUnknownInCatchVariables": false,
-    "useDefineForClassFields": false,
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
-    "typeRoots": ["./apps/api/node_modules/@types", "./node_modules/@types"]
-  },
-  "include": ["apps/api/src/**/*.ts", "apps/api/src/**/*.d.ts"],
-  "exclude": ["dist"]
+  // Назначение файла: объединяющая конфигурация TypeScript для пакетов
+  // Основные модули: typescript
+  "files": [],
+  "references": [
+    { "path": "./packages/shared" },
+    { "path": "./apps/api" },
+    { "path": "./apps/web" }
+  ]
 }


### PR DESCRIPTION
## Что сделано
- введён общий `tsconfig.base.json` для пакетов
- подключены project references на `shared`
- добавлены скрипты `build` и `dev` в корень
- настроен Vite alias на `shared`

## Зачем
- упрощает повторное использование кода и ускоряет сборку
- единые команды запуска для всех пакетов

## Чек-лист
- [ ] `./scripts/setup_and_test.sh`
- [ ] `./scripts/pre_pr_check.sh`

## Логи
- `./scripts/setup_and_test.sh` (частичный вывод)
- `./scripts/pre_pr_check.sh` (частичный вывод)

## Самопроверка
- настройки TypeScript вынесены в базовый файл
- пакеты корректно ссылаются на `shared`
- Vite знает путь к `shared`
- корневые скрипты запускают команды во всех пакетах


------
https://chatgpt.com/codex/tasks/task_b_68a9884657a8832098501d7dc60703b7