### PR TITLE
feat: устранение дублирования React в Vite

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -53,6 +53,7 @@
     "react-router-dom": "^7.6.2",
     "react-select": "^5.10.2",
     "shared": "workspace:*",
+    "use-sync-external-store": "^1.5.0",
     "tailwind-merge": "^3.3.1",
     "validator": "^13.15.15",
     "zod": "^3.25.76"

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -56,6 +56,8 @@ export default defineConfig(() => ({
       "@": resolve(__dirname, "src"),
       shared: resolve(__dirname, "../../packages/shared/src"),
     },
+    // Устранение дублирования React в пакете
+    dedupe: ["react", "react-dom", "use-sync-external-store"],
   },
   build: {
     emptyOutDir: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -487,6 +487,9 @@ importers:
       shared:
         specifier: workspace:*
         version: link:../../packages/shared
+      use-sync-external-store:
+        specifier: ^1.5.0
+        version: 1.5.0(react@18.2.0)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1


### PR DESCRIPTION
## Summary
- исключено дублирование React и use-sync-external-store через Vite `resolve.dedupe`
- добавлена явная зависимость `use-sync-external-store`

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm build` *(apps/web построен успешно)*
- `./scripts/pre_pr_check.sh` *(не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68b2aa929ce483208d781165745f23cd