### PR TITLE
feat(api): handle startup failures

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -4,12 +4,17 @@ import './di';
 import config from './config';
 import buildApp from './api/server';
 
-buildApp().then((app) => {
-  const port: number = config.port;
-  app.listen(port, '0.0.0.0', () => {
-    console.log(`API запущен на порту ${port}`);
-    console.log(
-      `Окружение: ${process.env.NODE_ENV || 'development'}, Node ${process.version}`,
-    );
+buildApp()
+  .then((app) => {
+    const port: number = config.port;
+    app.listen(port, '0.0.0.0', () => {
+      console.log(`API запущен на порту ${port}`);
+      console.log(
+        `Окружение: ${process.env.NODE_ENV || 'development'}, Node ${process.version}`,
+      );
+    });
+  })
+  .catch((e) => {
+    console.error('API не стартовал', e);
+    process.exit(1);
   });
-});


### PR DESCRIPTION
## Summary
- exit process when API fails to build or start

## Testing
- `pnpm install`
- `./scripts/setup_and_test.sh`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm run dev` *(fails: Could not find a declaration file for module 'clamscan')*
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68aea406f9e48320bcdcd9a535b7f28b