### PR TITLE
test: cover login page loading

### DIFF
--- a/tests/e2e/login.spec.ts
+++ b/tests/e2e/login.spec.ts
@@ -1,10 +1,14 @@
 /**
- * Назначение файла: e2e-тест формы входа и проверки отсутствия JS-ошибок.
- * Основные модули: @playwright/test.
+ * Назначение файла: e2e-тест маршрута /login, проверка формы и индикатора загрузки без JS-ошибок.
+ * Основные модули: @playwright/test, express.
  */
 import { test, expect } from '@playwright/test';
+import express from 'express';
+import type { Server } from 'http';
+import type { AddressInfo } from 'net';
 
 const markup = `<!DOCTYPE html><html><body>
+<div id="loader">Загрузка...</div>
 <form id="login">
   <input placeholder="Telegram ID" />
   <button type="submit">Отправить</button>
@@ -12,14 +16,29 @@ const markup = `<!DOCTYPE html><html><body>
 <script>console.log('loaded');</script>
 </body></html>`;
 
-test('форма входа загружается без JS-ошибок', async ({ page }) => {
+const app = express();
+app.get('/login', (_req, res) => res.send(markup));
+const server: Server = app.listen(0);
+const { port } = server.address() as AddressInfo;
+
+test.use({ baseURL: `http://localhost:${port}` });
+
+test.afterAll(() => {
+  server.close();
+});
+
+test('страница /login рендерит форму и индикатор загрузки без ошибок', async ({
+  page,
+}) => {
   const errors: string[] = [];
   page.on('pageerror', (e) => errors.push(e.message));
   page.on('console', (msg) => {
     if (msg.type() === 'error') errors.push(msg.text());
   });
 
-  await page.setContent(markup);
+  await page.goto('/login');
   await expect(page.locator('form#login')).toBeVisible();
+  await expect(page.locator('#loader')).toBeVisible();
+
   expect(errors).toEqual([]);
 });


### PR DESCRIPTION
## Summary
- add Express-backed /login test via `page.goto`
- fail on console and page errors; assert form and loader

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm test:e2e`
- `./scripts/pre_pr_check.sh` *(failed: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68b024a4aaa483208488dcc79485b98b