### PR TITLE
feat: add srcset support and sourcemaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
   pull_request:
     branches: [main]
 
@@ -56,3 +56,9 @@ jobs:
         run: pnpm test:e2e
       - name: Проверка размера бандла
         run: pnpm size
+      - name: Загрузка sourcemap
+        if: github.ref == 'refs/heads/staging'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sourcemaps
+          path: apps/api/public/assets/**/*.map

--- a/apps/web/src/components/FileUploader.tsx
+++ b/apps/web/src/components/FileUploader.tsx
@@ -119,6 +119,8 @@ export default function FileUploader({
             <li key={i} className="flex items-center gap-2">
               {it.isImage && (
                 <img
+                  srcSet={`${it.url} 1x, ${it.url} 2x`}
+                  sizes="48px"
                   src={it.url}
                   alt={it.name}
                   className="h-12 w-12 rounded object-cover"

--- a/apps/web/src/components/TaskDialog.tsx
+++ b/apps/web/src/components/TaskDialog.tsx
@@ -882,7 +882,13 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
                 {attachments.map((a) => (
                   <li key={a.url} className="flex items-center gap-2">
                     {/\.(png|jpe?g|gif|webp|bmp|svg)$/i.test(a.url) ? (
-                      <img src={a.url} alt={a.name} className="h-16 rounded" />
+                      <img
+                        srcSet={`${a.url} 1x, ${a.url} 2x`}
+                        sizes="64px"
+                        src={a.url}
+                        alt={a.name}
+                        className="h-16 rounded"
+                      />
                     ) : (
                       <a
                         href={a.url}

--- a/apps/web/src/pages/Storage.tsx
+++ b/apps/web/src/pages/Storage.tsx
@@ -151,7 +151,13 @@ export default function StoragePage() {
       </FileBrowser>
       <Modal open={!!preview} onClose={() => setPreview(null)}>
         {preview?.type === "image" && (
-          <img src={preview.url} alt="" className="max-h-[80vh]" />
+          <img
+            srcSet={`${preview.url} 1x, ${preview.url} 2x`}
+            sizes="(max-width: 800px) 100vw, 800px"
+            src={preview.url}
+            alt=""
+            className="max-h-[80vh]"
+          />
         )}
         {preview?.type === "video" && (
           <video src={preview.url} controls className="max-h-[80vh]" />

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -63,8 +63,8 @@ export default defineConfig(() => {
       emptyOutDir: true,
       outDir: "../api/public",
       manifest: true,
-      // Временные настройки для отладки (отключены в CI)
-      sourcemap: !isCi,
+      // Карты исходников включены для всех окружений
+      sourcemap: true,
       minify: isCi ? "esbuild" : false,
       chunkSizeWarningLimit: 1500,
       commonjsOptions: {


### PR DESCRIPTION
## Summary
- render thumbnails with `srcset` and size hints
- enable sourcemaps in Vite build
- upload sourcemap artifacts in CI

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_68b88b9f6c588320a96a8f23fbd23c22