### PR TITLE
feat: добавить подсказку перезагрузки

### DIFF
--- a/apps/web/src/locales/en/translation.json
+++ b/apps/web/src/locales/en/translation.json
@@ -6,5 +6,6 @@
   "adminPanel": "Admin panel",
   "language": "Language",
   "noNotifications": "No notifications",
-  "notifications": "Notifications"
+  "notifications": "Notifications",
+  "errorFallback": "Something went wrong. Reload the page (Ctrl+R or ⌘+R)."
 }

--- a/apps/web/src/locales/ru/translation.json
+++ b/apps/web/src/locales/ru/translation.json
@@ -6,5 +6,6 @@
   "adminPanel": "Админка",
   "language": "Язык",
   "noNotifications": "Нет уведомлений",
-  "notifications": "Уведомления"
+  "notifications": "Уведомления",
+  "errorFallback": "Что-то пошло не так. Перезагрузите страницу (Ctrl+R или ⌘+R)."
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import * as ReactDOM from "react-dom/client";
 import ErrorBoundary from "./components/ErrorBoundary";
+import i18n from "./i18n";
 import "./index.css";
 
 function bootstrap() {
@@ -17,7 +18,7 @@ function bootstrap() {
 
   function render(Component: React.ComponentType) {
     ReactDOM.createRoot(root).render(
-      <ErrorBoundary fallback={<div>Что-то пошло не так</div>}>
+      <ErrorBoundary fallback={<div>{i18n.t("errorFallback")}</div>}>
         <React.StrictMode>
           <Component />
         </React.StrictMode>

--- a/tests/error-boundary.fallback.spec.tsx
+++ b/tests/error-boundary.fallback.spec.tsx
@@ -1,25 +1,34 @@
 /** @jest-environment jsdom */
-// Назначение файла: проверяет вывод запасного UI в ErrorBoundary при исключении.
-// Основные модули: React, @testing-library/react.
+// Назначение файла: проверяет наличие подсказки по перезагрузке в запасном UI ErrorBoundary.
+// Основные модули: React, @testing-library/react, i18next.
 import '@testing-library/jest-dom';
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import ErrorBoundary from '../apps/web/src/components/ErrorBoundary';
+import i18n from '../apps/web/src/i18n';
 
 describe('ErrorBoundary', () => {
-  it('отображает fallback при ошибке', () => {
-    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    const Problem: React.FC = () => {
-      throw new Error('boom');
-    };
-    render(
-      <ErrorBoundary fallback={<div role="alert">Ошибка</div>}>
-        <React.StrictMode>
-          <Problem />
-        </React.StrictMode>
-      </ErrorBoundary>,
-    );
-    expect(screen.getByRole('alert')).toHaveTextContent('Ошибка');
-    spy.mockRestore();
-  });
+  it.each(['ru', 'en'] as const)(
+    'выводит подсказку перезагрузки (%s)',
+    async (lng) => {
+      await i18n.changeLanguage(lng);
+      const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const Problem: React.FC = () => {
+        throw new Error('boom');
+      };
+      render(
+        <ErrorBoundary
+          fallback={<div role="alert">{i18n.t('errorFallback')}</div>}
+        >
+          <React.StrictMode>
+            <Problem />
+          </React.StrictMode>
+        </ErrorBoundary>,
+      );
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        lng === 'ru' ? 'Перезагрузите страницу' : 'Reload the page',
+      );
+      spy.mockRestore();
+    },
+  );
 });


### PR DESCRIPTION
## Summary
- локализован fallback ErrorBoundary с инструкцией по перезагрузке
- обновлены тесты для проверки подсказки

## Testing
- `./scripts/setup_and_test.sh` *(ошибка tsd)*
- `pnpm --dir apps/api run lint`
- `pnpm --dir apps/web run lint`
- `pnpm test` *(не хватает Playwright browsers)*
- `./scripts/pre_pr_check.sh` *(не удалось запустить бот)*

------
https://chatgpt.com/codex/tasks/task_b_68b46b0c7a4083208b5670a300ffc714