### PR TITLE
feat: integrate tasks global search

### DIFF
--- a/apps/web/src/components/GlobalSearch.tsx
+++ b/apps/web/src/components/GlobalSearch.tsx
@@ -5,10 +5,11 @@ import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import useTasks from "../context/useTasks";
 
 export default function GlobalSearch() {
   const [open, setOpen] = React.useState(false);
-  const [query, setQuery] = React.useState("");
+  const { query, setQuery } = useTasks();
   const { t } = useTranslation();
   return (
     <>

--- a/apps/web/src/components/TaskTable.tsx
+++ b/apps/web/src/components/TaskTable.tsx
@@ -12,6 +12,7 @@ import type {
 import useGrid from "../hooks/useGrid";
 import taskColumns from "../columns/taskColumns";
 import type { Task } from "shared";
+import useTasks from "../context/useTasks";
 
 type TaskRow = Task & Record<string, any>;
 
@@ -20,7 +21,6 @@ interface TaskTableProps {
   users?: Record<number, any>;
   onSelectionChange?: (ids: string[]) => void;
   onDataChange?: (rows: TaskRow[]) => void;
-  quickFilterText?: string;
   selectable?: boolean;
   onRowClick?: (id: string) => void;
 }
@@ -30,11 +30,11 @@ export default function TaskTable({
   users = {},
   onSelectionChange,
   onDataChange,
-  quickFilterText,
   selectable = false,
   onRowClick,
 }: TaskTableProps) {
   const apiRef = React.useRef<GridApi | null>(null);
+  const { query } = useTasks();
   const columnDefs = React.useMemo(
     () => taskColumns(selectable, users),
     [selectable, users],
@@ -90,7 +90,7 @@ export default function TaskTable({
             onSortChanged={updateData}
             onFilterChanged={updateData}
             onRowClicked={(e) => onRowClick && onRowClick(e.data._id)}
-            quickFilterText={quickFilterText}
+            quickFilterText={query}
             {...gridOptions}
           />
         </React.Suspense>

--- a/apps/web/src/context/TasksContext.ts
+++ b/apps/web/src/context/TasksContext.ts
@@ -1,9 +1,11 @@
-// Контекст обновления списка задач
+// Контекст задач и глобального поиска
 import { createContext } from "react";
 
 export interface TasksState {
   version: number;
   refresh: () => void;
+  query: string;
+  setQuery: (q: string) => void;
 }
 
 export const TasksContext = createContext<TasksState | undefined>(undefined);

--- a/apps/web/src/context/TasksContext.tsx
+++ b/apps/web/src/context/TasksContext.tsx
@@ -1,4 +1,4 @@
-// Провайдер контекста задач, увеличивает версию для перезагрузки
+// Провайдер контекста задач и глобального поиска
 import React, { useState } from "react";
 import { TasksContext } from "./TasksContext";
 
@@ -6,9 +6,10 @@ export const TasksProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const [version, setVersion] = useState(0);
+  const [query, setQuery] = useState("");
   const refresh = () => setVersion((v) => v + 1);
   return (
-    <TasksContext.Provider value={{ version, refresh }}>
+    <TasksContext.Provider value={{ version, refresh, query, setQuery }}>
       {children}
     </TasksContext.Provider>
   );

--- a/apps/web/src/pages/TasksPage.tsx
+++ b/apps/web/src/pages/TasksPage.tsx
@@ -24,8 +24,6 @@ export default function TasksPage() {
   const { version, refresh } = useTasks();
   const { user } = useContext(AuthContext);
   const isAdmin = user?.role === "admin";
-  const [query, setQuery] = React.useState("");
-  const [search, setSearch] = React.useState("");
 
   const load = React.useCallback(() => {
     setLoading(true);
@@ -120,24 +118,9 @@ export default function TasksPage() {
           </button>
         </div>
       </div>
-      <div className="flex flex-wrap items-center gap-2">
-        <input
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="Поиск"
-          className="rounded border px-2 py-1"
-        />
-        <button
-          onClick={() => setSearch(query)}
-          className="btn btn-blue xsm:w-full hover:shadow-lg"
-        >
-          Искать
-        </button>
-      </div>
       <TaskTable
         tasks={tasks}
         users={userMap}
-        quickFilterText={search}
         selectable
         onSelectionChange={setSelected}
         onRowClick={(id) => {


### PR DESCRIPTION
## Summary
- extend tasks context with query and setter
- hook GlobalSearch into tasks context
- feed global query to task table and remove page-level search

## Testing
- `pnpm format apps/web/src/components/GlobalSearch.tsx apps/web/src/components/TaskTable.tsx apps/web/src/context/TasksContext.ts apps/web/src/context/TasksContext.tsx apps/web/src/pages/TasksPage.tsx`
- `./scripts/setup_and_test.sh`
- `pnpm run build`
- `pnpm run dev` *(fails: Command failed with SIGTERM)*
- `./scripts/pre_pr_check.sh` *(fails: Запуск не удался)*

------
https://chatgpt.com/codex/tasks/task_b_68ac05b76de48320960d2810462cb264