### PR TITLE
feat: add task formdata builder

### DIFF
--- a/apps/web/src/services/buildTaskFormData.ts
+++ b/apps/web/src/services/buildTaskFormData.ts
@@ -1,0 +1,27 @@
+// Назначение: создание FormData для задач
+// Основные модули: FormSchema
+import formSchemaJson from "../../../api/src/form/taskForm.schema.json";
+import type { FormSchema } from "../../../api/src/form";
+
+const formSchema = formSchemaJson as FormSchema;
+
+export const buildTaskFormData = (
+  data: Record<string, unknown>,
+  files?: FileList | File[],
+): FormData => {
+  const body = new FormData();
+  body.append("formVersion", String(formSchema.formVersion));
+  Object.entries(data).forEach(([k, v]) => {
+    if (v === undefined || v === null) return;
+    if (Array.isArray(v)) {
+      if (v.length === 0) return;
+      v.forEach((val) => body.append(k, String(val)));
+    } else if (typeof v === "object") {
+      body.append(k, JSON.stringify(v));
+    } else {
+      body.append(k, String(v));
+    }
+  });
+  if (files) Array.from(files).forEach((f) => body.append("files", f));
+  return body;
+};

--- a/apps/web/src/services/tasks.ts
+++ b/apps/web/src/services/tasks.ts
@@ -1,7 +1,7 @@
 // Назначение: запросы к API задач
-// Основные модули: authFetch
+// Основные модули: authFetch, buildTaskFormData
 import authFetch from "../utils/authFetch";
-import formSchema from "../../../api/src/form/taskForm.schema.json";
+import { buildTaskFormData } from "./buildTaskFormData";
 
 export const fetchKanban = () =>
   authFetch("/api/v1/tasks?kanban=true")
@@ -22,20 +22,7 @@ export const createTask = (
   files?: FileList | File[],
   onProgress?: (e: ProgressEvent) => void,
 ) => {
-  const body = new FormData();
-  body.append("formVersion", String((formSchema as any).formVersion));
-  Object.entries(data).forEach(([k, v]) => {
-    if (v === undefined || v === null) return;
-    if (Array.isArray(v)) {
-      if (v.length === 0) return;
-      v.forEach((val) => body.append(k, String(val)));
-    } else if (typeof v === "object") {
-      body.append(k, JSON.stringify(v));
-    } else {
-      body.append(k, String(v));
-    }
-  });
-  if (files) Array.from(files).forEach((f) => body.append("files", f));
+  const body = buildTaskFormData(data, files);
   return authFetch("/api/v1/tasks", { method: "POST", body, onProgress }).then(
     async (r) => {
       if (!r.ok) return null;
@@ -60,20 +47,7 @@ export const updateTask = (
   files?: FileList | File[],
   onProgress?: (e: ProgressEvent) => void,
 ) => {
-  const body = new FormData();
-  body.append("formVersion", String((formSchema as any).formVersion));
-  Object.entries(data).forEach(([k, v]) => {
-    if (v === undefined || v === null) return;
-    if (Array.isArray(v)) {
-      if (v.length === 0) return;
-      v.forEach((val) => body.append(k, String(val)));
-    } else if (typeof v === "object") {
-      body.append(k, JSON.stringify(v));
-    } else {
-      body.append(k, String(v));
-    }
-  });
-  if (files) Array.from(files).forEach((f) => body.append("files", f));
+  const body = buildTaskFormData(data, files);
   return authFetch(`/api/v1/tasks/${id}`, {
     method: "PATCH",
     body,


### PR DESCRIPTION
## Summary
- вынесена сборка FormData задачи в отдельный сервис
- createTask и updateTask используют общий билдёр

## Testing
- `pnpm lint`
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68b1e42273788320837ffb199e4edf13