### PR TITLE
fix: prevent messageQueue leaks in tests

### DIFF
--- a/apps/api/src/services/messageQueue.ts
+++ b/apps/api/src/services/messageQueue.ts
@@ -1,5 +1,7 @@
-// Очередь вызовов Telegram API с ограничением объёма
-// Модули: Promise, setInterval
+/**
+ * Назначение файла: очередь вызовов Telegram API с ограничением объёма.
+ * Основные модули: Promise, setInterval.
+ */
 
 interface QueueItem<T> {
   fn: () => Promise<T> | T;
@@ -12,7 +14,7 @@ export const MAX_QUEUE_SIZE = 100;
 let tokens = 30;
 let timer: NodeJS.Timeout | undefined;
 
-function process(): void {
+function processQueue(): void {
   while (tokens > 0 && queue.length) {
     tokens--;
     const { fn, resolve, reject } = queue.shift()!;
@@ -26,15 +28,18 @@ function process(): void {
   }
 }
 
-function start(): void {
+export function startQueue(): void {
   if (!timer) {
     timer = setInterval(() => {
       tokens = 30;
-      process();
+      processQueue();
     }, 1000);
   }
 }
-start();
+
+if (process.env.NODE_ENV !== 'test') {
+  startQueue();
+}
 
 export function stopQueue(): void {
   if (timer) {
@@ -55,6 +60,6 @@ export function enqueue<T>(fn: () => Promise<T> | T): Promise<T> {
       resolve: resolve as unknown as (value: unknown) => void,
       reject,
     });
-    process();
+    processQueue();
   });
 }

--- a/apps/web/src/services/tasks.storage.spec.ts
+++ b/apps/web/src/services/tasks.storage.spec.ts
@@ -9,11 +9,7 @@ jest.mock("../utils/authFetch", () => ({
 
 declare global {
   interface Window {
-    Telegram?: {
-      WebApp?: {
-        sendData: (data: string) => void;
-      };
-    };
+    Telegram?: any;
   }
 }
 


### PR DESCRIPTION
## Summary
- avoid starting message queue timer during tests
- clean up tasks storage test typings

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `pnpm run dev` *(fails: apps/api dev: Failed)*
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68b40e93ddf083208af0f8173d3b22f9