### PR TITLE
feat: run lint across workspaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Установка браузеров Playwright
         run: npx playwright install --with-deps
       - name: Линтеры
-        run: pnpm -r lint
+        run: pnpm lint
       - name: Тесты
         run: pnpm -r test
       - name: Сборка

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ curl -X POST http://localhost:3000/api/v1/task-templates \
 - ESLint проверяет серверные файлы TypeScript; правило `no-explicit-any` включено,
   `ban-ts-comment` остаётся отключено.
 - ESLint запрещает файлы `.js` вне конфигурации.
-- Корневой `package.json` содержит зависимости `eslint`, `jiti` и `reflect-metadata`, поэтому `pnpm exec eslint apps/api/src` работает без дополнительных флагов.
+- Корневой `package.json` содержит зависимости `eslint`, `jiti` и `reflect-metadata`, поэтому `pnpm lint` запускает линтер во всех пакетах.
 - Конфигурационные файлы переведены на TypeScript, скрипт `scripts/check_no_js.sh` предотвращает возврат к JavaScript.
 - Автотесты бота написаны на TypeScript и выполняются через Jest.
 - Утилиты `userLink`, `formatTask`, `validate`, `haversine`, `verifyInitData`, `accessMask`, `formatUser`, `setTokenCookie`, `rateLimiter`, `parseJwt`, `csrfToken`, `extractCoords` и `parseGoogleAddress` переписаны на TypeScript.
@@ -205,8 +205,8 @@ curl -X POST http://localhost:3000/api/v1/task-templates \
 - Логи включают IP и User-Agent для каждого запроса.
 - Превышение лимитов запросов также записывается с IP и путём запроса.
 - Глобальный лимитер применяется только к маршрутам `/api`; статические файлы и `/api/v1/csrf` не ограничиваются и кешируются на год.
- - AuthProvider отслеживает загрузку профиля и предотвращает ложный редирект на `/login`.
- - Express отдаёт `index.html` для любых путей, включая `/login`, обеспечивая корректный переход при ответах 401/403.
+- AuthProvider отслеживает загрузку профиля и предотвращает ложный редирект на `/login`.
+- Express отдаёт `index.html` для любых путей, включая `/login`, обеспечивая корректный переход при ответах 401/403.
 - Cookie `token` использует `SameSite=Lax`. В продакшене домен берётся из переменной `COOKIE_DOMAIN` либо из `APP_URL`. В режиме разработки домен не задаётся, что исключает ошибку с localhost.
 - Значение `COOKIE_DOMAIN` может быть полным URL, при загрузке конфигурации берётся только его hostname. Неверный формат вызывает ошибку при запуске.
 - Сессия и cookie живут семь дней, совпадая со временем действия JWT.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,7 +30,7 @@
   синхронизатор токенов и защищённые cookie
 - Флаг Secure у cookie включён всегда; переменная `COOKIE_SECURE=false` разрешает HTTP только локально
 - Внедрён единый middleware ошибок с форматом `application/problem+json`
-- Добавлен корневой `package.json` с зависимостями `eslint`, `jiti` и `reflect-metadata` для запуска `npx eslint apps/api/src`
+- Добавлен корневой `package.json` с зависимостями `eslint`, `jiti` и `reflect-metadata` для запуска линтера во всех пакетах командой `pnpm lint`
 - Массовые действия над задачами позволяют выбирать все статусы и выделять все задачи.
 - Оптимизированы запросы задач: добавлен скрипт `ensureIndexes` с индексами `{assigneeId,status,dueAt}` и `createdAt`.
 - Ограничены запросы к `/api/v1/auth` и `/api/v1/route`, отдельные лимиты для Mini App и Admin, метрика `rate_limit_drops_total` доступна в Prometheus

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "pnpm -r build",
     "dev": "pnpm -r dev",
-    "lint": "eslint apps/api/src",
+    "lint": "pnpm -r lint",
     "a11y": "ts-node scripts/a11y.ts",
     "test:e2e": "playwright test tests/e2e",
     "test:api": "mocha -r ts-node/register tests/api/*.spec.ts",


### PR DESCRIPTION
## Summary
- run lint in all workspaces from root script
- document linting and update roadmap
- adjust CI to call root lint script

## Testing
- `pnpm lint`
- `./scripts/setup_and_test.sh` (fails: queue overflow; mongo indexes tests)
- `./scripts/pre_pr_check.sh` (fails: unable to start bot)


------
https://chatgpt.com/codex/tasks/task_b_68aab65a481883208d0eccb7a01f913b