### PR TITLE
feat: генерировать SESSION_SECRET по умолчанию

### DIFF
--- a/scripts/create_env_from_exports.sh
+++ b/scripts/create_env_from_exports.sh
@@ -20,6 +20,7 @@ declare -A DEFAULTS=(
   [BOT_TOKEN]="$(openssl rand -hex 16)"
   [CHAT_ID]="$(shuf -i 100000000-999999999 -n 1)"
   [JWT_SECRET]="$(openssl rand -hex 32)"
+  [SESSION_SECRET]="$(openssl rand -hex 64)"
   [APP_URL]="https://localhost:3000"
   [MONGO_DATABASE_URL]="mongodb://admin:admin@localhost:27017/ermdb?authSource=admin"
 )


### PR DESCRIPTION
## Summary
- generate SESSION_SECRET in create_env_from_exports.sh using openssl

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68b427ffe0388320bbd574e498f14c62