### PR TITLE
fix: prevent stale SPA assets after deploy

### DIFF
--- a/apps/api/src/api/routes.ts
+++ b/apps/api/src/api/routes.ts
@@ -160,6 +160,12 @@ export default async function registerRoutes(
     express.static(path.join(__dirname, '../../public'), {
       maxAge: '1y',
       immutable: true,
+      // Для HTML отключаем кэш, чтобы браузер получал свежий index.html
+      setHeaders(res, filePath) {
+        if (filePath.endsWith('.html')) {
+          res.setHeader('Cache-Control', 'no-cache');
+        }
+      },
     }),
   );
   app.use(
@@ -277,7 +283,12 @@ export default async function registerRoutes(
     res.sendFile(path.join(pub, 'index.html'));
   });
 
-  app.get('*', spaRateLimiter, (_req: Request, res: Response) => {
+  app.get('*', spaRateLimiter, (req: Request, res: Response) => {
+    // Не отдаём index.html для запросов статических файлов
+    if (req.path.includes('.')) {
+      res.status(404).end();
+      return;
+    }
     res.sendFile(path.join(pub, 'index.html'));
   });
 


### PR DESCRIPTION
## Summary
- disable caching for HTML files so index.html is always fresh
- return 404 for unknown static paths to avoid serving HTML instead of JS

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68afe075e0a88320926fa6a9e1888426