### PR TITLE
fix(web): restore sidebar link formatting

### DIFF
--- a/apps/web/src/layouts/Sidebar.tsx
+++ b/apps/web/src/layouts/Sidebar.tsx
@@ -69,7 +69,9 @@ export default function Sidebar() {
             key={i.to}
             to={i.to}
             aria-label={i.label}
-            className={`flex h-12 items-center gap-2 rounded-lg px-2 text-gray-700 hover:bg-gray-100 ${pathname === i.to ? "bg-gray-100 font-semibold" : ""}`}
+            className={`flex h-12 items-center gap-2 rounded-lg px-2 text-gray-700 hover:bg-gray-100 ${
+              pathname === i.to ? "bg-gray-100 font-semibold" : ""
+            }`}
           >
             <i.icon className="h-5 w-5" />
             {!collapsed && <span>{i.label}</span>}


### PR DESCRIPTION
## Summary
- improve Sidebar link formatting to align with accessibility changes from commit 4865663

## Testing
- `pnpm lint`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_b_68b958c3f674832089c696bbb21d7f0d