### PR TITLE
fix(web): обработка отсутствующего ребёнка в FormField

### DIFF
--- a/apps/web/src/components/a11y/FormField.tsx
+++ b/apps/web/src/components/a11y/FormField.tsx
@@ -1,0 +1,38 @@
+// Поле формы с уникальным идентификатором
+// Модули: React
+import React from "react";
+
+type FieldProps = {
+  label: string;
+  children: React.ReactNode;
+  hint?: string;
+  className?: string;
+};
+
+export function FormField({
+  label,
+  children,
+  hint,
+  className = "",
+}: FieldProps) {
+  const id = React.useId();
+  return (
+    <div className={`flex flex-col gap-1 ${className}`}>
+      <label htmlFor={id} className="text-sm font-medium">
+        {label}
+      </label>
+      {children != null ? (
+        React.isValidElement(children) ? (
+          React.cloneElement(children, { id })
+        ) : (
+          children
+        )
+      ) : (
+        <span data-testid="empty-field" />
+      )}
+      {hint && <span className="text-xs text-gray-500">{hint}</span>}
+    </div>
+  );
+}
+
+export default FormField;

--- a/apps/web/src/components/a11y/TaskForm.test.tsx
+++ b/apps/web/src/components/a11y/TaskForm.test.tsx
@@ -1,0 +1,16 @@
+/** @jest-environment jsdom */
+// Назначение: проверяет, что FormField не падает при undefined ребёнке
+// Модули: React, @testing-library/react, FormField
+import { render } from "@testing-library/react";
+import { FormField } from "./FormField";
+
+describe("FormField", () => {
+  it("не падает при undefined ребёнке", () => {
+    const { container } = render(
+      <FormField label="тест">{undefined}</FormField>,
+    );
+    expect(
+      container.querySelector('[data-testid="empty-field"]'),
+    ).not.toBeNull();
+  });
+});

--- a/apps/web/src/components/a11y/TaskForm.tsx
+++ b/apps/web/src/components/a11y/TaskForm.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import formSchema from "../../../api/src/form/taskForm.schema.json";
 import type { Field } from "../../../api/src/form";
+import { FormField } from "./FormField";
 
 type TaskFormProps = { customFields?: Field[] };
 
@@ -85,29 +86,5 @@ const renderField = (field: Field) => {
       return null;
   }
 };
-
-type FieldProps = {
-  label: string;
-  children: React.ReactNode;
-  hint?: string;
-  className?: string;
-};
-
-// Поле формы с уникальным идентификатором
-// Модули: React
-function FormField({ label, children, hint, className = "" }: FieldProps) {
-  const id = React.useId();
-  return (
-    <div className={`flex flex-col gap-1 ${className}`}>
-      <label htmlFor={id} className="text-sm font-medium">
-        {label}
-      </label>
-      {React.isValidElement(children)
-        ? React.cloneElement(children, { id })
-        : children}
-      {hint && <span className="text-xs text-gray-500">{hint}</span>}
-    </div>
-  );
-}
 
 export default TaskForm;


### PR DESCRIPTION
## Summary
- предотвратить падение FormField при отсутствии дочернего элемента
- добавить тест на безопасный рендер заглушки

## Testing
- `./scripts/setup_and_test.sh` (ошибка: tsd не нашёл файлы)
- `pnpm test:unit apps/web/src/components/a11y/TaskForm.test.tsx`
- `pnpm --dir apps/web run lint`
- `pnpm --dir apps/api run lint`
- `./scripts/pre_pr_check.sh` (ошибка: tsc -b в apps/api)


------
https://chatgpt.com/codex/tasks/task_b_68b5546a7c188320a2abe634781747a7