### PR TITLE
feat: unify react dependencies chunk

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -49,9 +49,15 @@ export default defineConfig(() => ({
               ? `${pkgPath[0]}/${pkgPath[1]}`
               : pkgPath[0];
             if (pkg.includes("@ckeditor")) return "ckeditor";
-            // Объединяем зависимости React и use-callback-ref в один чанк,
-            // чтобы избежать циклической загрузки и ошибок useLayoutEffect.
-            if (pkg.startsWith("react") || pkg.includes("use-callback-ref"))
+            // Объединяем зависимости React, react-is и hoist-non-react-statics
+            // в один чанк, чтобы избежать циклической загрузки и ошибок
+            // `ContextConsumer`.
+            if (
+              pkg.startsWith("react") ||
+              pkg.includes("use-callback-ref") ||
+              pkg === "hoist-non-react-statics" ||
+              pkg === "react-is"
+            )
               return "react";
             return pkg.replace("@", "").replace("/", "-");
           }


### PR DESCRIPTION
## Summary
- include `hoist-non-react-statics` and `react-is` in React chunk
- avoid `ContextConsumer` runtime failure after deployment

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh` *(fails to start bot)*

------
https://chatgpt.com/codex/tasks/task_b_68addb7ee86c8320aeb090dded59797a