### PR TITLE
feat: add logout endpoint and client support

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -5,7 +5,8 @@ import formatUser from '../utils/formatUser';
 import { writeLog } from '../services/service';
 import setTokenCookie from '../utils/setTokenCookie';
 import type { RequestWithUser } from '../types/request';
-import { Request, Response } from 'express';
+import { Request, Response, CookieOptions } from 'express';
+import config from '../config';
 import type { UserDocument } from '../db/model';
 import { sendProblem } from '../utils/problem';
 
@@ -91,6 +92,16 @@ export const updateProfile = async (
   }
   await writeLog(`Профиль ${req.user!.id}/${req.user!.username} изменён`);
   res.json(formatUser(user));
+};
+
+export const logout = (_req: Request, res: Response) => {
+  const secure = process.env.NODE_ENV === 'production';
+  const opts: CookieOptions = { httpOnly: true, secure, sameSite: 'lax' };
+  if (secure) {
+    opts.domain = config.cookieDomain || new URL(config.appUrl).hostname;
+  }
+  res.clearCookie('token', opts);
+  res.json({ status: 'ok' });
 };
 
 export const codes = service.codes;

--- a/apps/api/src/routes/authUser.ts
+++ b/apps/api/src/routes/authUser.ts
@@ -37,6 +37,8 @@ router.post(
   asyncHandler(authCtrl.verifyInitData),
 );
 
+router.post('/logout', authCtrl.logout as unknown as RequestHandler);
+
 router.get(
   '/profile',
   authMiddleware(),

--- a/apps/api/tests/authCsrfRoute.test.ts
+++ b/apps/api/tests/authCsrfRoute.test.ts
@@ -18,6 +18,7 @@ jest.mock('../src/auth/auth.controller.ts', () => ({
   verifyCode: jest.fn((_req, res) => res.json({ token: 't' })),
   profile: jest.fn((_req, res) => res.json({ ok: true })),
   updateProfile: jest.fn((_req, res) => res.json({ ok: true })),
+  logout: jest.fn((_req, res) => res.json({ status: 'ok' })),
 }));
 
 const authRouter = require('../src/routes/authUser').default;

--- a/apps/api/tests/expensiveRateLimit.test.ts
+++ b/apps/api/tests/expensiveRateLimit.test.ts
@@ -18,6 +18,7 @@ jest.mock('../src/auth/auth.controller.ts', () => ({
   verifyInitData: jest.fn((_req, res) => res.json({ ok: true })),
   profile: jest.fn((_req, res) => res.json({ ok: true })),
   updateProfile: jest.fn((_req, res) => res.json({ ok: true })),
+  logout: jest.fn((_req, res) => res.json({ status: 'ok' })),
 }));
 
 jest.mock('../src/api/middleware', () => ({

--- a/apps/web/src/context/AuthContext.ts
+++ b/apps/web/src/context/AuthContext.ts
@@ -5,13 +5,13 @@ import type { User } from "../types/user";
 interface AuthContextType {
   user: User | null;
   loading: boolean;
-  logout: () => void;
+  logout: () => Promise<void>;
   setUser: (u: User | null) => void;
 }
 
 export const AuthContext = createContext<AuthContextType>({
   user: null,
   loading: true,
-  logout: () => {},
+  logout: async () => {},
   setUser: () => {},
 });

--- a/apps/web/src/context/AuthProvider.tsx
+++ b/apps/web/src/context/AuthProvider.tsx
@@ -1,7 +1,7 @@
 // Контекст аутентификации, запрашивает профиль и CSRF-токен, JWT не хранится
 // Модули: React, services/auth, AuthContext
 import { useEffect, useState, type ReactNode } from "react";
-import { getProfile } from "../services/auth";
+import { getProfile, logout as apiLogout } from "../services/auth";
 import { AuthContext } from "./AuthContext";
 import { setCsrfToken } from "../utils/csrfToken";
 import type { User } from "../types/user";
@@ -45,7 +45,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
       document.removeEventListener("visibilitychange", onVisible);
     };
   }, []);
-  const logout = () => {
+  const logout = async () => {
+    await apiLogout();
     setUser(null);
   };
   return (

--- a/apps/web/src/services/auth.ts
+++ b/apps/web/src/services/auth.ts
@@ -30,3 +30,6 @@ export const updateProfile = (data: ProfileData) =>
     },
     body: JSON.stringify(data),
   }).then((r) => r.json());
+
+export const logout = () =>
+  authFetch("/api/v1/auth/logout", { method: "POST" }).then(() => undefined);

--- a/tests/e2e/logout.spec.ts
+++ b/tests/e2e/logout.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * Назначение файла: e2e-тест удаления cookie при выходе.
+ * Основные модули: @playwright/test, express.
+ */
+import { test, expect } from '@playwright/test';
+import express from 'express';
+import type { Server } from 'http';
+import type { AddressInfo } from 'net';
+
+process.env.BOT_TOKEN = 'test';
+process.env.CHAT_ID = '1';
+process.env.JWT_SECRET = 'secret';
+process.env.APP_URL = 'https://example.org';
+process.env.MONGO_DATABASE_URL =
+  'mongodb://admin:admin@localhost:27017/ermdb?authSource=admin';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { logout } =
+  require('../../apps/api/src/auth/auth.controller') as typeof import('../../apps/api/src/auth/auth.controller');
+
+test('выход удаляет cookie', async ({ request }) => {
+  const app = express();
+  app.post('/api/v1/auth/logout', logout);
+  const server: Server = app.listen(0);
+  const { port } = server.address() as AddressInfo;
+  const base = `http://localhost:${port}`;
+  const res = await request.post(`${base}/api/v1/auth/logout`, {
+    headers: { cookie: 'token=abc' },
+  });
+  const cookieHeader = res.headers()['set-cookie'] || '';
+  expect(cookieHeader).toContain('token=');
+  server.close();
+});

--- a/tests/route.loader.spec.tsx
+++ b/tests/route.loader.spec.tsx
@@ -11,7 +11,7 @@ import { AuthContext } from '../apps/web/src/context/AuthContext';
 const value = {
   user: null,
   loading: true,
-  logout: jest.fn(),
+  logout: jest.fn().mockResolvedValue(undefined),
   setUser: jest.fn(),
 };
 


### PR DESCRIPTION
## Summary
- add API route POST /api/v1/auth/logout that clears session cookie
- call logout from web AuthProvider and expose service method
- add e2e test confirming logout clears auth cookie

## Testing
- `./scripts/setup_and_test.sh` (passed)
- `pnpm test:e2e` (failed: missing browsers)
- `./scripts/pre_pr_check.sh` (failed: could not start bot)


------
https://chatgpt.com/codex/tasks/task_b_68b01e32bd6883208a2bc4c6883a13f4