### PR TITLE
fix: normalize task attachments

### DIFF
--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -132,13 +132,25 @@ const upload = multer({
   },
   limits: { fileSize: 10 * 1024 * 1024 },
 });
-const normalizeArrays: RequestHandler = (req, _res, next) => {
+/**
+ * Нормализует массивы и парсит вложения из JSON-строк.
+ * Поддерживает поля исполнителей, контролёров и вложений.
+ */
+export const normalizeArrays: RequestHandler = (req, _res, next) => {
   ['assignees', 'controllers'].forEach((k) => {
     const v = (req.body as Record<string, unknown>)[k];
     if (v !== undefined && !Array.isArray(v)) {
       (req.body as Record<string, unknown>)[k] = [v];
     }
   });
+  const at = (req.body as BodyWithAttachments).attachments;
+  if (typeof at === 'string') {
+    try {
+      (req.body as BodyWithAttachments).attachments = JSON.parse(at);
+    } catch {
+      (req.body as BodyWithAttachments).attachments = [];
+    }
+  }
   next();
 };
 

--- a/tests/attachments.normalize.spec.ts
+++ b/tests/attachments.normalize.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * Назначение файла: проверка нормализации вложений из JSON-строки.
+ * Основные модули: express, supertest, multer, routes/tasks.
+ */
+import express = require('express');
+import request = require('supertest');
+// @ts-ignore
+import multer from '../apps/api/node_modules/multer';
+import { normalizeArrays } from '../apps/api/src/routes/tasks';
+
+const app = express();
+const upload = multer();
+
+app.post('/tasks', upload.none() as any, normalizeArrays as any, (req, res) => {
+  res.json({ attachments: (req.body as any).attachments });
+});
+
+describe('Нормализация вложений', () => {
+  test('парсит строку в массив объектов', async () => {
+    const payload = [
+      {
+        name: 'f.png',
+        url: '/f',
+        uploadedBy: 1,
+        uploadedAt: new Date().toISOString(),
+        type: 'image/png',
+        size: 1,
+      },
+    ];
+    const res = await request(app)
+      .post('/tasks')
+      .field('attachments', JSON.stringify(payload));
+    expect(res.body.attachments[0].name).toBe('f.png');
+  });
+});


### PR DESCRIPTION
## Summary
- parse JSON-encoded `attachments` in task routes
- cover attachment string parsing with test

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68ab5e2989108320aa692f38fea21346