### PR TITLE
fix: align Telegram type in tasks storage test

### DIFF
--- a/apps/web/src/services/tasks.storage.spec.ts
+++ b/apps/web/src/services/tasks.storage.spec.ts
@@ -7,11 +7,7 @@ jest.mock("../utils/authFetch", () => ({
   default: jest.fn(),
 }));
 
-declare global {
-  interface Window {
-    Telegram?: any;
-  }
-}
+import type {} from "../types/telegram";
 
 import authFetch from "../utils/authFetch";
 import { fetchTasks } from "./tasks";


### PR DESCRIPTION
## Summary
- remove redundant Window.Telegram redeclaration in tasks storage spec
- import Telegram types to satisfy TypeScript

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `pnpm run dev` *(fails: ELIFECYCLE Command failed, SIGTERM)*
- `./scripts/pre_pr_check.sh` *(Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68b42ec060108320849dfa61f2adcc6d