### PR TITLE
feat: оптимизация CSS и изображений

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -54,8 +54,8 @@
     "react-router-dom": "^6.26.2",
     "react-select": "^5.10.2",
     "shared": "workspace:*",
-    "use-sync-external-store": "^1.5.0",
     "tailwind-merge": "^3.3.1",
+    "use-sync-external-store": "^1.5.0",
     "validator": "^13.15.15",
     "zod": "^3.25.76"
   },
@@ -75,6 +75,7 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
     "jiti": "^2.5.1",
+    "lightningcss": "^1.30.1",
     "postcss": "^8.5.6",
     "prettier": "^3.6.1",
     "prettier-plugin-tailwindcss": "^0.6.1",
@@ -83,6 +84,7 @@
     "ts-node": "^10.9.2",
     "tw-animate-css": "^1.3.6",
     "typescript": "^5.4.5",
-    "vite": "^7.0.0"
+    "vite": "^7.0.0",
+    "vite-plugin-image-optimizer": "^2.0.2"
   }
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -11,6 +11,7 @@ import { resolve } from "path";
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import sri from "./plugins/sri";
 import { visualizer } from "rollup-plugin-visualizer";
+import { ViteImageOptimizer } from "vite-plugin-image-optimizer";
 
 /**
  * Плагин сохраняет `index.html` с уведомлением, чтобы Vite не удалял файл при
@@ -42,6 +43,7 @@ export default defineConfig(() => {
     plugins: [
       react(),
       sri(),
+      ViteImageOptimizer(),
       process.env.ANALYZE
         ? visualizer({
             filename: "bundle-report.html",
@@ -68,6 +70,7 @@ export default defineConfig(() => {
       // Sourcemap включены для всех сборок
       sourcemap: true,
       minify: "esbuild",
+      cssMinify: "lightningcss",
       treeshake: true,
 
       chunkSizeWarningLimit: 1500,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -552,6 +552,9 @@ importers:
       jiti:
         specifier: ^2.5.1
         version: 2.5.1
+      lightningcss:
+        specifier: ^1.30.1
+        version: 1.30.1
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -579,6 +582,9 @@ importers:
       vite:
         specifier: ^7.0.0
         version: 7.1.3(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
+      vite-plugin-image-optimizer:
+        specifier: ^2.0.2
+        version: 2.0.2(vite@7.1.3(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
 
   packages/shared: {}
 
@@ -12332,6 +12338,12 @@ packages:
       }
     engines: { node: '>=8' }
 
+  pathe@2.0.3:
+    resolution:
+      {
+        integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
+      }
+
   pause-stream@0.0.11:
     resolution:
       {
@@ -15176,6 +15188,22 @@ packages:
         integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==,
       }
 
+  vite-plugin-image-optimizer@2.0.2:
+    resolution:
+      {
+        integrity: sha512-BYK27SpSScRIaveJVjbP7EjSrawuCc+ffESGvKVRhByAu6RGvwE3EyGg9ZeqQiLUE8e1hKSCr8v5ZfvQNiqvJQ==,
+      }
+    engines: { node: '>=18.17.0' }
+    peerDependencies:
+      sharp: '>=0.34.0'
+      svgo: '>=4'
+      vite: '>=5'
+    peerDependenciesMeta:
+      sharp:
+        optional: true
+      svgo:
+        optional: true
+
   vite@7.1.3:
     resolution:
       {
@@ -17564,6 +17592,8 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 46.0.2
       '@ckeditor/ckeditor5-utils': 46.0.2
       ckeditor5: 46.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-special-characters@46.0.2':
     dependencies:
@@ -24963,6 +24993,8 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
   pause-stream@0.0.11:
     dependencies:
       through: 2.3.8
@@ -26871,6 +26903,12 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  vite-plugin-image-optimizer@2.0.2(vite@7.1.3(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)):
+    dependencies:
+      ansi-colors: 4.1.3
+      pathe: 2.0.3
+      vite: 7.1.3(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
 
   vite@7.1.3(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1):
     dependencies:


### PR DESCRIPTION
## Что сделано
- добавлены lightningcss и vite-plugin-image-optimizer в веб-клиент
- настроена сборка Vite для минимизации CSS и оптимизации изображений

## Зачем
- уменьшение размера стилей и картинок

## Чек-лист
- [x] `pnpm lint`
- [ ] `pnpm test` *(недоступны браузеры Playwright)*
- [x] `pnpm --filter web build`

## Риски
- возможны предупреждения плагина оптимизации изображений
- при сбое можно откатиться `git revert <commit>`

------
https://chatgpt.com/codex/tasks/task_b_68bab16fe5108320b3aacdbdd39af18a