### PR TITLE
test: limit task uploads

### DIFF
--- a/tests/tasks.upload.spec.ts
+++ b/tests/tasks.upload.spec.ts
@@ -5,6 +5,7 @@
 import express = require('express');
 import type { Request, RequestHandler } from 'express';
 import request = require('supertest');
+import rateLimit = require('express-rate-limit');
 // @ts-ignore
 import multer from '../apps/api/node_modules/multer';
 import * as path from 'path';
@@ -36,9 +37,11 @@ const setUser: RequestHandler = (req, _res, next) => {
   (req as any).user = { id: 1 };
   next();
 };
+const limiter = rateLimit({ windowMs: 60 * 1000, max: 50 });
 app.post(
   '/tasks',
   setUser,
+  limiter,
   upload.any() as any,
   processUploads as unknown as RequestHandler,
   (req, res) => {


### PR DESCRIPTION
## Summary
- ensure task upload route under test has basic rate limiting

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68b2edc689e483208e249ae9b0e564e5