### PR TITLE
feat: handle localStorage overflow

### DIFF
--- a/apps/web/src/services/tasks.storage.spec.ts
+++ b/apps/web/src/services/tasks.storage.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * Назначение файла: проверка fetchTasks при переполненном localStorage.
+ * Основные модули: fetchTasks.
+ */
+jest.mock("../utils/authFetch", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+declare global {
+  interface Window {
+    Telegram?: {
+      WebApp?: {
+        sendData: (data: string) => void;
+      };
+    };
+  }
+}
+
+import authFetch from "../utils/authFetch";
+import { fetchTasks } from "./tasks";
+
+describe("fetchTasks", () => {
+  test("игнорирует переполнение localStorage", async () => {
+    const data = { tasks: [], users: [], total: 0 };
+    (authFetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => data,
+    });
+    const setItem = jest.fn(() => {
+      throw new Error("QuotaExceededError");
+    });
+    (globalThis as any).localStorage = {
+      getItem: () => "",
+      setItem,
+    };
+    const res = await fetchTasks();
+    expect(res).toEqual(data);
+    expect(setItem).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/services/tasks.ts
+++ b/apps/web/src/services/tasks.ts
@@ -81,7 +81,14 @@ export const fetchTasks = (
   return authFetch(url)
     .then((r) => (r.ok ? r.json() : { tasks: [], users: [], total: 0 }))
     .then((d) => {
-      localStorage.setItem(key, JSON.stringify({ time: Date.now(), data: d }));
+      try {
+        localStorage.setItem(
+          key,
+          JSON.stringify({ time: Date.now(), data: d }),
+        );
+      } catch {
+        // игнорируем переполнение
+      }
       return d;
     });
 };


### PR DESCRIPTION
## Summary
- wrap localStorage.setItem with try-catch to ignore quota errors
- add unit test for storage overflow scenario

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm test:unit`
- `pnpm test` *(fails: missing Playwright browsers)*
- `pnpm build`
- `pnpm run dev`
- `pnpm size`
- `pnpm a11y` *(fails: Module '"node:http"' has no default export)*
- `./scripts/pre_pr_check.sh` *(fails: bot did not start)*

------
https://chatgpt.com/codex/tasks/task_b_68b2c75cbfd083208d478041e558ef04