### PR TITLE
fix(web): guard Modal for SSR

### DIFF
--- a/apps/web/src/components/Modal.ssr.test.tsx
+++ b/apps/web/src/components/Modal.ssr.test.tsx
@@ -1,0 +1,10 @@
+/** @jest-environment node */
+// Назначение файла: проверяет, что Modal возвращает null при отсутствии document.
+// Основные модули: React, Modal.
+import React from "react";
+import Modal from "./Modal";
+
+test("возвращает null без document", () => {
+  const result = Modal({ open: true, onClose: () => {}, children: <div /> });
+  expect(result).toBeNull();
+});

--- a/apps/web/src/components/Modal.test.tsx
+++ b/apps/web/src/components/Modal.test.tsx
@@ -1,0 +1,17 @@
+/** @jest-environment jsdom */
+// Назначение файла: проверяет, что Modal не рендерится при закрытом состоянии.
+// Основные модули: React, @testing-library/react, Modal.
+import React from "react";
+import { render } from "@testing-library/react";
+import Modal from "./Modal";
+
+describe("Modal", () => {
+  it("не рендерится когда закрыт", () => {
+    const { container } = render(
+      <Modal open={false} onClose={() => {}}>
+        <div>child</div>
+      </Modal>,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/web/src/components/Modal.tsx
+++ b/apps/web/src/components/Modal.tsx
@@ -10,7 +10,7 @@ interface ModalProps {
 }
 
 export default function Modal({ open, onClose, children }: ModalProps) {
-  if (!open) return null;
+  if (!open || typeof document === "undefined") return null;
   return createPortal(
     <div className="fixed inset-0 z-[1000]" role="dialog" aria-modal="true">
       <div className="fixed inset-0 bg-black/50" onClick={onClose} />


### PR DESCRIPTION
## Summary
- return `null` from Modal when document is missing
- add tests for closed state and SSR behavior

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm test:unit`
- `./scripts/pre_pr_check.sh` *(fails: "Не удалось запустить бот")*


------
https://chatgpt.com/codex/tasks/task_b_68b68c3073308320a8546b99bb107684