### PR TITLE
feat(web): цветовая индикация статусов задач

### DIFF
--- a/apps/web/src/columns/taskColumns.tsx
+++ b/apps/web/src/columns/taskColumns.tsx
@@ -5,6 +5,13 @@ import type { ColumnDef } from "@tanstack/react-table";
 import userLink from "../utils/userLink";
 import type { Task } from "shared";
 
+// Цвета статусов задач для соответствия WCAG контрасту ≥4.5:1
+const statusColorMap: Record<Task["status"], string> = {
+  Новая: "text-gray-600",
+  "В работе": "text-blue-600",
+  Выполнена: "text-green-600",
+};
+
 export type TaskRow = Task & Record<string, any>;
 
 export default function taskColumns(
@@ -37,7 +44,14 @@ export default function taskColumns(
         return <span title={v}>{v}</span>;
       },
     },
-    { header: "Статус", accessorKey: "status" },
+    {
+      header: "Статус",
+      accessorKey: "status",
+      cell: (p) => {
+        const value = p.getValue<string>() || "";
+        return <span className={statusColorMap[value] || ""}>{value}</span>;
+      },
+    },
     { header: "Приоритет", accessorKey: "priority" },
     { header: "Начало", accessorKey: "start_date" },
     { header: "Срок", accessorKey: "due_date" },


### PR DESCRIPTION
## Summary
- add statusColorMap and color-coded status cell in task table

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh`
- `pnpm test:e2e tests/e2e/contrast.spec.ts`


------
https://chatgpt.com/codex/tasks/task_b_68becdc7b9bc83208d9ba3e28bffb38e