### PR TITLE
test: stabilize queue and error boundary

### DIFF
--- a/tests/error-boundary.fallback.spec.tsx
+++ b/tests/error-boundary.fallback.spec.tsx
@@ -8,6 +8,7 @@ import ErrorBoundary from '../apps/web/src/components/ErrorBoundary';
 
 describe('ErrorBoundary', () => {
   it('отображает fallback при ошибке', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const Problem: React.FC = () => {
       throw new Error('boom');
     };
@@ -17,5 +18,6 @@ describe('ErrorBoundary', () => {
       </ErrorBoundary>,
     );
     expect(screen.getByRole('alert')).toHaveTextContent('Ошибка');
+    spy.mockRestore();
   });
 });

--- a/tests/messageQueue.test.ts
+++ b/tests/messageQueue.test.ts
@@ -1,20 +1,27 @@
-// Назначение: автотесты. Модули: jest, supertest.
+/**
+ * Назначение файла: проверяет работу очереди Telegram API.
+ * Основные модули: messageQueue.
+ */
 process.env.BOT_TOKEN = 't';
 process.env.CHAT_ID = '1';
 process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
 process.env.JWT_SECRET = 's';
 process.env.APP_URL = 'https://localhost';
 
-const {
+import {
   enqueue,
   queue,
   stopQueue,
+  startQueue,
   MAX_QUEUE_SIZE,
-} = require('../src/services/messageQueue');
+} from '../apps/api/src/services/messageQueue';
+
+beforeAll(() => startQueue());
+afterAll(() => stopQueue());
 
 test('очередь замедляет отправку при большом числе задач', async () => {
   const start = Date.now();
-  const jobs = [];
+  const jobs: Promise<unknown>[] = [];
   for (let i = 0; i < 60; i++) {
     jobs.push(enqueue(() => Promise.resolve()));
   }
@@ -32,5 +39,3 @@ test('enqueue отклоняет переполнение', async () => {
     'queue overflow',
   );
 });
-
-afterAll(() => stopQueue());


### PR DESCRIPTION
## Summary
- ensure message queue test starts and stops scheduler
- mute console.error in ErrorBoundary test

## Testing
- `pnpm test`
- `pnpm build`
- `pnpm run dev`

------
https://chatgpt.com/codex/tasks/task_b_68b4179c86d483208f1c59a30be2f74b