### PR TITLE
feat: add reload fallback string

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -18,7 +18,16 @@ function bootstrap() {
 
   function render(Component: React.ComponentType) {
     ReactDOM.createRoot(root).render(
-      <ErrorBoundary fallback={<div>{i18n.t("errorFallback")}</div>}>
+      <ErrorBoundary
+        fallback={
+          <div>
+            {i18n.t(
+              "errorFallback",
+              "Что-то пошло не так. Перезагрузите страницу (Ctrl+R или ⌘+R).",
+            )}
+          </div>
+        }
+      >
         <React.StrictMode>
           <Component />
         </React.StrictMode>


### PR DESCRIPTION
## Summary
- show default reload hint when i18n resources are missing

## Testing
- `pnpm format`
- `./scripts/setup_and_test.sh`
- `pnpm lint`
- `pnpm test` *(fails: TypeScript import equals not supported)*
- `pnpm build`
- `pnpm run dev`
- `./scripts/pre_pr_check.sh` *(fails: bot failed to start)*

------
https://chatgpt.com/codex/tasks/task_b_68b47669d36883208d8f580c6280eb1b