### PR TITLE
feat: функциональный ErrorBoundary

### DIFF
--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -1,35 +1,44 @@
 // Компонент границы ошибок для перехвата исключений и вывода запасного UI.
 // Основные модули: React.
-import React, { type ReactNode } from "react";
+import React, { type ReactNode, useState } from "react";
 
 interface Props {
   fallback: ReactNode;
   children: ReactNode;
 }
 
-interface State {
-  hasError: boolean;
-}
-
-export default class ErrorBoundary extends React.Component<Props, State> {
-  state: State = { hasError: false };
-
-  static getDerivedStateFromError(): State {
-    return { hasError: true };
+class InnerBoundary extends React.Component<{
+  onError: (error: unknown, info: React.ErrorInfo) => void;
+  children: ReactNode;
+}> {
+  override componentDidCatch(error: unknown, info: React.ErrorInfo) {
+    this.props.onError(error, info);
   }
 
-  componentDidCatch(error: unknown) {
-    const msg =
-      error instanceof Error
-        ? `${error.name}: ${error.message}`
-        : String(error);
-    console.error("Ошибка приложения:", msg);
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return this.props.fallback;
-    }
+  override render() {
     return this.props.children;
   }
+}
+
+export default function ErrorBoundary({ fallback, children }: Props) {
+  const [hasError, setHasError] = useState(false);
+
+  if (hasError) {
+    return <>{fallback}</>;
+  }
+
+  return (
+    <InnerBoundary
+      onError={(error, info) => {
+        const msg =
+          error instanceof Error
+            ? `${error.name}: ${error.message}`
+            : String(error);
+        console.error("Ошибка приложения:", msg, info);
+        setHasError(true);
+      }}
+    >
+      {children}
+    </InnerBoundary>
+  );
 }

--- a/tests/e2e/no-typeerror.spec.ts
+++ b/tests/e2e/no-typeerror.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * Назначение файла: e2e-тест запуска приложения без TypeError в консоли.
+ * Основные модули: @playwright/test, express.
+ */
+import { test, expect } from '@playwright/test';
+import express from 'express';
+import { resolve } from 'path';
+import { readFileSync } from 'fs';
+import type { Server } from 'http';
+import type { AddressInfo } from 'net';
+
+const app = express();
+const staticDir = resolve(__dirname, '../../apps/api/public');
+app.use(express.static(staticDir));
+const indexHtml = readFileSync(
+  resolve(staticDir, 'index.html'),
+  'utf8',
+).replace(/\s+integrity="[^"]+"/g, '');
+app.get('*', (_req, res) => res.send(indexHtml));
+const server: Server = app.listen(0);
+const { port } = server.address() as AddressInfo;
+
+test.use({ baseURL: `http://localhost:${port}` });
+
+test.afterAll(() => {
+  server.close();
+});
+
+test('приложение стартует без TypeError в консоли', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('pageerror', (e) => {
+    if (e.message.includes('TypeError')) errors.push(e.message);
+  });
+  page.on('console', (msg) => {
+    if (msg.type() === 'error' && msg.text().includes('TypeError')) {
+      errors.push(msg.text());
+    }
+  });
+  await page.goto('/');
+  expect(errors).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- refactor ErrorBoundary to functional component with `useState` and `componentDidCatch`
- add e2e test ensuring app starts without console TypeError

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm --dir apps/web run lint`
- `pnpm test:e2e tests/e2e/no-typeerror.spec.ts`


------
https://chatgpt.com/codex/tasks/task_b_68b5b38f04208320977586c028786ad2