### PR TITLE
fix: align react-is and hoist-non-react-statics versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 - Dockerfile копирует каталог `patches` перед `pnpm fetch`, устраняя ошибку отсутствующего патча.
 
-- Зафиксирована версия `react-is` 18.2.0 в `pnpm.overrides`,
-  устраняя ошибку «Cannot set properties of undefined (setting 'AsyncMode')»
-  в production-сборке.
+- Зафиксированы версии `react-is` 18.3.1 и `hoist-non-react-statics` 3.3.2
+  в `pnpm.overrides`, что устраняет зависимость старых пакетов и
+  предотвращает сбой клиента.
 - Исправлена ошибка разделения чанков: `use-callback-ref` включён в `react`,
   что устраняет сбой `useLayoutEffect`.
 - Отключён таймаут PNPM для `pnpm run dev`, сервер работает без завершения.

--- a/package.json
+++ b/package.json
@@ -66,7 +66,9 @@
       "dompurify@<3.2.4": ">=3.2.4",
       "react": "18.2.0",
       "react-dom": "18.2.0",
-      "react-is": "18.2.0"
+      "react-is": "18.3.1",
+      "hoist-non-react-statics": "3.3.2",
+      "@types/hoist-non-react-statics": "3.3.7"
     },
     "allowedBuiltDependencies": [
       "esbuild",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,9 @@ overrides:
   dompurify@<3.2.4: '>=3.2.4'
   react: 18.2.0
   react-dom: 18.2.0
-  react-is: 18.2.0
+  react-is: 18.3.1
+  hoist-non-react-statics: 3.3.2
+  '@types/hoist-non-react-statics': 3.3.7
 
 patchedDependencies:
   jspdf:
@@ -7063,9 +7065,6 @@ packages:
       typescript:
         optional: true
 
-  react-is@18.2.0:
-    resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
-
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
@@ -7672,7 +7671,7 @@ packages:
     peerDependencies:
       react: 18.2.0
       react-dom: 18.2.0
-      react-is: 18.2.0
+      react-is: 18.3.1
 
   stylis@4.2.0:
     resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
@@ -9789,8 +9788,6 @@ snapshots:
       '@ckeditor/ckeditor5-paste-from-office': 41.4.2
       '@ckeditor/ckeditor5-table': 41.4.2
       '@ckeditor/ckeditor5-typing': 41.4.2
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-ckbox@41.4.2':
     dependencies:
@@ -9901,6 +9898,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 46.0.2
       ckeditor5: 46.0.2
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-editor-classic@41.4.2':
     dependencies:
@@ -9926,6 +9925,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 46.0.2
       ckeditor5: 46.0.2
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-editor-inline@46.0.2':
     dependencies:
@@ -9935,6 +9936,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 46.0.2
       ckeditor5: 46.0.2
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-editor-multi-root@46.0.2':
     dependencies:
@@ -9970,6 +9973,8 @@ snapshots:
     dependencies:
       '@ckeditor/ckeditor5-utils': 46.0.2
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-enter@46.0.2':
     dependencies:
@@ -10002,6 +10007,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 46.0.2
       ckeditor5: 46.0.2
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-font@46.0.2':
     dependencies:
@@ -10060,6 +10067,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 46.0.2
       '@ckeditor/ckeditor5-widget': 46.0.2
       ckeditor5: 46.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-html-embed@46.0.2':
     dependencies:
@@ -10117,8 +10126,6 @@ snapshots:
   '@ckeditor/ckeditor5-indent@41.4.2':
     dependencies:
       ckeditor5: 46.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-indent@46.0.2':
     dependencies:
@@ -10224,8 +10231,6 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 46.0.2
       '@ckeditor/ckeditor5-widget': 46.0.2
       ckeditor5: 46.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-mention@46.0.2':
     dependencies:
@@ -10245,8 +10250,6 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 46.0.2
       '@ckeditor/ckeditor5-utils': 46.0.2
       ckeditor5: 46.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-page-break@46.0.2':
     dependencies:
@@ -10256,8 +10259,6 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 46.0.2
       '@ckeditor/ckeditor5-widget': 46.0.2
       ckeditor5: 46.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-paragraph@41.4.2':
     dependencies:
@@ -10283,8 +10284,6 @@ snapshots:
       '@ckeditor/ckeditor5-core': 46.0.2
       '@ckeditor/ckeditor5-engine': 46.0.2
       ckeditor5: 46.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-react@6.3.0(@ckeditor/ckeditor5-core@46.0.2)(@ckeditor/ckeditor5-editor-multi-root@46.0.2)(@ckeditor/ckeditor5-engine@46.0.2)(@ckeditor/ckeditor5-utils@46.0.2)(@ckeditor/ckeditor5-watchdog@46.0.2)(react@18.2.0)':
     dependencies:
@@ -10328,8 +10327,6 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 46.0.2
       '@ckeditor/ckeditor5-utils': 46.0.2
       ckeditor5: 46.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-source-editing@46.0.2':
     dependencies:
@@ -10360,8 +10357,6 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 46.0.2
       ckeditor5: 46.0.2
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-table@41.4.2':
     dependencies:
@@ -10380,8 +10375,6 @@ snapshots:
       '@ckeditor/ckeditor5-widget': 46.0.2
       ckeditor5: 46.0.2
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-theme-lark@46.0.2':
     dependencies:
@@ -10477,8 +10470,6 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 46.0.2
       ckeditor5: 46.0.2
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -11289,7 +11280,7 @@ snapshots:
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-is: 18.2.0
+      react-is: 18.3.1
       react-transition-group: 4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     optionalDependencies:
       '@types/react': 17.0.88
@@ -11338,7 +11329,7 @@ snapshots:
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-is: 18.2.0
+      react-is: 18.3.1
 
   '@mongodb-js/saslprep@1.3.0':
     dependencies:
@@ -14619,7 +14610,7 @@ snapshots:
 
   hoist-non-react-statics@3.3.2:
     dependencies:
-      react-is: 18.2.0
+      react-is: 18.3.1
 
   hosted-git-info@2.8.9: {}
 
@@ -16869,13 +16860,13 @@ snapshots:
     dependencies:
       '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
-      react-is: 18.2.0
+      react-is: 18.3.1
 
   pretty-format@30.0.5:
     dependencies:
       '@jest/schemas': 30.0.5
       ansi-styles: 5.2.0
-      react-is: 18.2.0
+      react-is: 18.3.1
 
   process-nextick-args@2.0.1: {}
 
@@ -16900,7 +16891,7 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-      react-is: 18.2.0
+      react-is: 18.3.1
 
   property-information@7.1.0: {}
 
@@ -17077,8 +17068,6 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.2
 
-  react-is@18.2.0: {}
-
   react-is@18.3.1: {}
 
   react-jss@10.10.0(react@18.2.0):
@@ -17112,7 +17101,7 @@ snapshots:
       loose-envify: 1.4.0
       prop-types: 15.8.1
       react: 18.2.0
-      react-is: 18.2.0
+      react-is: 18.3.1
     optionalDependencies:
       react-dom: 18.2.0(react@18.2.0)
 


### PR DESCRIPTION
## Summary
- pin react-is and hoist-non-react-statics via pnpm overrides
- document the change in changelog

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm lint`
- `pnpm --filter web build`
- `./scripts/pre_pr_check.sh` (fails: build retried)


------
https://chatgpt.com/codex/tasks/task_b_68ad9e35e5848320a45578e918b2b534