### PR TITLE
feat: copy web build into api public directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,11 @@ RUN corepack enable \
   && pnpm config set fetch-retries 5 \
   && pnpm fetch
 
-# Копирование исходников, сборка сервера и клиента
+# Копирование исходников, сборка сервера и клиента, перенос фронтенда в public API
 COPY . .
 RUN pnpm install --offline --frozen-lockfile || pnpm install \
   && pnpm build \
+  && cp -r apps/web/dist/* apps/api/public/ \
   && pnpm prune --prod \
   && pnpm store prune
 


### PR DESCRIPTION
## Summary
- copy built web assets into API public dir inside Docker image

## Testing
- `pnpm format`
- `./scripts/setup_and_test.sh`
- `docker compose config`
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*
- `docker build -t erm-bot-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_b_68b19cefe73c8320a7bc19e81837e639