### PR TITLE
feat(web): добавить фильтры поиска

### DIFF
--- a/apps/web/src/components/GlobalSearch.tsx
+++ b/apps/web/src/components/GlobalSearch.tsx
@@ -1,50 +1,50 @@
 // Глобальный модуль поиска
-// Модули: React, heroicons, i18next
+// Модули: React, heroicons, i18next, ui
 import React from "react";
-import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { MagnifyingGlassIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import { useTranslation } from "react-i18next";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import useTasks from "../context/useTasks";
 
 export default function GlobalSearch() {
-  const [open, setOpen] = React.useState(false);
   const { query, setQuery } = useTasks();
   const { t } = useTranslation();
+  const ref = React.useRef<HTMLInputElement>(null);
+
+  const clear = () => {
+    setQuery("");
+    ref.current?.focus();
+  };
+
+  const onKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Escape") {
+      e.stopPropagation();
+      clear();
+      ref.current?.blur();
+    }
+  };
+
   return (
-    <>
-      <Button
-        onClick={() => setOpen(true)}
-        variant="ghost"
-        size="icon"
+    <div className="relative">
+      <MagnifyingGlassIcon className="pointer-events-none absolute top-1/2 left-2 size-4 -translate-y-1/2 text-gray-400" />
+      <Input
+        ref={ref}
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={onKey}
+        placeholder={t("search")}
         aria-label={t("search")}
-        className="size-12"
-      >
-        <MagnifyingGlassIcon className="size-5" />
-      </Button>
-      {open && (
-        <div
-          className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 p-4"
-          onClick={() => setOpen(false)}
+        className="h-9 w-64 pr-8 pl-8"
+      />
+      {query && (
+        <button
+          onClick={clear}
+          aria-label="Очистить"
+          className="absolute top-1/2 right-2 -translate-y-1/2 text-gray-400 hover:text-black"
         >
-          <div
-            className="w-full max-w-md rounded bg-white p-4 shadow-lg"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <label htmlFor="global-search" className="sr-only">
-              {t("search")}
-            </label>
-            <Input
-              id="global-search"
-              autoFocus
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder={t("search")}
-              className="h-12"
-            />
-          </div>
-        </div>
+          <XMarkIcon className="size-4" />
+        </button>
       )}
-    </>
+    </div>
   );
 }

--- a/apps/web/src/components/SearchFilters.tsx
+++ b/apps/web/src/components/SearchFilters.tsx
@@ -1,0 +1,75 @@
+// Фильтры поиска задач
+// Модули: React, shared, useTasks
+import React from "react";
+import { TASK_STATUSES, PRIORITIES } from "shared";
+import useTasks from "../context/useTasks";
+
+export default function SearchFilters() {
+  const { filters, setFilters } = useTasks();
+  const [local, setLocal] = React.useState(filters);
+
+  const toggle = (key: "status" | "priority", value: string) => {
+    setLocal((prev) => {
+      const arr = prev[key];
+      const exists = arr.includes(value);
+      const next = exists ? arr.filter((v) => v !== value) : [...arr, value];
+      return { ...prev, [key]: next };
+    });
+  };
+
+  return (
+    <details className="relative">
+      <summary className="cursor-pointer rounded border px-2 py-1 select-none">
+        Фильтры
+      </summary>
+      <div className="absolute z-10 mt-1 flex w-64 flex-col gap-2 rounded border bg-white p-2 shadow">
+        <div>
+          <span className="block text-sm font-medium">Статус</span>
+          {TASK_STATUSES.map((s) => (
+            <label key={s} className="flex items-center gap-1">
+              <input
+                type="checkbox"
+                checked={local.status.includes(s)}
+                onChange={() => toggle("status", s)}
+              />
+              {s}
+            </label>
+          ))}
+        </div>
+        <div>
+          <span className="block text-sm font-medium">Приоритет</span>
+          {PRIORITIES.map((p) => (
+            <label key={p} className="flex items-center gap-1">
+              <input
+                type="checkbox"
+                checked={local.priority.includes(p)}
+                onChange={() => toggle("priority", p)}
+              />
+              {p}
+            </label>
+          ))}
+        </div>
+        <div className="flex items-center gap-2">
+          <input
+            type="date"
+            className="rounded border p-1"
+            value={local.from}
+            onChange={(e) => setLocal({ ...local, from: e.target.value })}
+          />
+          <input
+            type="date"
+            className="rounded border p-1"
+            value={local.to}
+            onChange={(e) => setLocal({ ...local, to: e.target.value })}
+          />
+        </div>
+        <button
+          onClick={() => setFilters(local)}
+          className="mt-2 rounded border px-2 py-1"
+        >
+          Искать
+        </button>
+      </div>
+    </details>
+  );
+}

--- a/apps/web/src/components/TableToolbar.tsx
+++ b/apps/web/src/components/TableToolbar.tsx
@@ -1,6 +1,8 @@
-// Назначение файла: общий тулбар таблицы с экспортом и настройкой колонок
+// Назначение файла: общий тулбар таблицы с экспортом, поиском и фильтрацией
 // Модули: React, @tanstack/react-table, jspdf
 import type { Table } from "@tanstack/react-table";
+import GlobalSearch from "./GlobalSearch";
+import SearchFilters from "./SearchFilters";
 
 interface Props<T> {
   table: Table<T>;
@@ -60,6 +62,8 @@ export default function TableToolbar<T>({ table }: Props<T>) {
 
   return (
     <div className="flex flex-wrap items-center gap-2 text-sm">
+      <GlobalSearch />
+      <SearchFilters />
       <button onClick={exportCsv} className="rounded border px-2 py-1">
         CSV
       </button>

--- a/apps/web/src/components/TaskTable.tsx
+++ b/apps/web/src/components/TaskTable.tsx
@@ -24,18 +24,33 @@ export default function TaskTable({
   onPageChange,
   onRowClick,
 }: TaskTableProps) {
-  const { query } = useTasks();
+  const { query, filters } = useTasks();
   const columns = React.useMemo(() => taskColumns(true, users), [users]);
 
   return (
     <Suspense fallback={<div>Загрузка таблицы...</div>}>
       <DataTable
         columns={columns}
-        data={tasks.filter((t) =>
-          query
-            ? JSON.stringify(t).toLowerCase().includes(query.toLowerCase())
-            : true,
-        )}
+        data={tasks.filter((t) => {
+          if (
+            query &&
+            !JSON.stringify(t).toLowerCase().includes(query.toLowerCase())
+          )
+            return false;
+          if (filters.status.length && !filters.status.includes(t.status))
+            return false;
+          if (
+            filters.priority.length &&
+            !filters.priority.includes(t.priority as string)
+          )
+            return false;
+          const created = t.createdAt ? new Date(t.createdAt) : null;
+          if (filters.from && created && created < new Date(filters.from))
+            return false;
+          if (filters.to && created && created > new Date(filters.to))
+            return false;
+          return true;
+        })}
         pageIndex={page}
         pageSize={25}
         pageCount={pageCount}

--- a/apps/web/src/context/TasksContext.ts
+++ b/apps/web/src/context/TasksContext.ts
@@ -1,11 +1,21 @@
-// Контекст задач и глобального поиска
+// Контекст задач, глобального поиска и фильтров
 import { createContext } from "react";
+
+// Фильтры поиска задач
+export interface TaskFilters {
+  status: string[];
+  priority: string[];
+  from: string;
+  to: string;
+}
 
 export interface TasksState {
   version: number;
   refresh: () => void;
   query: string;
   setQuery: (q: string) => void;
+  filters: TaskFilters;
+  setFilters: (f: TaskFilters) => void;
 }
 
 export const TasksContext = createContext<TasksState | undefined>(undefined);

--- a/apps/web/src/context/TasksContext.tsx
+++ b/apps/web/src/context/TasksContext.tsx
@@ -1,15 +1,23 @@
-// Провайдер контекста задач и глобального поиска
+// Провайдер контекста задач, поиска и фильтров
 import React, { useState } from "react";
-import { TasksContext } from "./TasksContext";
+import { TasksContext, type TaskFilters } from "./TasksContext";
 
 export const TasksProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const [version, setVersion] = useState(0);
   const [query, setQuery] = useState("");
+  const [filters, setFilters] = useState<TaskFilters>({
+    status: [],
+    priority: [],
+    from: "",
+    to: "",
+  });
   const refresh = () => setVersion((v) => v + 1);
   return (
-    <TasksContext.Provider value={{ version, refresh, query, setQuery }}>
+    <TasksContext.Provider
+      value={{ version, refresh, query, setQuery, filters, setFilters }}
+    >
       {children}
     </TasksContext.Provider>
   );


### PR DESCRIPTION
## Что сделано
- поиск перенесён в тулбар и стал инлайновым
- добавлена очистка по кнопке и Escape
- реализован компонент `SearchFilters` со статусом, приоритетом и датами

## Почему
Упрощает работу с задачами и добавляет гибкую фильтрацию.

## Чек-лист
- [ ] `./scripts/setup_and_test.sh`
- [ ] `./scripts/pre_pr_check.sh`
- [ ] `pnpm build`
- [ ] `pnpm run dev`

## Самопроверка
- поиск очищается по Esc
- фильтры применяются корректно
- таблица учитывает фильтры

## Риски
MongoMemoryServer падает в тестах; при проблемах откатить коммит можно командой `git revert`.

------
https://chatgpt.com/codex/tasks/task_b_68be9061d48c832093b4bfd518bdffac