### PR TITLE
feat: добавить id для форм и обновить тест доступности

### DIFF
--- a/apps/web/src/components/FiltersPanel.tsx
+++ b/apps/web/src/components/FiltersPanel.tsx
@@ -9,6 +9,7 @@ interface Props {
 }
 
 export default function FiltersPanel({ filters, onChange }: Props) {
+  const noCsrfId = React.useId();
   return (
     <div className="flex flex-wrap gap-2">
       <select
@@ -68,14 +69,15 @@ export default function FiltersPanel({ filters, onChange }: Props) {
         value={filters.to || ""}
         onChange={(e) => onChange({ ...filters, to: e.target.value })}
       />
-      <label className="flex items-center gap-1 text-sm">
+      <div className="flex items-center gap-1 text-sm">
         <input
+          id={noCsrfId}
           type="checkbox"
           checked={filters.noCsrf || false}
           onChange={(e) => onChange({ ...filters, noCsrf: e.target.checked })}
         />
-        no-csrf
-      </label>
+        <label htmlFor={noCsrfId}>no-csrf</label>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/a11y/TaskForm.tsx
+++ b/apps/web/src/components/a11y/TaskForm.tsx
@@ -93,13 +93,20 @@ type FieldProps = {
   className?: string;
 };
 
+// Поле формы с уникальным идентификатором
+// Модули: React
 function FormField({ label, children, hint, className = "" }: FieldProps) {
+  const id = React.useId();
   return (
-    <label className={`flex flex-col gap-1 ${className}`}>
-      <span className="text-sm font-medium">{label}</span>
-      {children}
+    <div className={`flex flex-col gap-1 ${className}`}>
+      <label htmlFor={id} className="text-sm font-medium">
+        {label}
+      </label>
+      {React.isValidElement(children)
+        ? React.cloneElement(children, { id })
+        : children}
       {hint && <span className="text-xs text-gray-500">{hint}</span>}
-    </label>
+    </div>
   );
 }
 

--- a/tests/e2e/contrast.spec.ts
+++ b/tests/e2e/contrast.spec.ts
@@ -12,11 +12,15 @@ const markup = `<!DOCTYPE html><html><head>
 <button class="bg-blue-600 text-white rounded-md px-4 py-2 focus-visible:ring-2 focus-visible:ring-offset-2">
 Кнопка
 </button>
-<input class="mt-4 w-full rounded-md border border-gray-300 px-4 py-2 focus-visible:ring-2 focus-visible:ring-blue-500" placeholder="Введите" />
+<div class="mt-4">
+<label for="input" class="mb-1 block">Введите</label>
+<input id="input" class="w-full rounded-md border border-gray-300 px-4 py-2 focus-visible:ring-2 focus-visible:ring-blue-500" />
+</div>
 </body></html>`;
 
 test('контраст и фокусы компонентов', async ({ page }) => {
   await page.setContent(markup);
+  await expect(page.getByLabel('Введите')).toBeVisible();
   const results = await new AxeBuilder({ page })
     .withTags(['color-contrast'])
     .analyze();
@@ -29,9 +33,9 @@ test('контраст и фокусы компонентов', async ({ page })
   );
   expect(buttonRing).not.toBe('none');
 
-  await page.focus('input');
+  await page.focus('#input');
   const inputRing = await page.$eval(
-    'input',
+    '#input',
     (el) => getComputedStyle(el).outlineStyle,
   );
   expect(inputRing).not.toBe('none');


### PR DESCRIPTION
## Что сделано
- добавлены уникальные id и связка `label`/`input` в `TaskForm`
- checkbox панели фильтров получил `label for`
- тест `contrast.spec.ts` проверяет наличие label и обновлён

## Зачем
Улучшается доступность форм и корректность e2e-проверок.

## Чек-лист
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [ ] `pnpm run dev`

## Самопроверка
- [x] ID генерируются через `useId`
- [x] `label` связан с полем через `htmlFor`
- [x] axe-проверка проходит без нарушений
- [x] тесты и сборка зелёные
- [ ] dev-сервер не стартовал из-за отсутствия типов `clamscan`

## Риски
- возможны пропущенные поля без `id`
- dev-сервер потребует установки `@types/clamscan`

## Откат
- `git revert 16acc26`


------
https://chatgpt.com/codex/tasks/task_b_68acb22fd09083208cb627b659938073