### PR TITLE
chore: обновить APP_URL для локальной разработки

### DIFF
--- a/scripts/create_env_from_exports.sh
+++ b/scripts/create_env_from_exports.sh
@@ -20,7 +20,7 @@ declare -A DEFAULTS=(
   [BOT_TOKEN]="$(openssl rand -hex 16)"
   [CHAT_ID]="$(shuf -i 100000000-999999999 -n 1)"
   [JWT_SECRET]="$(openssl rand -hex 32)"
-  [APP_URL]="http://localhost:3000"
+  [APP_URL]="https://localhost:3000"
   [MONGO_DATABASE_URL]="mongodb://admin:admin@localhost:27017/ermdb?authSource=admin"
 )
 


### PR DESCRIPTION
## Summary
- использовать HTTPS по умолчанию в скрипте генерации `.env`

## Testing
- `./scripts/create_env_from_exports.sh`
- `./scripts/setup_and_test.sh`
- `pnpm --dir apps/api run build`
- `pnpm --dir apps/api run start` *(ошибка: connect ECONNREFUSED 127.0.0.1:27017)*
- `./scripts/pre_pr_check.sh` *(ошибка: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68b420044b688320a284f1522b7e09af