### PR TITLE
fix: заменить алиасы на относительные импорты

### DIFF
--- a/apps/web/src/components/NotificationDropdown.tsx
+++ b/apps/web/src/components/NotificationDropdown.tsx
@@ -1,13 +1,14 @@
-// Выпадающий список уведомлений
+// Назначение: выпадающий список уведомлений.
+// Основные модули: React, react-i18next, shadcn/ui.
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { Button } from "@/components/ui/button";
+import { Button } from "./ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+} from "./ui/dropdown-menu";
 
 export default function NotificationDropdown({
   notifications,


### PR DESCRIPTION
## Summary
- заменить алиасы на относительные импорты в NotificationDropdown
- проверены конфигурации alias

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm build`
- `pnpm test`
- `./scripts/pre_pr_check.sh` *(fail: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68b3292510ac83208146a434a7937222