### PR TITLE
feat(web): типы Telegram WebApp

### DIFF
--- a/apps/web/src/services/tasks.ts
+++ b/apps/web/src/services/tasks.ts
@@ -26,10 +26,10 @@ export const createTask = (
   return authFetch("/api/v1/tasks", { method: "POST", body, onProgress }).then(
     async (r) => {
       if (!r.ok) return null;
-      const result = await r.json();
-      const id = (result as any)._id || (result as any).id;
-      if (id && (window as any).Telegram?.WebApp) {
-        (window as any).Telegram.WebApp.sendData(`task_created:${id}`);
+      const result = (await r.json()) as { _id?: string; id?: string };
+      const id = result._id || result.id;
+      if (id && window.Telegram?.WebApp) {
+        window.Telegram.WebApp.sendData(`task_created:${id}`);
       }
       return result;
     },

--- a/apps/web/src/types/telegram.d.ts
+++ b/apps/web/src/types/telegram.d.ts
@@ -1,0 +1,25 @@
+// Назначение файла: объявления интерфейсов Telegram WebApp
+// Основные модули: Telegram.WebApp
+
+/* eslint-disable no-redeclare */
+interface Telegram {
+  WebApp?: Telegram.WebApp;
+}
+
+declare namespace Telegram {
+  interface WebApp {
+    initData: string;
+    initDataUnsafe: Record<string, unknown>;
+    sendData(data: string): void;
+    translate?(key: string): string;
+  }
+}
+/* eslint-enable no-redeclare */
+
+declare global {
+  interface Window {
+    Telegram?: Telegram;
+  }
+}
+
+export {};

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -24,7 +24,8 @@
       "shared": ["../../packages/shared/src"],
       "shared/*": ["../../packages/shared/src/*"]
     },
-    "composite": true
+    "composite": true,
+    "types": ["vite/client", "./src/types/telegram"]
   },
   "include": ["src"],
   "references": [{ "path": "../../packages/shared" }]


### PR DESCRIPTION
## Что сделано
- добавлены глобальные объявления `Telegram` и `Telegram.WebApp`
- подключены типы в `tsconfig.json`
- убрано приведение `window as any` при отправке данных

## Почему
Улучшена типизация и убраны `any` при работе с мини‑приложением Telegram.

## Чек‑лист
- [x] `pnpm install`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm run dev`
- [x] `./scripts/setup_and_test.sh`
- [ ] `./scripts/pre_pr_check.sh`

## Самопроверка
- [x] Нет лишних изменений
- [x] Код отформатирован
- [x] Комментарии на русском
- [x] Типы объявлены глобально
- [x] WebApp используется без `any`


------
https://chatgpt.com/codex/tasks/task_b_68b1e85613308320b2f844ccc57b75b6