### PR TITLE
feat: add error boundary to web client

### DIFF
--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,31 @@
+// Компонент границы ошибок для перехвата исключений и вывода запасного UI.
+// Основные модули: React.
+import React, { type ReactNode } from "react";
+
+interface Props {
+  fallback: ReactNode;
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends React.Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown, info: unknown) {
+    console.error(error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+    return this.props.children;
+  }
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,6 +1,7 @@
 // Точка входа: выбирает режим приложения (браузер или Telegram)
 import React from "react";
 import * as ReactDOM from "react-dom/client";
+import ErrorBoundary from "./components/ErrorBoundary";
 import "./index.css";
 
 const root = document.getElementById("root");
@@ -16,7 +17,9 @@ const isBrowser = forcedBrowser || !hasTelegram;
 function render(Component: React.ComponentType) {
   ReactDOM.createRoot(root).render(
     <React.StrictMode>
-      <Component />
+      <ErrorBoundary fallback={<div>Что-то пошло не так</div>}>
+        <Component />
+      </ErrorBoundary>
     </React.StrictMode>,
   );
 }

--- a/tests/error-boundary.fallback.spec.tsx
+++ b/tests/error-boundary.fallback.spec.tsx
@@ -1,0 +1,21 @@
+/** @jest-environment jsdom */
+// Назначение файла: проверяет вывод запасного UI в ErrorBoundary при исключении.
+// Основные модули: React, @testing-library/react.
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ErrorBoundary from '../apps/web/src/components/ErrorBoundary';
+
+describe('ErrorBoundary', () => {
+  it('отображает fallback при ошибке', () => {
+    const Problem: React.FC = () => {
+      throw new Error('boom');
+    };
+    render(
+      <ErrorBoundary fallback={<div role="alert">Ошибка</div>}>
+        <Problem />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Ошибка');
+  });
+});


### PR DESCRIPTION
## Summary
- add ErrorBoundary component with custom fallback
- wrap web app root component with ErrorBoundary
- test error fallback rendering

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`
- `pnpm run dev`
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68b00ebfb07083208f61238138204ed6