### PR TITLE
feat: динамический импорт тяжёлых библиотек

### DIFF
--- a/apps/web/src/components/CKEditorPopup.tsx
+++ b/apps/web/src/components/CKEditorPopup.tsx
@@ -1,10 +1,19 @@
 // Поле редактирования текста в модальном окне CKEditor 5
 // Модули: React, CKEditor 5, DOMPurify, Modal
 import React, { useState } from "react";
-import { CKEditor } from "@ckeditor/ckeditor5-react";
-import ClassicEditor from "@ckeditor/ckeditor5-build-classic";
 import DOMPurify from "dompurify";
 import Modal from "./Modal";
+
+const LazyCKEditor = React.lazy(async () => {
+  const [{ CKEditor }, { default: ClassicEditor }] = await Promise.all([
+    import("@ckeditor/ckeditor5-react"),
+    import("@ckeditor/ckeditor5-build-classic"),
+  ]);
+  type Props = React.ComponentProps<typeof CKEditor>;
+  return {
+    default: (props: Props) => <CKEditor editor={ClassicEditor} {...props} />,
+  };
+});
 
 interface Props {
   value: string;
@@ -41,11 +50,12 @@ export default function CKEditorPopup({ value, onChange, readOnly }: Props) {
       />
       <Modal open={open} onClose={() => setOpen(false)}>
         <div className="space-y-4">
-          <CKEditor
-            editor={ClassicEditor}
-            data={draft}
-            onChange={(_e, editor) => setDraft(editor.getData())}
-          />
+          <React.Suspense fallback={<div>Загрузка...</div>}>
+            <LazyCKEditor
+              data={draft}
+              onChange={(_e, editor) => setDraft(editor.getData())}
+            />
+          </React.Suspense>
           <div className="flex justify-end gap-2">
             <button
               type="button"

--- a/apps/web/src/components/LogViewer.tsx
+++ b/apps/web/src/components/LogViewer.tsx
@@ -1,7 +1,9 @@
 // Компонент просмотра логов на AG Grid и экспортом
 // Модули: React, useLogsQuery, FiltersPanel, ag-grid, useGrid
 import React from "react";
-import { AgGridReact } from "ag-grid-react";
+const AgGridReact = React.lazy(() =>
+  import("ag-grid-react").then((m) => ({ default: m.AgGridReact })),
+);
 import useLogsQuery, { LogFilters } from "../hooks/useLogsQuery";
 import FiltersPanel from "./FiltersPanel";
 import useGrid from "../hooks/useGrid";
@@ -73,12 +75,14 @@ export default function LogViewer() {
       </div>
       <FiltersPanel filters={filters} onChange={setFilters} />
       <div className="ag-theme-alpine" style={{ height: 500 }}>
-        <AgGridReact
-          rowData={logs}
-          columnDefs={logColumns}
-          defaultColDef={defaultColDef}
-          {...gridOptions}
-        />
+        <React.Suspense fallback={<div>Загрузка...</div>}>
+          <AgGridReact
+            rowData={logs}
+            columnDefs={logColumns}
+            defaultColDef={defaultColDef}
+            {...gridOptions}
+          />
+        </React.Suspense>
       </div>
       <div className="flex justify-between text-sm">
         <button

--- a/apps/web/src/components/RecentTasks.tsx
+++ b/apps/web/src/components/RecentTasks.tsx
@@ -1,7 +1,9 @@
 // Таблица последних задач на AG Grid
 // Модули: React, authFetch, ag-grid, useGrid
 import React, { useEffect, useState } from "react";
-import { AgGridReact } from "ag-grid-react";
+const AgGridReact = React.lazy(() =>
+  import("ag-grid-react").then((m) => ({ default: m.AgGridReact })),
+);
 import authFetch from "../utils/authFetch";
 import useGrid from "../hooks/useGrid";
 import recentTaskColumns from "../columns/recentTaskColumns";
@@ -48,12 +50,14 @@ export default function RecentTasks() {
 
   return (
     <div className="ag-theme-alpine" style={{ height: 200 }}>
-      <AgGridReact
-        rowData={tasks}
-        columnDefs={recentTaskColumns}
-        defaultColDef={defaultColDef}
-        {...gridOptions}
-      />
+      <React.Suspense fallback={<div>Загрузка...</div>}>
+        <AgGridReact
+          rowData={tasks}
+          columnDefs={recentTaskColumns}
+          defaultColDef={defaultColDef}
+          {...gridOptions}
+        />
+      </React.Suspense>
     </div>
   );
 }

--- a/apps/web/src/components/TaskTable.tsx
+++ b/apps/web/src/components/TaskTable.tsx
@@ -1,7 +1,9 @@
 // Назначение файла: универсальная таблица задач на AG Grid
 // Модули: React, ag-grid, утилиты, useGrid
 import React from "react";
-import { AgGridReact } from "ag-grid-react";
+const AgGridReact = React.lazy(() =>
+  import("ag-grid-react").then((m) => ({ default: m.AgGridReact })),
+);
 import type {
   GridApi,
   GridReadyEvent,
@@ -73,23 +75,25 @@ export default function TaskTable({
         Экспорт CSV
       </button>
       <div className="ag-theme-alpine" style={{ height: 500 }}>
-        <AgGridReact
-          rowData={tasks}
-          columnDefs={columnDefs}
-          defaultColDef={defaultColDef}
-          rowSelection={
-            selectable
-              ? { mode: "multiRow", checkboxes: true, headerCheckbox: true }
-              : undefined
-          }
-          onSelectionChanged={onSel}
-          onGridReady={onGridReady}
-          onSortChanged={updateData}
-          onFilterChanged={updateData}
-          onRowClicked={(e) => onRowClick && onRowClick(e.data._id)}
-          quickFilterText={quickFilterText}
-          {...gridOptions}
-        />
+        <React.Suspense fallback={<div>Загрузка...</div>}>
+          <AgGridReact
+            rowData={tasks}
+            columnDefs={columnDefs}
+            defaultColDef={defaultColDef}
+            rowSelection={
+              selectable
+                ? { mode: "multiRow", checkboxes: true, headerCheckbox: true }
+                : undefined
+            }
+            onSelectionChanged={onSel}
+            onGridReady={onGridReady}
+            onSortChanged={updateData}
+            onFilterChanged={updateData}
+            onRowClicked={(e) => onRowClick && onRowClick(e.data._id)}
+            quickFilterText={quickFilterText}
+            {...gridOptions}
+          />
+        </React.Suspense>
       </div>
     </div>
   );

--- a/apps/web/src/components/TasksChart.tsx
+++ b/apps/web/src/components/TasksChart.tsx
@@ -1,8 +1,9 @@
 // График количества задач за период
+// Модули: React, react-apexcharts, next-themes, authFetch
 import React, { useEffect, useState } from "react";
-import ReactApexChart from "react-apexcharts";
 import { useTheme } from "next-themes";
 import authFetch from "../utils/authFetch";
+const ReactApexChart = React.lazy(() => import("react-apexcharts"));
 
 interface ChartState {
   series: { data: number[] }[];
@@ -44,11 +45,13 @@ export default function TasksChart() {
   };
 
   return (
-    <ReactApexChart
-      series={series}
-      options={options}
-      type="line"
-      height={200}
-    />
+    <React.Suspense fallback={<div>Загрузка...</div>}>
+      <ReactApexChart
+        series={series}
+        options={options}
+        type="line"
+        height={200}
+      />
+    </React.Suspense>
   );
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -31,6 +31,12 @@ export default defineConfig({
       output: {
         manualChunks: {
           react: ["react", "react-dom", "react-router-dom"],
+          "ag-grid": ["ag-grid-react", "ag-grid-community"],
+          ckeditor: [
+            "@ckeditor/ckeditor5-react",
+            "@ckeditor/ckeditor5-build-classic",
+          ],
+          charts: ["react-apexcharts", "apexcharts"],
         },
       },
     },


### PR DESCRIPTION
## Summary
- вынесены ag-grid, ckeditor и charts в отдельные чанки
- компоненты загружают тяжёлые библиотеки через React.lazy

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm --dir apps/web run lint`
- `pnpm build`
- `pnpm run dev` *(fail: MongoDB connection error)*
- `./scripts/pre_pr_check.sh` *(fail: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68aac2b3de8c8320a3a94cb58f6fa237