### PR TITLE
feat: вынесены действия аутентификации в хук useAuth

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -25,7 +25,7 @@ import { SidebarProvider } from "./context/SidebarContext";
 import { useSidebar } from "./context/useSidebar";
 import { ThemeProvider } from "./context/ThemeProvider";
 import { AuthProvider } from "./context/AuthProvider";
-import { AuthContext } from "./context/AuthContext";
+import { useAuth } from "./context/useAuth";
 import { ToastProvider } from "./context/ToastContext";
 import { TasksProvider } from "./context/TasksContext";
 import Toasts from "./components/Toasts";
@@ -124,7 +124,7 @@ function Content() {
 }
 
 function Layout() {
-  const { user } = React.useContext(AuthContext);
+  const { user } = useAuth();
   const { open, toggle } = useSidebar();
   return (
     <>

--- a/apps/web/src/components/AdminRoute.tsx
+++ b/apps/web/src/components/AdminRoute.tsx
@@ -1,11 +1,12 @@
 // Маршрут только для админа
-import { useContext, type ReactElement } from "react";
+// Модули: React Router, хук useAuth
+import { type ReactElement } from "react";
 import { Navigate } from "react-router-dom";
-import { AuthContext } from "../context/AuthContext";
+import { useAuth } from "../context/useAuth";
 import Loader from "./Loader";
 
 export default function AdminRoute({ children }: { children: ReactElement }) {
-  const { user, loading } = useContext(AuthContext);
+  const { user, loading } = useAuth();
   if (loading) return <Loader />;
   if (!user) return <Navigate to="/login" />;
   if (user.role !== "admin") return <Navigate to="/tasks" />;

--- a/apps/web/src/components/ProtectedRoute.tsx
+++ b/apps/web/src/components/ProtectedRoute.tsx
@@ -1,6 +1,6 @@
-// Назначение: защита маршрута, модули: React, React Router
-import { useContext, type ReactNode } from "react";
-import { AuthContext } from "../context/AuthContext";
+// Назначение: защита маршрута, модули: React Router и хук useAuth
+import { type ReactNode } from "react";
+import { useAuth } from "../context/useAuth";
 import { Navigate } from "react-router-dom";
 import Loader from "./Loader";
 
@@ -9,7 +9,7 @@ interface ProtectedRouteProps {
 }
 
 export default function ProtectedRoute({ children }: ProtectedRouteProps) {
-  const { user, loading } = useContext(AuthContext);
+  const { user, loading } = useAuth();
   if (loading) return <Loader />;
   return user ? children : <Navigate to="/login" />;
 }

--- a/apps/web/src/components/TaskDialog.tsx
+++ b/apps/web/src/components/TaskDialog.tsx
@@ -1,10 +1,10 @@
 // Общая форма создания и редактирования задач
 // Модули: React, DOMPurify, контексты, сервисы задач, shared и логов
-import React, { useContext } from "react";
+import React from "react";
 import DOMPurify from "dompurify";
 import CKEditorPopup from "./CKEditorPopup";
 import MultiUserSelect from "./MultiUserSelect";
-import { AuthContext } from "../context/AuthContext";
+import { useAuth } from "../context/useAuth";
 import { taskFields as fields } from "shared";
 import {
   createTask,
@@ -39,7 +39,7 @@ interface Props {
 
 export default function TaskDialog({ onClose, onSave, id }: Props) {
   const isEdit = Boolean(id);
-  const { user } = useContext(AuthContext);
+  const { user } = useAuth();
   const isAdmin = user?.role === "admin";
   const [editing, setEditing] = React.useState(true);
   const [expanded, setExpanded] = React.useState(false);

--- a/apps/web/src/context/AuthActionsContext.ts
+++ b/apps/web/src/context/AuthActionsContext.ts
@@ -1,0 +1,13 @@
+// Контекст действий аутентификации
+import { createContext } from "react";
+import type { User } from "../types/user";
+
+interface AuthActionsContextType {
+  logout: () => Promise<void>;
+  setUser: (u: User | null) => void;
+}
+
+export const AuthActionsContext = createContext<AuthActionsContextType>({
+  logout: async () => {},
+  setUser: () => {},
+});

--- a/apps/web/src/context/AuthContext.ts
+++ b/apps/web/src/context/AuthContext.ts
@@ -5,13 +5,9 @@ import type { User } from "../types/user";
 interface AuthContextType {
   user: User | null;
   loading: boolean;
-  logout: () => Promise<void>;
-  setUser: (u: User | null) => void;
 }
 
 export const AuthContext = createContext<AuthContextType>({
   user: null,
   loading: true,
-  logout: async () => {},
-  setUser: () => {},
 });

--- a/apps/web/src/context/AuthProvider.test.tsx
+++ b/apps/web/src/context/AuthProvider.test.tsx
@@ -1,10 +1,9 @@
 /** @jest-environment jsdom */
 // Назначение файла: проверяет, что AuthProvider передаёт объект контекста и сбрасывает пользователя при logout.
-// Основные модули: React, @testing-library/react, AuthProvider, AuthContext.
-import { useContext } from "react";
+// Основные модули: React, @testing-library/react, AuthProvider, useAuth.
 import { render, act } from "@testing-library/react";
 import { AuthProvider } from "./AuthProvider";
-import { AuthContext } from "./AuthContext";
+import { useAuth } from "./useAuth";
 
 jest.mock("../services/auth", () => ({
   getProfile: jest.fn().mockResolvedValue(null),
@@ -19,7 +18,7 @@ describe("AuthProvider", () => {
   it("возвращает объект контекста", () => {
     let value: any;
     function Child() {
-      value = useContext(AuthContext);
+      value = useAuth();
       return null;
     }
     render(
@@ -34,7 +33,7 @@ describe("AuthProvider", () => {
   it("logout сбрасывает user", async () => {
     let value: any;
     function Child() {
-      value = useContext(AuthContext);
+      value = useAuth();
       return null;
     }
     render(

--- a/apps/web/src/context/AuthProvider.tsx
+++ b/apps/web/src/context/AuthProvider.tsx
@@ -1,8 +1,9 @@
 // Контекст аутентификации, запрашивает профиль и CSRF-токен, JWT не хранится
-// Модули: React, services/auth, AuthContext, utils/csrfToken
+// Модули: React, services/auth, AuthContext, AuthActionsContext, utils/csrfToken
 import { useEffect, useState, type ReactNode } from "react";
 import { getProfile, logout as apiLogout } from "../services/auth";
 import { AuthContext } from "./AuthContext";
+import { AuthActionsContext } from "./AuthActionsContext";
 import { setCsrfToken } from "../utils/csrfToken";
 import type { User } from "../types/user";
 
@@ -50,8 +51,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
     setUser(null);
   };
   return (
-    <AuthContext.Provider value={{ user, loading, logout, setUser }}>
-      {children}
+    <AuthContext.Provider value={{ user, loading }}>
+      <AuthActionsContext.Provider value={{ setUser, logout }}>
+        {children}
+      </AuthActionsContext.Provider>
     </AuthContext.Provider>
   );
 }

--- a/apps/web/src/context/useAuth.ts
+++ b/apps/web/src/context/useAuth.ts
@@ -1,0 +1,10 @@
+// Хук доступа к данным и действиям аутентификации
+import { useContext } from "react";
+import { AuthContext } from "./AuthContext";
+import { AuthActionsContext } from "./AuthActionsContext";
+
+export function useAuth() {
+  const state = useContext(AuthContext);
+  const actions = useContext(AuthActionsContext);
+  return { ...state, ...actions };
+}

--- a/apps/web/src/layouts/Header.tsx
+++ b/apps/web/src/layouts/Header.tsx
@@ -1,8 +1,8 @@
 // Шапка приложения с кнопкой темы и бургером меню
 // Верхняя панель навигации
-import React, { useContext } from "react";
+import React from "react";
 import { useSidebar } from "../context/useSidebar";
-import { AuthContext } from "../context/AuthContext";
+import { useAuth } from "../context/useAuth";
 import NotificationDropdown from "../components/NotificationDropdown";
 import ThemeToggle from "../components/ThemeToggle";
 import { Bars3Icon, BellIcon } from "@heroicons/react/24/outline";
@@ -11,7 +11,7 @@ import { useTranslation } from "react-i18next";
 
 export default function Header() {
   const { toggle, collapsed, open } = useSidebar();
-  const { user } = useContext(AuthContext);
+  const { user } = useAuth();
   const { t, i18n } = useTranslation();
   return (
     <header

--- a/apps/web/src/layouts/Sidebar.tsx
+++ b/apps/web/src/layouts/Sidebar.tsx
@@ -1,8 +1,8 @@
 // Боковое меню с навигацией по разделам
-import React, { useContext } from "react";
+import React from "react";
 import { Link, useLocation } from "react-router-dom";
 import { useSidebar } from "../context/useSidebar";
-import { AuthContext } from "../context/AuthContext";
+import { useAuth } from "../context/useAuth";
 import {
   HomeIcon,
   ClipboardDocumentListIcon,
@@ -33,7 +33,7 @@ const adminExtra = [
 export default function Sidebar() {
   const { open, toggle, collapsed, toggleCollapsed } = useSidebar();
   const { pathname } = useLocation();
-  const { user } = useContext(AuthContext);
+  const { user } = useAuth();
   const role = user?.role || "user";
   const items = React.useMemo(() => {
     return role === "admin" ? [...baseItems, ...adminExtra] : baseItems;

--- a/apps/web/src/pages/Profile.tsx
+++ b/apps/web/src/pages/Profile.tsx
@@ -1,11 +1,11 @@
 // Назначение: страница профиля пользователя; модули: React, React Router
-import { useContext, useEffect, useState } from "react";
-import { AuthContext } from "../context/AuthContext";
+import { useEffect, useState } from "react";
+import { useAuth } from "../context/useAuth";
 import Breadcrumbs from "../components/Breadcrumbs";
 import { updateProfile } from "../services/auth";
 
 export default function Profile() {
-  const { user, setUser } = useContext(AuthContext);
+  const { user, setUser } = useAuth();
   const [name, setName] = useState("");
   const [mobNumber, setMobNumber] = useState("");
 

--- a/apps/web/src/pages/Routes.tsx
+++ b/apps/web/src/pages/Routes.tsx
@@ -1,5 +1,5 @@
 // Страница отображения маршрутов на карте с фильтрами
-import React, { useContext } from "react";
+import React from "react";
 import Breadcrumbs from "../components/Breadcrumbs";
 import fetchRouteGeometry from "../services/osrm";
 import { fetchTasks } from "../services/tasks";
@@ -9,7 +9,7 @@ import createMultiRouteLink from "../utils/createMultiRouteLink";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import { useNavigate, useLocation, useSearchParams } from "react-router-dom";
-import { AuthContext } from "../context/AuthContext";
+import { useAuth } from "../context/useAuth";
 import type { Task } from "shared";
 
 type RouteTask = Task & Record<string, any>;
@@ -26,7 +26,7 @@ export default function RoutesPage() {
   const location = useLocation();
   const [params] = useSearchParams();
   const hasDialog = params.has("task") || params.has("newTask");
-  const { user } = useContext(AuthContext);
+  const { user } = useAuth();
 
   const openTask = React.useCallback(
     (id: string) => {

--- a/apps/web/src/pages/TasksPage.tsx
+++ b/apps/web/src/pages/TasksPage.tsx
@@ -1,6 +1,6 @@
 // Назначение файла: список задач с таблицей AG Grid
 // Модули: React, контексты, сервисы задач, shared
-import React, { useContext } from "react";
+import React from "react";
 import { useSearchParams } from "react-router-dom";
 import TaskTable from "../components/TaskTable";
 import { useToast } from "../context/useToast";
@@ -8,7 +8,7 @@ import useTasks from "../context/useTasks";
 import { fetchTasks } from "../services/tasks";
 import authFetch from "../utils/authFetch";
 import { taskFields as fields, type Task, type User } from "shared";
-import { AuthContext } from "../context/AuthContext";
+import { useAuth } from "../context/useAuth";
 
 type TaskExtra = Task & Record<string, any>;
 
@@ -24,7 +24,7 @@ export default function TasksPage() {
   const [params, setParams] = useSearchParams();
   const { addToast } = useToast();
   const { version, refresh } = useTasks();
-  const { user } = useContext(AuthContext);
+  const { user } = useAuth();
   const isAdmin = user?.role === "admin";
 
   const load = React.useCallback(() => {

--- a/tests/route.loader.spec.tsx
+++ b/tests/route.loader.spec.tsx
@@ -7,20 +7,22 @@ import { render } from '@testing-library/react';
 import ProtectedRoute from '../apps/web/src/components/ProtectedRoute';
 import AdminRoute from '../apps/web/src/components/AdminRoute';
 import { AuthContext } from '../apps/web/src/context/AuthContext';
+import { AuthActionsContext } from '../apps/web/src/context/AuthActionsContext';
 
-const value = {
-  user: null,
-  loading: true,
+const state = { user: null, loading: true };
+const actions = {
   logout: jest.fn().mockResolvedValue(undefined),
   setUser: jest.fn(),
 };
 
 test('ProtectedRoute показывает индикатор при загрузке', () => {
   const { getByTestId } = render(
-    <AuthContext.Provider value={value}>
-      <ProtectedRoute>
-        <div>child</div>
-      </ProtectedRoute>
+    <AuthContext.Provider value={state}>
+      <AuthActionsContext.Provider value={actions}>
+        <ProtectedRoute>
+          <div>child</div>
+        </ProtectedRoute>
+      </AuthActionsContext.Provider>
     </AuthContext.Provider>,
   );
   expect(getByTestId('loader')).toBeInTheDocument();
@@ -28,10 +30,12 @@ test('ProtectedRoute показывает индикатор при загруз
 
 test('AdminRoute показывает индикатор при загрузке', () => {
   const { getByTestId } = render(
-    <AuthContext.Provider value={value}>
-      <AdminRoute>
-        <div>child</div>
-      </AdminRoute>
+    <AuthContext.Provider value={state}>
+      <AuthActionsContext.Provider value={actions}>
+        <AdminRoute>
+          <div>child</div>
+        </AdminRoute>
+      </AuthActionsContext.Provider>
     </AuthContext.Provider>,
   );
   expect(getByTestId('loader')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- оставить в AuthContext только данные профиля и флаг загрузки
- вынести logout и setUser в AuthActionsContext и хук useAuth
- обновить компоненты на использование useAuth

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm --dir apps/web run lint`
- `./scripts/pre_pr_check.sh` *(failed: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68b2da03289483209786ede0168607f1