### PR TITLE
fix: bundle emotion with react

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -49,11 +49,12 @@ export default defineConfig(() => ({
               ? `${pkgPath[0]}/${pkgPath[1]}`
               : pkgPath[0];
             if (pkg.includes("@ckeditor")) return "ckeditor";
-            // Объединяем зависимости React, react-is и hoist-non-react-statics
-            // в один чанк, чтобы избежать циклической загрузки и ошибок
-            // `ContextConsumer`.
+            // Объединяем зависимости React и @emotion, а также react-is и
+            // hoist-non-react-statics в один чанк, чтобы избежать циклической
+            // загрузки и ошибок `ContextConsumer`.
             if (
               pkg.startsWith("react") ||
+              pkg.startsWith("@emotion") ||
               pkg.includes("use-callback-ref") ||
               pkg === "hoist-non-react-statics" ||
               pkg === "react-is"


### PR DESCRIPTION
## Summary
- bundle `@emotion` packages into react chunk to avoid circular runtime init errors

## Testing
- `pnpm install`
- `pnpm lint`
- `pnpm build`
- `pnpm test` *(fails: browserType.launch: Executable doesn't exist...)*
- `pnpm exec playwright install chromium`
- `pnpm exec playwright install-deps` *(incomplete: long install)*
- `pnpm test:e2e` *(fails: Host system is missing dependencies to run browsers)*
- `timeout 5 pnpm dev` *(fails: telegram-task-bot@1.0.0 dev: `ts-node src/server.ts` command failed with signal "SIGTERM")*

------
https://chatgpt.com/codex/tasks/task_b_68ade5bbdf5c8320b3119b566ec44201