### PR TITLE
feat: показать индикатор загрузки маршрутов

### DIFF
--- a/apps/web/src/components/AdminRoute.tsx
+++ b/apps/web/src/components/AdminRoute.tsx
@@ -2,10 +2,11 @@
 import { useContext, type ReactElement } from "react";
 import { Navigate } from "react-router-dom";
 import { AuthContext } from "../context/AuthContext";
+import Loader from "./Loader";
 
 export default function AdminRoute({ children }: { children: ReactElement }) {
   const { user, loading } = useContext(AuthContext);
-  if (loading) return null;
+  if (loading) return <Loader />;
   if (!user) return <Navigate to="/login" />;
   if (user.role !== "admin") return <Navigate to="/tasks" />;
   return children;

--- a/apps/web/src/components/Loader.tsx
+++ b/apps/web/src/components/Loader.tsx
@@ -1,0 +1,13 @@
+// Назначение: индикатор загрузки приложения, модули: React
+import Spinner from "./Spinner";
+
+export default function Loader() {
+  return (
+    <div
+      className="flex h-full w-full items-center justify-center"
+      data-testid="loader"
+    >
+      <Spinner />
+    </div>
+  );
+}

--- a/apps/web/src/components/ProtectedRoute.tsx
+++ b/apps/web/src/components/ProtectedRoute.tsx
@@ -2,6 +2,7 @@
 import { useContext, type ReactNode } from "react";
 import { AuthContext } from "../context/AuthContext";
 import { Navigate } from "react-router-dom";
+import Loader from "./Loader";
 
 interface ProtectedRouteProps {
   children: ReactNode;
@@ -9,6 +10,6 @@ interface ProtectedRouteProps {
 
 export default function ProtectedRoute({ children }: ProtectedRouteProps) {
   const { user, loading } = useContext(AuthContext);
-  if (loading) return null;
+  if (loading) return <Loader />;
   return user ? children : <Navigate to="/login" />;
 }

--- a/tests/route.loader.spec.tsx
+++ b/tests/route.loader.spec.tsx
@@ -1,0 +1,38 @@
+/** @jest-environment jsdom */
+// Назначение файла: тесты маршрутов ProtectedRoute и AdminRoute на индикатор загрузки.
+// Основные модули: React, @testing-library/react.
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render } from '@testing-library/react';
+import ProtectedRoute from '../apps/web/src/components/ProtectedRoute';
+import AdminRoute from '../apps/web/src/components/AdminRoute';
+import { AuthContext } from '../apps/web/src/context/AuthContext';
+
+const value = {
+  user: null,
+  loading: true,
+  logout: jest.fn(),
+  setUser: jest.fn(),
+};
+
+test('ProtectedRoute показывает индикатор при загрузке', () => {
+  const { getByTestId } = render(
+    <AuthContext.Provider value={value}>
+      <ProtectedRoute>
+        <div>child</div>
+      </ProtectedRoute>
+    </AuthContext.Provider>,
+  );
+  expect(getByTestId('loader')).toBeInTheDocument();
+});
+
+test('AdminRoute показывает индикатор при загрузке', () => {
+  const { getByTestId } = render(
+    <AuthContext.Provider value={value}>
+      <AdminRoute>
+        <div>child</div>
+      </AdminRoute>
+    </AuthContext.Provider>,
+  );
+  expect(getByTestId('loader')).toBeInTheDocument();
+});

--- a/tests/setupEnv.ts
+++ b/tests/setupEnv.ts
@@ -1,13 +1,18 @@
 /**
- * Назначение файла: настройка переменных окружения для юнит-тестов.
- * Основные модули: process.
+ * Назначение файла: настройка переменных окружения и полифиллов для юнит-тестов.
+ * Основные модули: process, util.
  */
 
-process.env.NODE_ENV ||= 'test';
+process.env.NODE_ENV = 'test';
 process.env.BOT_TOKEN ||= 'test-bot-token';
 process.env.CHAT_ID ||= '0';
 process.env.JWT_SECRET ||= 'test-secret';
 process.env.APP_URL ||= 'https://example.com';
-process.env.MONGO_DATABASE_URL ||= 'mongodb://admin:admin@localhost:27017/ermdb?authSource=admin';
+process.env.MONGO_DATABASE_URL ||=
+  'mongodb://admin:admin@localhost:27017/ermdb?authSource=admin';
 process.env.RETRY_ATTEMPTS ||= '0';
 process.env.SUPPRESS_LOGS ||= '1';
+
+import { TextDecoder, TextEncoder } from 'util';
+(global as any).TextEncoder = TextEncoder;
+(global as any).TextDecoder = TextDecoder as any;


### PR DESCRIPTION
## Summary
- добавить компонент `Loader`
- выводить индикатор в `ProtectedRoute` и `AdminRoute`
- покрыть индикатор тестами

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm test:unit`
- `pnpm lint`
- `pnpm build`
- `timeout 5 pnpm run dev` *(fails: SIGTERM)*
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68b007134d2083208181a83d097bb8ef