### PR TITLE
fix(api): disable uninitialized session saving

### DIFF
--- a/apps/api/src/api/server.ts
+++ b/apps/api/src/api/server.ts
@@ -84,7 +84,7 @@ export async function buildApp(): Promise<express.Express> {
   const sessionOpts: session.SessionOptions = {
     secret: process.env.SESSION_SECRET || 'session_secret',
     resave: false,
-    saveUninitialized: true,
+    saveUninitialized: false,
     cookie: { ...cookieFlags, maxAge: 7 * 24 * 60 * 60 * 1000 },
   };
   if (process.env.NODE_ENV !== 'test') {


### PR DESCRIPTION
## Summary
- disable uninitialized session saving

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68aec73745b88320a8f8b48cfad78451