### PR TITLE
refactor(api): убрать загрузку dotenv

### DIFF
--- a/apps/api/src/api/server.ts
+++ b/apps/api/src/api/server.ts
@@ -1,6 +1,5 @@
 // Назначение файла: сборка HTTP API.
 // Основные модули: express, security, routes
-import dotenv from 'dotenv';
 import config from '../config';
 import express from 'express';
 import compression from 'compression';
@@ -14,8 +13,6 @@ import { promisify } from 'util';
 import applySecurity from './security';
 import registerRoutes from './routes';
 import { startDiskMonitor } from '../services/diskSpace';
-
-dotenv.config();
 
 process.on('unhandledRejection', (err) => {
   console.error('Unhandled rejection in API:', err);


### PR DESCRIPTION
## Summary
- убрать импорт dotenv и вызов dotenv.config из серверного API
- полагаться на загрузку переменных окружения в config.ts

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh` *(failed: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68aece6b9980832099aacaae0ae8beda