### PR TITLE
feat: добавить ErrorBoundary и санитизацию логов

### DIFF
--- a/apps/api/src/api/server.ts
+++ b/apps/api/src/api/server.ts
@@ -13,12 +13,13 @@ import { promisify } from 'util';
 import applySecurity from './security';
 import registerRoutes from './routes';
 import { startDiskMonitor } from '../services/diskSpace';
+import sanitizeError from '../utils/sanitizeError';
 
 process.on('unhandledRejection', (err) => {
-  console.error('Unhandled rejection in API:', err);
+  console.error('Unhandled rejection in API:', sanitizeError(err));
 });
 process.on('uncaughtException', (err) => {
-  console.error('Uncaught exception in API:', err);
+  console.error('Uncaught exception in API:', sanitizeError(err));
   process.exit(1);
 });
 

--- a/apps/api/src/middleware/errorMiddleware.ts
+++ b/apps/api/src/middleware/errorMiddleware.ts
@@ -8,6 +8,7 @@ import type { RequestWithUser } from '../types/request';
 import { sendProblem } from '../utils/problem';
 import { ProblemDetails } from '../types/problem';
 import { apiErrors } from '../api/middleware';
+import sanitizeError from '../utils/sanitizeError';
 
 const csrfErrors = new client.Counter({
   name: 'csrf_errors_total',
@@ -70,9 +71,10 @@ export default function errorMiddleware(
     apiErrors.inc({ method: req.method, path: req.originalUrl, status: 403 });
     return;
   }
-  console.error(error);
+  const clean = sanitizeError(error);
+  console.error('API error:', clean);
   writeLog(
-    `Ошибка ${error.message} path:${req.originalUrl} ip:${req.ip} trace:${traceId} instance:${traceId}`,
+    `Ошибка ${clean} path:${req.originalUrl} ip:${req.ip} trace:${traceId} instance:${traceId}`,
     'error',
   ).catch(() => {});
   const status = res.statusCode >= 400 ? res.statusCode : 500;

--- a/apps/api/src/utils/sanitizeError.ts
+++ b/apps/api/src/utils/sanitizeError.ts
@@ -1,0 +1,9 @@
+// Назначение: упрощённое представление ошибок без стека.
+// Основные модули: стандартные типы.
+
+export default function sanitizeError(err: unknown): string {
+  if (err instanceof Error) {
+    return `${err.name}: ${err.message}`;
+  }
+  return String(err);
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -32,6 +32,7 @@ import Toasts from "./components/Toasts";
 import ProtectedRoute from "./components/ProtectedRoute";
 import AdminRoute from "./components/AdminRoute";
 import TaskDialogRoute from "./components/TaskDialogRoute";
+import ErrorBoundary from "./components/ErrorBoundary";
 
 function Content() {
   const { collapsed, open } = useSidebar();
@@ -156,9 +157,11 @@ export default function App() {
           <ToastProvider>
             <SidebarProvider>
               <TasksProvider>
-                <Router>
-                  <Layout />
-                </Router>
+                <ErrorBoundary fallback={<div>Произошла ошибка</div>}>
+                  <Router>
+                    <Layout />
+                  </Router>
+                </ErrorBoundary>
               </TasksProvider>
             </SidebarProvider>
           </ToastProvider>

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -18,8 +18,12 @@ export default class ErrorBoundary extends React.Component<Props, State> {
     return { hasError: true };
   }
 
-  componentDidCatch(error: unknown, info: unknown) {
-    console.error(error, info);
+  componentDidCatch(error: unknown) {
+    const msg =
+      error instanceof Error
+        ? `${error.name}: ${error.message}`
+        : String(error);
+    console.error("Ошибка приложения:", msg);
   }
 
   render() {


### PR DESCRIPTION
## Что сделано
- добавлен компонент ErrorBoundary и обёрнут Router
- ошибки API и процесса логируются без stack trace

## Почему
- запасной UI и чистые логи облегчают поддержку

## Чек-лист
- [x] `pnpm install`
- [x] `./scripts/setup_and_test.sh`
- [x] `pnpm --filter ./apps/api build`
- [x] `pnpm --filter ./apps/web build`
- [ ] `./scripts/pre_pr_check.sh` *(MongoMemoryServer: SIGSEGV)*

## Самопроверка
- подключён sanitizeError
- Router работает под ErrorBoundary
- предупреждения выводятся на русском

## Риски
- временная недоступность MongoMemoryServer.
- откат: удалить новые файлы и вернуть изменения в сервере и App.

------
https://chatgpt.com/codex/tasks/task_b_68b5a85d935083209c6c91746aef413d