### PR TITLE
feat: restrict cross-app imports

### DIFF
--- a/apps/web/eslint.config.ts
+++ b/apps/web/eslint.config.ts
@@ -44,6 +44,13 @@ const config = [
         "warn",
         { allowConstantExport: true },
       ],
+      // Запрещаем импорт серверного кода
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: ["apps/api/**"],
+        },
+      ],
     },
   },
 ];

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -25,7 +25,14 @@ const config = [
           message: 'Используйте TypeScript вместо JavaScript',
         },
       ],
-      'no-restricted-imports': ['error', { paths: ['lodash', 'moment'] }],
+      // Запрещаем импорт модулей клиентского приложения
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: ['lodash', 'moment'],
+          patterns: ['apps/web/**'],
+        },
+      ],
     },
   },
   {
@@ -53,7 +60,14 @@ const config = [
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/ban-ts-comment': 'off',
       'no-undef': 'off',
-      'no-restricted-imports': ['error', { paths: ['lodash', 'moment'] }],
+      // Запрещаем импорт модулей клиентского приложения
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: ['lodash', 'moment'],
+          patterns: ['apps/web/**'],
+        },
+      ],
     },
   },
 ];


### PR DESCRIPTION
## Summary
- forbid imports from web in server files via `no-restricted-imports`
- forbid imports from api in web ESLint config

## Testing
- `pnpm lint`
- `pnpm --dir apps/web run lint`
- `pnpm --dir apps/api test tests/csrf.test.ts`
- `pnpm build`
- `timeout 5s pnpm run dev` *(fails: command terminated)*
- `docker compose config`
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68aab366c5208320b57fda7abdd77e03