### PR TITLE
feat: проверка переменных маршрутов

### DIFF
--- a/apps/api/src/services/route.ts
+++ b/apps/api/src/services/route.ts
@@ -6,10 +6,26 @@ import { getTrace } from '../utils/trace';
 import { cacheGet, cacheSet, cacheClear } from '../utils/cache';
 
 const tableGuard = process.env.ROUTE_TABLE_GUARD !== '0';
-const tableMaxPoints = Number(process.env.ROUTE_TABLE_MAX_POINTS || '100');
-const tableMinInterval = Number(
-  process.env.ROUTE_TABLE_MIN_INTERVAL_MS || '200',
+const defaultTableMaxPoints = 100;
+let tableMaxPoints = Number(
+  process.env.ROUTE_TABLE_MAX_POINTS || defaultTableMaxPoints,
 );
+if (!Number.isFinite(tableMaxPoints) || tableMaxPoints <= 0) {
+  console.warn(
+    `ROUTE_TABLE_MAX_POINTS должен быть положительным. Используется значение по умолчанию ${defaultTableMaxPoints}`,
+  );
+  tableMaxPoints = defaultTableMaxPoints;
+}
+const defaultTableMinInterval = 200;
+let tableMinInterval = Number(
+  process.env.ROUTE_TABLE_MIN_INTERVAL_MS || defaultTableMinInterval,
+);
+if (!Number.isFinite(tableMinInterval) || tableMinInterval <= 0) {
+  console.warn(
+    `ROUTE_TABLE_MIN_INTERVAL_MS должен быть положительным. Используется значение по умолчанию ${defaultTableMinInterval}`,
+  );
+  tableMinInterval = defaultTableMinInterval;
+}
 let tableLastCall = 0;
 
 const base = routingUrl.replace(/\/route$/, '');

--- a/apps/api/tests/routeValidation.test.ts
+++ b/apps/api/tests/routeValidation.test.ts
@@ -1,5 +1,5 @@
 // Назначение: автотесты. Модули: jest, supertest.
-// Тесты проверки координат сервиса маршрутов
+// Тесты проверки координат и переменных сервиса маршрутов
 process.env.NODE_ENV = 'test';
 process.env.BOT_TOKEN = 't';
 process.env.CHAT_ID = '1';
@@ -8,16 +8,67 @@ process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
 process.env.APP_URL = 'https://localhost';
 process.env.ROUTING_URL = 'https://localhost:8000/route';
 
-const { table } = require('../src/services/route');
-
 afterEach(() => {
   jest.resetAllMocks();
+  jest.resetModules();
+  jest.restoreAllMocks();
+  delete process.env.ROUTE_TABLE_MAX_POINTS;
+  delete process.env.ROUTE_TABLE_MIN_INTERVAL_MS;
+  delete process.env.ROUTE_TABLE_GUARD;
 });
 
 test('table отклоняет некорректные координаты', async () => {
+  jest.doMock('../src/metrics', () => ({
+    osrmRequestDuration: { startTimer: () => () => {} },
+    osrmErrorsTotal: { inc: jest.fn() },
+  }));
+  const { table } = require('../src/services/route');
   global.fetch = jest.fn();
   await expect(table('1,1;../../../etc', {})).rejects.toThrow(
     'Некорректные координаты',
   );
   expect(fetch).not.toHaveBeenCalled();
+});
+
+test('использует дефолт ROUTE_TABLE_MAX_POINTS при отрицательном значении', async () => {
+  process.env.ROUTE_TABLE_GUARD = '1';
+  process.env.ROUTE_TABLE_MAX_POINTS = '-1';
+  const warn = jest.spyOn(console, 'warn').mockImplementation();
+  jest.doMock('../src/metrics', () => ({
+    osrmRequestDuration: { startTimer: () => () => {} },
+    osrmErrorsTotal: { inc: jest.fn() },
+  }));
+  const { table } = require('../src/services/route');
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({}),
+  });
+  await expect(table('1,1;2,2', {})).resolves.toBeDefined();
+  expect(fetch).toHaveBeenCalled();
+  expect(warn).toHaveBeenCalledWith(
+    'ROUTE_TABLE_MAX_POINTS должен быть положительным. Используется значение по умолчанию 100',
+  );
+});
+
+test('использует дефолт ROUTE_TABLE_MIN_INTERVAL_MS при отрицательном значении', async () => {
+  process.env.ROUTE_TABLE_GUARD = '1';
+  process.env.ROUTE_TABLE_MIN_INTERVAL_MS = '-5';
+  const warn = jest.spyOn(console, 'warn').mockImplementation();
+  jest.doMock('../src/metrics', () => ({
+    osrmRequestDuration: { startTimer: () => () => {} },
+    osrmErrorsTotal: { inc: jest.fn() },
+  }));
+  const { table } = require('../src/services/route');
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({}),
+  });
+  await table('1,1;2,2', {});
+  const mid = Date.now();
+  await table('1,1;2,2', {});
+  const diff = Date.now() - mid;
+  expect(diff).toBeGreaterThanOrEqual(190);
+  expect(warn).toHaveBeenCalledWith(
+    'ROUTE_TABLE_MIN_INTERVAL_MS должен быть положительным. Используется значение по умолчанию 200',
+  );
 });

--- a/scripts/pre_pr_check.sh
+++ b/scripts/pre_pr_check.sh
@@ -21,9 +21,13 @@ done
 ./scripts/create_env_from_exports.sh >/dev/null || true
 
 # Проверяем наличие SESSION_SECRET
-if ! grep -q '^SESSION_SECRET=' .env || \
-  [ -z "$(grep '^SESSION_SECRET=' .env | cut -d= -f2-)" ]; then
+secret=$(grep '^SESSION_SECRET=' .env | cut -d= -f2-)
+if [ -z "$secret" ]; then
   echo "SESSION_SECRET не задан" >&2
+  exit 1
+fi
+if [ ${#secret} -lt 64 ]; then
+  echo "SESSION_SECRET короче 64 символов" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- проверить переменные маршрутов на положительность и падать на дефолты с предупреждением
- протестировать неверные значения переменных
- проверять длину SESSION_SECRET в pre_pr_check

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh` *(failed: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68b04e8ce78c8320b364ff1410d31eb1