### PR TITLE
feat: lazy-load CKEditor and drop charts chunk

### DIFF
--- a/apps/web/src/components/CKEditorPopup.tsx
+++ b/apps/web/src/components/CKEditorPopup.tsx
@@ -48,35 +48,38 @@ export default function CKEditorPopup({ value, onChange, readOnly }: Props) {
             : "<p class='text-gray-500'>Нажмите для редактирования</p>",
         }}
       />
-      <Modal open={open} onClose={() => setOpen(false)}>
-        <div className="space-y-4">
-          <React.Suspense fallback={<div>Загрузка...</div>}>
-            <LazyCKEditor
-              data={draft}
-              onChange={(_e, editor) => setDraft(editor.getData())}
-            />
-          </React.Suspense>
-          <div className="flex justify-end gap-2">
-            <button
-              type="button"
-              className="rounded bg-slate-200 px-4 py-2"
-              onClick={() => setOpen(false)}
-            >
-              Отмена
-            </button>
-            <button
-              type="button"
-              className="rounded bg-indigo-600 px-4 py-2 text-white"
-              onClick={() => {
-                onChange?.(draft);
-                setOpen(false);
-              }}
-            >
-              Сохранить
-            </button>
+      {open && (
+        // Модальное окно рендерится только при открытии, что откладывает загрузку CKEditor
+        <Modal open onClose={() => setOpen(false)}>
+          <div className="space-y-4">
+            <React.Suspense fallback={<div>Загрузка...</div>}>
+              <LazyCKEditor
+                data={draft}
+                onChange={(_e, editor) => setDraft(editor.getData())}
+              />
+            </React.Suspense>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                className="rounded bg-slate-200 px-4 py-2"
+                onClick={() => setOpen(false)}
+              >
+                Отмена
+              </button>
+              <button
+                type="button"
+                className="rounded bg-indigo-600 px-4 py-2 text-white"
+                onClick={() => {
+                  onChange?.(draft);
+                  setOpen(false);
+                }}
+              >
+                Сохранить
+              </button>
+            </div>
           </div>
-        </div>
-      </Modal>
+        </Modal>
+      )}
     </>
   );
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
             "@ckeditor/ckeditor5-react",
             "@ckeditor/ckeditor5-build-classic",
           ],
-          charts: ["react-apexcharts", "apexcharts"],
+          // чанк charts удалён: react-apexcharts загружается динамически
         },
       },
     },


### PR DESCRIPTION
## Summary
- remove unused charts chunk from Vite config
- lazy-render CKEditor modal so editor loads on demand

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm build`
- `pnpm size-limit`
- `timeout 5 pnpm dev` *(fails: signal SIGTERM)*
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68ac7304c1cc8320bb30c4c1a42ed7a5