### PR TITLE
fix: handle missing web dist in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,11 @@ RUN corepack enable \
   && pnpm config set fetch-retries 5 \
   && pnpm fetch
 
-# Копирование исходников, сборка сервера и клиента, перенос фронтенда в public API
+# Копирование исходников, сборка сервера и клиента, перенос фронтенда в public API при наличии dist
 COPY . .
 RUN pnpm install --offline --frozen-lockfile || pnpm install \
   && pnpm build \
-  && cp -r apps/web/dist/* apps/api/public/ \
+  && if [ -d apps/web/dist ]; then cp -r apps/web/dist/* apps/api/public/; fi \
   && pnpm prune --prod \
   && pnpm store prune
 


### PR DESCRIPTION
## Summary
- copy web assets only if dist exists during Docker build

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68b1c392076c8320bc29f221ec34ebcc