### PR TITLE
fix: validate upload files

### DIFF
--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -70,7 +70,15 @@ async function createThumbnail(
 
 export const processUploads: RequestHandler = async (req, res, next) => {
   try {
-    const files = (req.files as Express.Multer.File[]) || [];
+    const filesRaw = req.files;
+    const files = Array.isArray(filesRaw)
+      ? (filesRaw as Express.Multer.File[])
+      : [];
+    // Проверяем тип полученных файлов
+    if (!Array.isArray(filesRaw) && filesRaw !== undefined && filesRaw !== null) {
+      res.status(400).json({ error: 'Некорректный формат загрузки файлов' });
+      return;
+    }
     if (files.length > 0) {
       const userId = (req as RequestWithUser).user?.id as number;
       const attachments = await Promise.all(


### PR DESCRIPTION
## Summary
- validate runtime type of uploaded files

## Testing
- `./scripts/setup_and_test.sh` *(failed: лимитер auth возвращает 429 и затем 200; индексы задач; индексы загрузок)*
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68ac2a824e8c832082a9430c2ce5c872