### PR TITLE
fix: корректные типы Telegram и authFetch в тестах

### DIFF
--- a/apps/web/src/utils/authFetch.ts
+++ b/apps/web/src/utils/authFetch.ts
@@ -3,12 +3,9 @@
 // Основные модули: fetch, XMLHttpRequest, window.location, localStorage
 import { getCsrfToken, setCsrfToken } from "./csrfToken";
 
-interface FetchOptions {
-  method?: string;
+interface FetchOptions extends globalThis.RequestInit {
   headers?: Record<string, string>;
-  body?: unknown;
-  credentials?: string;
-  redirect?: string;
+  body?: globalThis.BodyInit | null;
   [key: string]: unknown;
 }
 

--- a/tests/attachment.menu.spec.tsx
+++ b/tests/attachment.menu.spec.tsx
@@ -1,4 +1,5 @@
 /** @jest-environment jsdom */
+/// <reference path="../apps/web/src/types/telegram.d.ts" />
 // Назначение файла: проверяет отсутствие перезагрузки при 401 в AttachmentMenu.
 // Основные модули: React, @testing-library/react.
 import '@testing-library/jest-dom';
@@ -13,9 +14,7 @@ test('не перезагружает страницу при 401', async () => 
   const removeToast = jest.fn();
   const originalHref = window.location.href;
   const originalFetch = global.fetch;
-  global.fetch = jest
-    .fn()
-    .mockResolvedValue(new Response(null, { status: 401 })) as any;
+  global.fetch = jest.fn().mockResolvedValue({ status: 401 } as Response);
   render(
     <ToastContext.Provider value={{ toasts: [], addToast, removeToast }}>
       <AttachmentMenu />

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -12,7 +12,14 @@
     "emitDecoratorMetadata": true,
     "resolveJsonModule": true,
     "allowJs": true,
-    "types": ["node", "jest", "@testing-library/jest-dom", "express", "multer"],
+    "types": [
+      "node",
+      "jest",
+      "@testing-library/jest-dom",
+      "express",
+      "multer",
+      "../apps/web/src/types/telegram"
+    ],
     "typeRoots": ["../node_modules/@types", "../apps/api/src/types"]
   }
 }


### PR DESCRIPTION
## Summary
- include Telegram WebApp typings in test tsconfig
- adjust authFetch options to extend DOM RequestInit
- stabilize AttachmentMenu test by referencing Telegram types and mocking fetch

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_68b40a12f484832090256336a2c0406b