### PR TITLE
feat: update shared paths for api

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -5,7 +5,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "commonjs",
-    "rootDir": "src",
+    "rootDir": ".",
     "outDir": "dist",
     "useUnknownInCatchVariables": false,
     "useDefineForClassFields": false,
@@ -19,10 +19,14 @@
     ],
     "composite": true,
     "paths": {
-      "shared": ["../../packages/shared/dist"],
-      "shared/*": ["../../packages/shared/dist/*"]
+      "shared": ["../../packages/shared/src"],
+      "shared/*": ["../../packages/shared/src/*"]
     }
   },
-  "include": ["src/**/*", "src/form/taskForm.schema.json"],
+  "include": [
+    "src/**/*",
+    "src/form/taskForm.schema.json",
+    "../../packages/shared/src/**/*"
+  ],
   "references": [{ "path": "../../packages/shared" }]
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "pretest:unit": "pnpm --filter shared build",
     "pretest:api": "pnpm --filter shared build",
     "pretest:e2e": "pnpm --filter shared build",
-    "build": "pnpm -r build",
+    "build": "pnpm --filter packages/shared build && pnpm -r --filter '!packages/shared' build",
     "dev": "PNPM_SCRIPT_TIMEOUT=0 pnpm -r dev",
     "lint": "pnpm -r lint",
     "a11y": "ts-node scripts/a11y.ts",


### PR DESCRIPTION
## Summary
- redirect api tsconfig shared path to source directory
- ensure root build script builds shared package before others

## Testing
- `pnpm --filter ./packages/shared build`
- `pnpm --filter ./apps/api build`
- `./scripts/setup_and_test.sh` *(fails: File packages/shared/src/constants.ts is not under rootDir /workspace/ERM-Telegram-web-bot/apps/api)*
- `./scripts/pre_pr_check.sh` *(fails: Не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68b4430560c08320ab8253590658f964