### PR TITLE
feat: enforce session secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ CHAT_ID=your_chat_id
 # JWT_SECRET — строка для подписи JWT, придумайте её сами и никому не показывайте.
 JWT_SECRET=rotated_jwt_secret
 
+# SESSION_SECRET — секрет express-session. Обязателен.
+SESSION_SECRET=rotated_session_secret
+
 # JWT_MISSING_STATUS — текст ошибки при отсутствии или неверном JWT. Можно оставить как есть.
 JWT_MISSING_STATUS=Missing or invalid JWT token
 

--- a/apps/api/src/api/server.ts
+++ b/apps/api/src/api/server.ts
@@ -24,6 +24,11 @@ process.on('uncaughtException', (err) => {
 
 const execAsync = promisify(exec);
 
+const sessionSecret = process.env.SESSION_SECRET ?? '';
+if (!sessionSecret) {
+  throw new Error('Переменная SESSION_SECRET не задана');
+}
+
 export async function buildApp(): Promise<express.Express> {
   const { default: connect } = await import('../db/connection');
   await connect();
@@ -79,7 +84,7 @@ export async function buildApp(): Promise<express.Express> {
     ...(domain ? { domain } : {}),
   };
   const sessionOpts: session.SessionOptions = {
-    secret: process.env.SESSION_SECRET || 'session_secret',
+    secret: sessionSecret,
     resave: false,
     saveUninitialized: false,
     cookie: { ...cookieFlags, maxAge: 7 * 24 * 60 * 60 * 1000 },

--- a/scripts/pre_pr_check.sh
+++ b/scripts/pre_pr_check.sh
@@ -6,6 +6,15 @@ cd "$(dirname "$0")/.."
 
 ./scripts/create_env_from_exports.sh >/dev/null || true
 
+# Проверяем наличие SESSION_SECRET
+if ! grep -q '^SESSION_SECRET=' .env || \
+  [ -z "$(grep '^SESSION_SECRET=' .env | cut -d= -f2-)" ]; then
+  echo "SESSION_SECRET не задан" >&2
+  exit 1
+fi
+
+cp .env apps/.env
+
 ./scripts/audit_deps.sh
 
 ./scripts/build_client.sh >/dev/null


### PR DESCRIPTION
## Summary
- require SESSION_SECRET to be set before starting API server
- document SESSION_SECRET in .env.example
- ensure pre_pr_check verifies SESSION_SECRET and copies env file for runtime

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68b036a70e7c832088a1086ccc63ff1a