### PR TITLE
feat: remove debug log from Routes page

### DIFF
--- a/apps/web/src/pages/Routes.tsx
+++ b/apps/web/src/pages/Routes.tsx
@@ -47,7 +47,6 @@ export default function RoutesPage() {
         _id: t._id ?? t.id,
         ...t,
       }));
-      console.log("rows", list.length, list[0]);
       setTasks(list);
       setSorted(list);
     });


### PR DESCRIPTION
## Summary
- remove leftover console.log from route list loader

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(fails: apps/web build failed)*
- `pnpm run dev` *(fails: apps/api dev process exit 1)*
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh` *(fails: repeated apps/api build failures)*

------
https://chatgpt.com/codex/tasks/task_b_68b2b200622483209ace20fab51f7888