### PR TITLE
feat(web): добавить тип пользователя

### DIFF
--- a/apps/web/src/context/AuthContext.ts
+++ b/apps/web/src/context/AuthContext.ts
@@ -1,12 +1,13 @@
 // Контекст аутентификации
 import { createContext } from "react";
+import type { User } from "../types/user";
 
 interface AuthContextType {
   token: string | null;
-  user: Record<string, unknown> | null;
+  user: User | null;
   loading: boolean;
   logout: () => void;
-  setUser: (u: Record<string, unknown> | null) => void;
+  setUser: (u: User | null) => void;
 }
 
 export const AuthContext = createContext<AuthContextType>({

--- a/apps/web/src/context/AuthProvider.tsx
+++ b/apps/web/src/context/AuthProvider.tsx
@@ -4,13 +4,14 @@ import { useEffect, useState, type ReactNode } from "react";
 import { getProfile } from "../services/auth";
 import { AuthContext } from "./AuthContext";
 import { setCsrfToken } from "../utils/csrfToken";
+import type { User } from "../types/user";
 
 interface AuthProviderProps {
   children: ReactNode;
 }
 
 export function AuthProvider({ children }: AuthProviderProps) {
-  const [user, setUser] = useState<Record<string, unknown> | null>(null);
+  const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
   useEffect(() => {
     const loadCsrf = async () => {

--- a/apps/web/src/services/auth.ts
+++ b/apps/web/src/services/auth.ts
@@ -2,6 +2,7 @@
 // Назначение: API запросы для профиля пользователя
 // Основные модули: authFetch
 import authFetch from "../utils/authFetch";
+import type { User } from "../types/user";
 
 interface FetchOptions {
   method?: string;
@@ -9,10 +10,11 @@ interface FetchOptions {
   body?: string;
 }
 
-export const getProfile = async (options?: FetchOptions) => {
+export const getProfile = async (options?: FetchOptions): Promise<User> => {
   const res = await authFetch("/api/v1/auth/profile", options);
   if (!res.ok) throw new Error("unauthorized");
-  return res.json();
+  const data = await res.json();
+  return { ...data, id: String(data.telegram_id ?? "") } as User;
 };
 
 interface ProfileData {

--- a/apps/web/src/types/user.ts
+++ b/apps/web/src/types/user.ts
@@ -1,0 +1,23 @@
+// Назначение: тип пользователя фронтенда
+// Модули: отсутствуют
+
+export interface User {
+  /** Строковый идентификатор пользователя */
+  id: string;
+  /** Telegram ID */
+  telegram_id?: number;
+  /** Имя пользователя в Telegram */
+  telegram_username?: string | null;
+  /** Логин пользователя, совпадает с Telegram ID */
+  username?: string;
+  /** Отображаемое имя */
+  name?: string;
+  /** Основной телефон */
+  phone?: string;
+  /** Мобильный номер */
+  mobNumber?: string;
+  /** Роль пользователя */
+  role?: string;
+  /** Уровень доступа */
+  access?: number;
+}


### PR DESCRIPTION
## Summary
- добавить тип `User` в веб-клиенте
- применить тип `User` в `AuthContext` и `AuthProvider`
- типизировать `getProfile`

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68af23c9ba388320aae058f777f29381