### PR TITLE
feat: improve accessibility

### DIFF
--- a/apps/web/src/components/GlobalSearch.tsx
+++ b/apps/web/src/components/GlobalSearch.tsx
@@ -18,6 +18,7 @@ export default function GlobalSearch() {
         variant="ghost"
         size="icon"
         aria-label={t("search")}
+        className="size-12"
       >
         <MagnifyingGlassIcon className="size-5" />
       </Button>
@@ -30,11 +31,16 @@ export default function GlobalSearch() {
             className="w-full max-w-md rounded bg-white p-4 shadow-lg"
             onClick={(e) => e.stopPropagation()}
           >
+            <label htmlFor="global-search" className="sr-only">
+              {t("search")}
+            </label>
             <Input
+              id="global-search"
               autoFocus
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder={t("search")}
+              className="h-12"
             />
           </div>
         </div>

--- a/apps/web/src/components/NotificationDropdown.tsx
+++ b/apps/web/src/components/NotificationDropdown.tsx
@@ -21,7 +21,12 @@ export default function NotificationDropdown({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" aria-label={t("notifications")}>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label={t("notifications")}
+          className="size-12"
+        >
           {children}
         </Button>
       </DropdownMenuTrigger>

--- a/apps/web/src/components/TaskDialog.tsx
+++ b/apps/web/src/components/TaskDialog.tsx
@@ -504,19 +504,26 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
             {isEdit && !editing && (
               <button
                 onClick={() => setEditing(true)}
-                className="p-1"
+                className="flex h-12 w-12 items-center justify-center"
                 title="Редактировать"
+                aria-label="Редактировать"
               >
                 ✎
               </button>
             )}
-            <button onClick={resetForm} className="p-1" title="Сбросить">
+            <button
+              onClick={resetForm}
+              className="flex h-12 w-12 items-center justify-center"
+              title="Сбросить"
+              aria-label="Сбросить"
+            >
               <ArrowPathIcon className="h-5 w-5" />
             </button>
             <button
               onClick={() => setExpanded(!expanded)}
-              className="p-1"
+              className="flex h-12 w-12 items-center justify-center"
               title="Развернуть"
+              aria-label="Развернуть"
             >
               {expanded ? (
                 <ArrowsPointingInIcon className="h-5 w-5" />
@@ -524,7 +531,12 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
                 <ArrowsPointingOutIcon className="h-5 w-5" />
               )}
             </button>
-            <button onClick={onClose} className="p-1" title="Закрыть">
+            <button
+              onClick={onClose}
+              className="flex h-12 w-12 items-center justify-center"
+              title="Закрыть"
+              aria-label="Закрыть"
+            >
               <XMarkIcon className="h-5 w-5" />
             </button>
           </div>

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -8,7 +8,13 @@ export default function ThemeToggle() {
   const { theme, setTheme } = useContext(ThemeContext);
   const toggle = () => setTheme(theme === "dark" ? "light" : "dark");
   return (
-    <Button variant="ghost" size="icon" onClick={toggle} aria-label="Тема">
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggle}
+      aria-label="Тема"
+      className="size-12"
+    >
       {theme === "dark" ? "🌙" : "☀️"}
     </Button>
   );

--- a/apps/web/src/layouts/Header.tsx
+++ b/apps/web/src/layouts/Header.tsx
@@ -18,15 +18,23 @@ export default function Header() {
       className={`border-stroke sticky top-0 z-10 flex h-14 items-center justify-between border-b bg-white px-4 transition-all ${open ? (collapsed ? "lg:ml-20" : "lg:ml-60") : "lg:ml-0"}`}
     >
       <div className="flex items-center gap-2">
-        <button onClick={toggle} className="block" aria-label={t("menu")}>
+        <button
+          onClick={toggle}
+          className="flex h-12 w-12 items-center justify-center"
+          aria-label={t("menu")}
+        >
           <Bars3Icon className="h-6 w-6" />
         </button>
         <h1 className="font-bold">agrmcs</h1>
       </div>
       <div className="flex items-center gap-4">
         <GlobalSearch />
+        <label htmlFor="lang-select" className="sr-only">
+          {t("language")}
+        </label>
         <select
-          className="rounded border p-1 text-sm"
+          id="lang-select"
+          className="h-12 rounded border px-2 text-sm"
           value={i18n.language}
           onChange={(e) => i18n.changeLanguage(e.target.value)}
           aria-label={t("language")}

--- a/apps/web/src/layouts/Sidebar.tsx
+++ b/apps/web/src/layouts/Sidebar.tsx
@@ -43,12 +43,16 @@ export default function Sidebar() {
       className={`fixed top-0 left-0 z-50 h-full ${collapsed ? "w-20" : "w-60"} border-stroke border-r bg-white p-4 transition-all ${open ? "translate-x-0" : "-translate-x-full"}`}
     >
       <div className="flex items-center justify-between">
-        <button onClick={toggle} className="p-1" aria-label="Закрыть меню">
+        <button
+          onClick={toggle}
+          className="flex h-12 w-12 items-center justify-center"
+          aria-label="Закрыть меню"
+        >
           <XMarkIcon className="h-5 w-5" />
         </button>
         <button
           onClick={toggleCollapsed}
-          className="hover:text-accentPrimary hidden p-1 lg:block"
+          className="hover:text-accentPrimary hidden h-12 w-12 items-center justify-center lg:flex"
           title="Свернуть меню"
           aria-label="Свернуть меню"
         >
@@ -64,7 +68,10 @@ export default function Sidebar() {
           <Link
             key={i.to}
             to={i.to}
-            className={`flex items-center gap-2 rounded-lg px-2 py-2 text-gray-700 hover:bg-gray-100 ${pathname === i.to ? "bg-gray-100 font-semibold" : ""}`}
+            aria-label={i.label}
+            className={`flex h-12 items-center gap-2 rounded-lg px-2 text-gray-700 hover:bg-gray-100 ${
+              pathname === i.to ? "bg-gray-100 font-semibold" : ""
+            }`}
           >
             <i.icon className="h-5 w-5" />
             {!collapsed && <span>{i.label}</span>}


### PR DESCRIPTION
## Summary
- add aria labels and larger touch zones for sidebar controls
- provide labels for language select and global search input
- enlarge icon buttons across header and dialogs for 48px targets

## Testing
- `pnpm format`
- `./scripts/setup_and_test.sh`
- `pnpm --dir apps/web build`
- `npx lighthouse http://localhost:4173 --only-categories=accessibility --quiet --chrome-flags="--headless --no-sandbox --disable-dev-shm-usage"` *(fails: NO_FCP)*
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68b6f5bc5b508320a747d08c7a5596a7