### PR TITLE
fix: фиксированные размеры ячеек таблицы

### DIFF
--- a/apps/web/src/components/DataTable.tsx
+++ b/apps/web/src/components/DataTable.tsx
@@ -78,7 +78,11 @@ export default function DataTable<T>({
           {table.getHeaderGroups().map((hg) => (
             <TableRow key={hg.id}>
               {hg.headers.map((header) => (
-                <TableHead key={header.id}>
+                <TableHead
+                  key={header.id}
+                  style={{ width: header.getSize() }}
+                  // фиксируем ширину ячейки заголовка
+                >
                   {header.isPlaceholder
                     ? null
                     : flexRender(
@@ -99,7 +103,11 @@ export default function DataTable<T>({
               className="cursor-pointer"
             >
               {row.getVisibleCells().map((cell) => (
-                <TableCell key={cell.id}>
+                <TableCell
+                  key={cell.id}
+                  style={{ width: cell.column.getSize() }}
+                  // фиксируем ширину ячейки данных
+                >
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}
                 </TableCell>
               ))}

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -12,7 +12,7 @@ function Table({ className, ...props }: React.ComponentProps<"table">) {
     >
       <table
         data-slot="table"
-        className={cn("w-full caption-bottom text-sm", className)}
+        className={cn("w-full table-fixed caption-bottom text-sm", className)}
         {...props}
       />
     </div>
@@ -57,7 +57,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
     <tr
       data-slot="table-row"
       className={cn(
-        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        "hover:bg-muted/50 data-[state=selected]:bg-muted h-12 border-b transition-colors",
         className,
       )}
       {...props}
@@ -70,7 +70,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "text-foreground h-12 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
       )}
       {...props}
@@ -83,7 +83,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "h-12 p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Что сделано
- заданы фиксированные ширина и высота ячеек таблиц, чтобы заранее резервировать место под данные и кнопки.

## Зачем
Фиксированные размеры предотвращают скачки интерфейса при появлении данных или действий.

## Чек-лист
- [x] `pnpm exec prettier apps/web/src/components/DataTable.tsx apps/web/src/components/ui/table.tsx --write`
- [x] `./scripts/setup_and_test.sh`
- [ ] `./scripts/pre_pr_check.sh` (не удалось запустить бот)

## Самопроверка
- таблица использует `table-fixed`.
- строки и ячейки имеют высоту `h-12`.
- ширина колонок задаётся через `getSize()`.
- тесты и линтеры прошли.
- `pre_pr_check.sh` завершился ошибкой запуска — требуется проверить локально.

## Риски
- фиксированная ширина может вызвать горизонтальную прокрутку; при проблемах откатить этот коммит.


------
https://chatgpt.com/codex/tasks/task_b_68aca7b1e1dc8320802b0fc34177d1ce