### PR TITLE
fix: корректная сборка SPA

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -12,7 +12,11 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "resolveJsonModule": true,
-    "typeRoots": ["./node_modules/@types", "../../node_modules/@types"],
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../node_modules/@types",
+      "./src/types"
+    ],
     "composite": true,
     "paths": {
       "shared": ["../../packages/shared/dist"],

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -14,20 +14,22 @@ import { visualizer } from "rollup-plugin-visualizer";
 
 /**
  * Плагин сохраняет `index.html` с уведомлением, чтобы Vite не удалял файл при
- * очистке каталога.
+ * очистке каталога. В продакшн-сборке не восстанавливает файл, если переменная
+ * `RESTORE_PLACEHOLDER` не равна `1`.
  */
 function preserveIndexHtml() {
   const indexPath = resolve(__dirname, "../api/public/index.html");
+  const restore = process.env.RESTORE_PLACEHOLDER === "1";
   let original = "";
   return {
     name: "preserve-index-html",
     buildStart() {
-      if (existsSync(indexPath)) {
+      if (restore && existsSync(indexPath)) {
         original = readFileSync(indexPath, "utf8");
       }
     },
     closeBundle() {
-      if (original) {
+      if (restore && original) {
         writeFileSync(indexPath, original);
       }
     },


### PR DESCRIPTION
## Описание
- не восстанавливаем заглушку `index.html` в продакшн-сборке
- добавлены локальные типы в `typeRoots` для dev-сервера

## Чеклист
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [ ] `pnpm run dev`

## Самопроверка
- [x] код соответствует стилю проекта
- [x] нет лишних артефактов сборки
- [x] сообщение об ошибке SPA больше не появляется после сборки

## Риски
- при установке переменной `RESTORE_PLACEHOLDER=1` заглушка восстановится
- dev-сервер требует доступный MongoDB

------
https://chatgpt.com/codex/tasks/task_b_68b1c7aa52448320be434edc7c63efd3