### PR TITLE
fix: build shared package before tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "description": "Вспомогательные зависимости для запуска ESLint и тестов.",
   "scripts": {
+    "pretest": "pnpm --filter shared build",
+    "pretest:unit": "pnpm --filter shared build",
+    "pretest:api": "pnpm --filter shared build",
+    "pretest:e2e": "pnpm --filter shared build",
     "build": "pnpm -r build",
     "dev": "PNPM_SCRIPT_TIMEOUT=0 pnpm -r dev",
     "lint": "pnpm -r lint",


### PR DESCRIPTION
## Summary
- build shared workspace package before running any tests

## Testing
- `pnpm lint`
- `pnpm test` *(fails: TypeScript import equals unsupported in Node strip mode)*
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68ac9dbb8f2883208e54f623dc796cfd