### PR TITLE
feat: add typed task helpers

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx}\"",
     "shadcn": "shadcn",
-    "bundle-report": "ANALYZE=true vite build"
+    "bundle-report": "ANALYZE=true vite build",
+    "test:types": "tsc --noEmit --lib ESNext,DOM --types node src/types/task.test.ts"
   },
   "dependencies": {
     "@ckeditor/ckeditor5-build-classic": "^41.4.2",

--- a/apps/web/src/components/FileUploader.tsx
+++ b/apps/web/src/components/FileUploader.tsx
@@ -1,15 +1,8 @@
 // Компонент загрузки файлов с drag-and-drop и прогрессом
-// Основные модули: React, authFetch
+// Основные модули: React, authFetch, типы задач
 import React from "react";
 import authFetch from "../utils/authFetch";
-
-interface Attachment {
-  name: string;
-  url: string;
-  thumbnailUrl?: string;
-  type: string;
-  size: number;
-}
+import type { Attachment } from "../types/task";
 
 interface UploadItem {
   file: File;

--- a/apps/web/src/types/task.test.ts
+++ b/apps/web/src/types/task.test.ts
@@ -1,0 +1,16 @@
+// Назначение: проверки корректности типов задач
+// Модули: HistoryItem, UserBrief, Attachment
+import type { HistoryItem, UserBrief, Attachment } from "./task";
+
+const history: HistoryItem[] = [
+  { changed_at: "2024-01-01T00:00:00Z", changes: { a: 1 } },
+];
+
+const users: UserBrief[] = [{ telegram_id: 1, name: "Иван" }];
+
+const attachments: Attachment[] = [
+  { name: "f.txt", url: "/f.txt", type: "text/plain", size: 1 },
+];
+
+// предотвращаем удаление при компиляции
+export { history, users, attachments };

--- a/apps/web/src/types/task.ts
+++ b/apps/web/src/types/task.ts
@@ -1,0 +1,33 @@
+// Назначение: типы задач фронтенда
+// Модули: отсутствуют
+
+export interface HistoryItem {
+  /** Время изменения */
+  changed_at: string;
+  /** Объект изменений */
+  changes: Record<string, unknown>;
+}
+
+export interface UserBrief {
+  /** Telegram ID пользователя */
+  telegram_id: number;
+  /** Имя пользователя */
+  name?: string;
+  /** Ник в Telegram */
+  telegram_username?: string | null;
+  /** Логин */
+  username?: string;
+}
+
+export interface Attachment {
+  /** Название файла */
+  name: string;
+  /** URL файла */
+  url: string;
+  /** Миниатюра */
+  thumbnailUrl?: string;
+  /** MIME-тип */
+  type: string;
+  /** Размер в байтах */
+  size: number;
+}


### PR DESCRIPTION
## Summary
- define HistoryItem, UserBrief and Attachment interfaces
- use typed arrays in task dialog and file uploader
- add TypeScript type test

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm --dir apps/web run test:types`
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68af322a328c832091cc9b6604b9cd14