### PR TITLE
fix: add express-rate-limit for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # История изменений
 
+- В корневые devDependencies добавлен `express-rate-limit`, исправлен сбой теста `tasks.upload.spec.ts`.
 - Скрипт `pre_pr_check.sh` поднимает MongoDB в памяти, `check_mongo.mjs` пропускает проверку при `CI=true`, обновлена документация переменной `MONGO_DATABASE_URL`.
 - `SESSION_SECRET` в `.env.example` пуст, добавлена команда генерации и предупреждение о коммите.
 - Исправлен запуск клиента: инициализация откладывается до `DOMContentLoaded`,

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "audit-ci": "^7.1.0",
     "eslint": "^9.29.0",
     "express": "^4.19.2",
+    "express-rate-limit": "^7.5.1",
     "globals": "^14.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       express:
         specifier: ^4.19.2
         version: 4.21.2
+      express-rate-limit:
+        specifier: ^7.5.1
+        version: 7.5.1(express@4.21.2)
       globals:
         specifier: ^14.0.0
         version: 14.0.0

--- a/tests/tasks.upload.spec.ts
+++ b/tests/tasks.upload.spec.ts
@@ -5,7 +5,7 @@
 import express = require('express');
 import type { Request, RequestHandler } from 'express';
 import request = require('supertest');
-import rateLimit = require('express-rate-limit');
+import rateLimit from 'express-rate-limit';
 // @ts-ignore
 import multer from '../apps/api/node_modules/multer';
 import * as path from 'path';


### PR DESCRIPTION
## Summary
- include express-rate-limit in root dev deps
- update tasks.upload spec import
- note change in changelog

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm test`
- `pnpm build`
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68b2f2481d048320b3b0abccb114bed6