### PR TITLE
test: добавить тест AuthProvider

### DIFF
--- a/apps/web/eslint.config.ts
+++ b/apps/web/eslint.config.ts
@@ -15,7 +15,7 @@ const config = [
     files: ["**/*.{js,jsx,ts,tsx}"],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: { ...globals.browser, ...globals.jest },
       parserOptions: {
         ecmaVersion: "latest",
         ecmaFeatures: { jsx: true },

--- a/apps/web/src/context/AuthProvider.test.tsx
+++ b/apps/web/src/context/AuthProvider.test.tsx
@@ -1,0 +1,54 @@
+/** @jest-environment jsdom */
+// Назначение файла: проверяет, что AuthProvider передаёт объект контекста и сбрасывает пользователя при logout.
+// Основные модули: React, @testing-library/react, AuthProvider, AuthContext.
+import { useContext } from "react";
+import { render, act } from "@testing-library/react";
+import { AuthProvider } from "./AuthProvider";
+import { AuthContext } from "./AuthContext";
+
+jest.mock("../services/auth", () => ({
+  getProfile: jest.fn().mockResolvedValue(null),
+  logout: jest.fn().mockResolvedValue(undefined),
+}));
+
+globalThis.fetch = jest.fn(
+  () => Promise.resolve({ json: () => Promise.resolve({}) }) as any,
+) as any;
+
+describe("AuthProvider", () => {
+  it("возвращает объект контекста", () => {
+    let value: any;
+    function Child() {
+      value = useContext(AuthContext);
+      return null;
+    }
+    render(
+      <AuthProvider>
+        <Child />
+      </AuthProvider>,
+    );
+    expect(typeof value).toBe("object");
+    expect(value.user).toBeNull();
+  });
+
+  it("logout сбрасывает user", async () => {
+    let value: any;
+    function Child() {
+      value = useContext(AuthContext);
+      return null;
+    }
+    render(
+      <AuthProvider>
+        <Child />
+      </AuthProvider>,
+    );
+    act(() => {
+      value.setUser({ id: "1" } as any);
+    });
+    expect(value.user).not.toBeNull();
+    await act(async () => {
+      await value.logout();
+    });
+    expect(value.user).toBeNull();
+  });
+});

--- a/apps/web/src/services/auth.ts
+++ b/apps/web/src/services/auth.ts
@@ -8,6 +8,7 @@ interface FetchOptions {
   method?: string;
   headers?: Record<string, string>;
   body?: string;
+  noRedirect?: boolean;
 }
 
 export const getProfile = async (options?: FetchOptions): Promise<User> => {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,8 +7,12 @@ import type { Config } from 'jest';
 const config: Config = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  roots: ['<rootDir>/tests'],
-  testPathIgnorePatterns: ['<rootDir>/tests/e2e/', '<rootDir>/tests/api/'],
+  roots: ['<rootDir>/tests', '<rootDir>/apps/web/src'],
+  testPathIgnorePatterns: [
+    '<rootDir>/tests/e2e/',
+    '<rootDir>/tests/api/',
+    '<rootDir>/apps/web/src/types/',
+  ],
   setupFiles: ['<rootDir>/tests/setupEnv.ts'],
   coverageDirectory: 'coverage',
   transform: {


### PR DESCRIPTION
## Summary
- add unit test for AuthProvider context and logout
- allow AuthProvider to request profile without redirect
- include web src in jest config and enable Jest globals in lint

## Testing
- `pnpm lint`
- `pnpm test:unit apps/web/src/context/AuthProvider.test.tsx`
- `pnpm test:api`
- `pnpm test:e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*
- `pnpm build`
- `pnpm size`
- `pnpm run dev`

------
https://chatgpt.com/codex/tasks/task_b_68b14f9ae44483209931decebda5da24