### PR TITLE
feat: e2e тест корневого компонента

### DIFF
--- a/tests/e2e/root.visible.spec.ts
+++ b/tests/e2e/root.visible.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * Назначение файла: e2e-тест видимости корневого компонента без TypeError в консоли.
+ * Основные модули: @playwright/test, express.
+ */
+import { test, expect } from '@playwright/test';
+import express from 'express';
+import { resolve } from 'path';
+import { readFileSync } from 'fs';
+import type { Server } from 'http';
+import type { AddressInfo } from 'net';
+
+const app = express();
+const staticDir = resolve(__dirname, '../../apps/api/public');
+app.use(express.static(staticDir));
+const indexHtml = readFileSync(
+  resolve(staticDir, 'index.html'),
+  'utf8',
+).replace(/\s+integrity="[^"]+"/g, '');
+app.get('*', (_req, res) => res.send(indexHtml));
+const server: Server = app.listen(0);
+const { port } = server.address() as AddressInfo;
+
+test.use({ baseURL: `http://localhost:${port}` });
+
+test.afterAll(() => {
+  server.close();
+});
+
+test('корневой компонент отображается без TypeError в консоли', async ({
+  page,
+}) => {
+  const errors: string[] = [];
+  page.on('pageerror', (e) => {
+    if (e.message.includes('TypeError')) errors.push(e.message);
+  });
+  page.on('console', (msg) => {
+    if (msg.type() === 'error' && msg.text().includes('TypeError')) {
+      errors.push(msg.text());
+    }
+  });
+  await page.goto('/');
+  const root = page.locator('#root');
+  await expect(root).toHaveJSProperty('hidden', false);
+  expect(errors).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- добавить Playwright-тест, проверяющий видимость корневого компонента и отсутствие TypeError
- убедиться, что CI запускает `pnpm test:e2e`

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm test:e2e`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68b5cbbe093483209325644be62e758b