### PR TITLE
feat: localize file uploader and task dialog

### DIFF
--- a/apps/web/src/components/FileUploader.tsx
+++ b/apps/web/src/components/FileUploader.tsx
@@ -1,6 +1,7 @@
 // Компонент загрузки файлов с drag-and-drop и прогрессом
 // Основные модули: React, authFetch, типы задач
 import React from "react";
+import { useTranslation } from "react-i18next";
 import authFetch from "../utils/authFetch";
 import type { Attachment } from "../types/task";
 
@@ -26,6 +27,7 @@ export default function FileUploader({
   onRemove,
 }: Props) {
   const [items, setItems] = React.useState<UploadItem[]>([]);
+  const { t } = useTranslation();
 
   const handleFiles = (files: FileList | File[]) => {
     Array.from(files).forEach((file) => {
@@ -86,7 +88,7 @@ export default function FileUploader({
         method: "POST",
         body: fd,
       });
-      if (!res.ok) throw new Error("upload failed");
+      if (!res.ok) throw new Error(t("uploadFailed"));
       if (i === total - 1) attachment = (await res.json()) as Attachment;
       onProgress(Math.round(((i + 1) / total) * 100));
     }
@@ -105,7 +107,7 @@ export default function FileUploader({
         onDrop={onDrop}
         className={`mt-2 flex flex-col items-center justify-center rounded border-2 border-dashed p-4 text-sm ${disabled ? "opacity-50" : ""}`}
       >
-        <p>Перетащите файлы сюда или выберите</p>
+        <p>{t("dragFilesOrSelect")}</p>
         <input
           type="file"
           multiple
@@ -119,7 +121,7 @@ export default function FileUploader({
             <li key={i} className="flex items-center gap-2">
               {it.isImage && (
                 <img
-                  srcSet={`${(it.attachment?.thumbnailUrl || it.url)} 1x, ${(it.attachment?.url || it.url)} 2x`}
+                  srcSet={`${it.attachment?.thumbnailUrl || it.url} 1x, ${it.attachment?.url || it.url} 2x`}
                   sizes="48px"
                   src={it.attachment?.thumbnailUrl || it.url}
                   alt={it.name}
@@ -142,7 +144,7 @@ export default function FileUploader({
                 className="text-red-500"
                 onClick={() => removeItem(it)}
               >
-                Удалить
+                {t("delete")}
               </button>
             </li>
           ))}

--- a/apps/web/src/components/TaskDialog.tsx
+++ b/apps/web/src/components/TaskDialog.tsx
@@ -6,6 +6,7 @@ import CKEditorPopup from "./CKEditorPopup";
 import MultiUserSelect from "./MultiUserSelect";
 import ConfirmDialog from "./ConfirmDialog";
 import { useAuth } from "../context/useAuth";
+import { useTranslation } from "react-i18next";
 import { taskFields as fields } from "shared";
 import {
   createTask,
@@ -43,6 +44,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
   const isEdit = Boolean(id);
   const { user } = useAuth();
   const isAdmin = user?.role === "admin";
+  const { t } = useTranslation();
   const [editing, setEditing] = React.useState(true);
   const [expanded, setExpanded] = React.useState(false);
   const initialRef = React.useRef<any>(null);
@@ -961,7 +963,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
                       className="text-red-500"
                       onClick={() => removeAttachment(a)}
                     >
-                      Удалить
+                      {t("delete")}
                     </button>
                   </li>
                 ))}
@@ -979,7 +981,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
                 className="btn-red rounded-full"
                 onClick={() => setShowDeleteConfirm(true)}
               >
-                Удалить
+                {t("delete")}
               </button>
             </div>
           )}
@@ -1005,9 +1007,9 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
           )}
           <ConfirmDialog
             open={showDeleteConfirm}
-            message="Удалить задачу?"
-            confirmText="Удалить"
-            cancelText="Отмена"
+            message={t("deleteTaskQuestion")}
+            confirmText={t("delete")}
+            cancelText={t("cancel")}
             onConfirm={() => {
               setShowDeleteConfirm(false);
               handleDelete();

--- a/apps/web/src/locales/en/translation.json
+++ b/apps/web/src/locales/en/translation.json
@@ -7,5 +7,10 @@
   "language": "Language",
   "noNotifications": "No notifications",
   "notifications": "Notifications",
-  "errorFallback": "Something went wrong. Reload the page (Ctrl+R or ⌘+R)."
+  "errorFallback": "Something went wrong. Reload the page (Ctrl+R or ⌘+R).",
+  "dragFilesOrSelect": "Drag files here or select",
+  "delete": "Delete",
+  "uploadFailed": "Upload failed",
+  "deleteTaskQuestion": "Delete task?",
+  "cancel": "Cancel"
 }

--- a/apps/web/src/locales/ru/translation.json
+++ b/apps/web/src/locales/ru/translation.json
@@ -7,5 +7,10 @@
   "language": "Язык",
   "noNotifications": "Нет уведомлений",
   "notifications": "Уведомления",
-  "errorFallback": "Что-то пошло не так. Перезагрузите страницу (Ctrl+R или ⌘+R)."
+  "errorFallback": "Что-то пошло не так. Перезагрузите страницу (Ctrl+R или ⌘+R).",
+  "dragFilesOrSelect": "Перетащите файлы сюда или выберите",
+  "delete": "Удалить",
+  "uploadFailed": "Ошибка загрузки",
+  "deleteTaskQuestion": "Удалить задачу?",
+  "cancel": "Отмена"
 }


### PR DESCRIPTION
## Summary
- add i18n support for file uploader UI and errors
- localize delete actions in task dialog
- provide RU/EN translations for file operations

## Testing
- `./scripts/setup_and_test.sh`


------
https://chatgpt.com/codex/tasks/task_b_68bee961758c8320be2785a3ee39de7d