### PR TITLE
fix: pin npm registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
-# Назначение: принудительный реестр для пакетов @jsr
+# Назначение: принудительный реестр для пакетов @jsr и общий реестр npmjs.org
+registry=https://registry.npmjs.org/
 @jsr:registry=https://registry.npmjs.org/

--- a/scripts/install_bot_deps.sh
+++ b/scripts/install_bot_deps.sh
@@ -48,8 +48,10 @@ if ! command -v pnpm >/dev/null; then
   command -v pnpm >/dev/null || { echo "Не удалось установить pnpm." >&2; exit 1; }
 fi
 
-# Гарантируем использование реестра npmjs.org для scope @jsr
+# Гарантируем использование реестра npmjs.org для всех пакетов и scope @jsr
+pnpm config set registry https://registry.npmjs.org/ >/dev/null
 pnpm config set @jsr:registry https://registry.npmjs.org/ >/dev/null
+npm config set registry https://registry.npmjs.org/ >/dev/null 2>&1 || true
 npm config set @jsr:registry https://registry.npmjs.org/ >/dev/null 2>&1 || true
 
 # Устанавливаем корневые зависимости для линтера


### PR DESCRIPTION
## Summary
- fix install script to force npmjs.org registry for all packages
- ensure .npmrc sets global registry to avoid auth errors

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68adc6f88da88320be56da02f59ae113