### PR TITLE
feat: add script for API with in-memory Mongo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # История изменений
 
+- Реализован скрипт `start_api_with_memdb.sh` для запуска API с MongoDB в памяти, инструкция в README.
 - Быстрый старт использует `./scripts/create_env_from_exports.sh`, добавлен `start_api_with_memdb.sh`.
 - В корневые devDependencies добавлен `express-rate-limit`, исправлен сбой теста `tasks.upload.spec.ts`.
 - Скрипт `pre_pr_check.sh` поднимает MongoDB в памяти, `check_mongo.mjs` пропускает проверку при `CI=true`, обновлена документация переменной `MONGO_DATABASE_URL`.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ pnpm run dev # запуск api и web без таймаута PNPM
 ./scripts/start_api_with_memdb.sh # только api с MongoDB в памяти
 ```
 
+## Локальный запуск API с MongoDB в памяти
+
+```bash
+./scripts/start_api_with_memdb.sh
+```
+
+Скрипт поднимает MongoDB в памяти через MongoMemoryServer и устанавливает переменную `MONGO_DATABASE_URL`, после чего запускает API.
+
 Сгенерированные значения запишите в `.env` и не коммитьте этот файл.
 
 ## Сборка и проверки

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,13 +2,13 @@
 
 # Дорожная карта проекта
 
+- Скрипт `start_api_with_memdb.sh` запускает API с MongoDB в памяти.
 - Команда `pnpm run dev` запускает api и web без таймаута PNPM.
 - AuthContext хранит только профиль и флаг загрузки, JWT на клиенте не используется.
 - README упрощён, устаревшие разделы удалены.
 - Procfile выполняет `pnpm build` перед запуском, раздел деплоя на Railway добавлен в документацию.
 - Скрипт `pre_pr_check.sh` сохраняет лог запуска в `/tmp/apps`.
 - Скрипт `pre_pr_check.sh` поднимает MongoDB в памяти, `check_mongo.mjs` пропускает проверку в CI.
-- Добавлен `start_api_with_memdb.sh` для запуска API с MongoDB в памяти.
 - `install_bot_deps.sh` при недоступности npm берёт pnpm из GitHub.
 - `.npmrc` фиксирует registry npmjs.org для scope `@jsr`.
 - Оптимизировать Docker-сборку: кеш зависимостей через `pnpm fetch`, раздельная сборка `web` и `api`.

--- a/scripts/start_api_with_memdb.sh
+++ b/scripts/start_api_with_memdb.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Назначение: запуск API с MongoDB в памяти.
+# Модули: bash, pnpm, MongoMemoryServer.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+pnpm --dir apps/api exec node <<'NODE' &
+import { MongoMemoryServer } from 'mongodb-memory-server';
+MongoMemoryServer.create({ instance: { port: 27017 } }).then(() => console.log('MongoDB в памяти запущена'));
+setInterval(() => {}, 1000);
+NODE
+MONGO_PID=$!
+trap 'kill $MONGO_PID' EXIT
+export MONGO_DATABASE_URL="mongodb://127.0.0.1:27017/ermdb"
+for i in {1..30}; do
+  nc -z 127.0.0.1 27017 && break
+  sleep 1
+done
+
+./scripts/create_env_from_exports.sh >/dev/null || true
+
+pnpm --dir apps/api run start


### PR DESCRIPTION
## Summary
- add start_api_with_memdb.sh to launch API with MongoMemoryServer
- document script usage in README
- mention script in roadmap and changelog

## Testing
- `pnpm install`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `timeout 5s pnpm run dev` *(fails: Command failed with signal "SIGTERM")*
- `./scripts/setup_and_test.sh` *(fails: Найдены файлы JavaScript. Используйте TypeScript.)*

------
https://chatgpt.com/codex/tasks/task_b_68b4406ce8d8832094a9405f54ece2c3