### PR TITLE
feat(web): ограничить ширину колонок и форматировать даты

### DIFF
--- a/apps/web/src/columns/taskColumns.tsx
+++ b/apps/web/src/columns/taskColumns.tsx
@@ -12,6 +12,18 @@ const statusColorMap: Record<Task["status"], string> = {
   Выполнена: "text-green-600",
 };
 
+const dateTimeFmt = new Intl.DateTimeFormat("ru-RU", {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+});
+
+const formatDate = (v?: string) =>
+  v ? dateTimeFmt.format(new Date(v)).replace(", ", " ") : "";
+
 export type TaskRow = Task & Record<string, any>;
 
 export default function taskColumns(
@@ -22,23 +34,18 @@ export default function taskColumns(
     {
       header: "Номер",
       accessorKey: "task_number",
+      meta: { minWidth: "6rem", maxWidth: "8rem" },
     },
     {
       header: "Дата создания",
       accessorKey: "createdAt",
-      cell: (p) => {
-        const v = p.getValue<string>();
-        return v
-          ? new Date(v).toLocaleString("ru-RU", {
-              dateStyle: "short",
-              timeStyle: "short",
-            })
-          : "";
-      },
+      meta: { minWidth: "12rem", maxWidth: "14rem" },
+      cell: (p) => formatDate(p.getValue<string>()),
     },
     {
       header: "Название",
       accessorKey: "title",
+      meta: { minWidth: "12rem", maxWidth: "24rem" },
       cell: (p) => {
         const v = p.getValue<string>() || "";
         return <span title={v}>{v}</span>;
@@ -47,18 +54,38 @@ export default function taskColumns(
     {
       header: "Статус",
       accessorKey: "status",
+      meta: { minWidth: "8rem", maxWidth: "10rem" },
       cell: (p) => {
         const value = p.getValue<string>() || "";
         return <span className={statusColorMap[value] || ""}>{value}</span>;
       },
     },
-    { header: "Приоритет", accessorKey: "priority" },
-    { header: "Начало", accessorKey: "start_date" },
-    { header: "Срок", accessorKey: "due_date" },
-    { header: "Тип", accessorKey: "task_type" },
+    {
+      header: "Приоритет",
+      accessorKey: "priority",
+      meta: { minWidth: "8rem", maxWidth: "10rem" },
+    },
+    {
+      header: "Начало",
+      accessorKey: "start_date",
+      meta: { minWidth: "12rem", maxWidth: "14rem" },
+      cell: (p) => formatDate(p.getValue<string>()),
+    },
+    {
+      header: "Срок",
+      accessorKey: "due_date",
+      meta: { minWidth: "12rem", maxWidth: "14rem" },
+      cell: (p) => formatDate(p.getValue<string>()),
+    },
+    {
+      header: "Тип",
+      accessorKey: "task_type",
+      meta: { minWidth: "8rem", maxWidth: "10rem" },
+    },
     {
       header: "Старт",
       accessorKey: "startCoordinates",
+      meta: { minWidth: "12rem", maxWidth: "16rem" },
       cell: (p) => {
         const v = p.getValue<any>();
         const text = v ? `${v.lat}, ${v.lng}` : "";
@@ -68,16 +95,22 @@ export default function taskColumns(
     {
       header: "Финиш",
       accessorKey: "finishCoordinates",
+      meta: { minWidth: "12rem", maxWidth: "16rem" },
       cell: (p) => {
         const v = p.getValue<any>();
         const text = v ? `${v.lat}, ${v.lng}` : "";
         return <span title={text}>{text}</span>;
       },
     },
-    { header: "Км", accessorKey: "route_distance_km" },
+    {
+      header: "Км",
+      accessorKey: "route_distance_km",
+      meta: { minWidth: "6rem", maxWidth: "8rem" },
+    },
     {
       header: "Исполнители",
       accessorKey: "assignees",
+      meta: { minWidth: "12rem", maxWidth: "20rem" },
       cell: ({ row }) => {
         const ids: number[] =
           row.original.assignees ||

--- a/apps/web/src/components/DataTable.tsx
+++ b/apps/web/src/components/DataTable.tsx
@@ -30,6 +30,11 @@ interface DataTableProps<T> {
   onRowClick?: (row: T) => void;
 }
 
+interface ColumnMeta {
+  minWidth?: string;
+  maxWidth?: string;
+}
+
 export default function DataTable<T>({
   columns,
   data,
@@ -77,21 +82,30 @@ export default function DataTable<T>({
         <TableHeader>
           {table.getHeaderGroups().map((hg) => (
             <TableRow key={hg.id}>
-              {hg.headers.map((header) => (
-                <TableHead
-                  key={header.id}
-                  style={{ width: header.getSize() }}
-                  className="max-w-[20rem] min-w-[4rem] overflow-hidden text-ellipsis whitespace-nowrap"
-                  // фиксируем ширину ячейки заголовка
-                >
-                  {header.isPlaceholder
-                    ? null
-                    : flexRender(
-                        header.column.columnDef.header,
-                        header.getContext(),
-                      )}
-                </TableHead>
-              ))}
+              {hg.headers.map((header) => {
+                const meta =
+                  (header.column.columnDef.meta as ColumnMeta | undefined) ||
+                  {};
+                return (
+                  <TableHead
+                    key={header.id}
+                    style={{
+                      width: header.getSize(),
+                      minWidth: meta.minWidth ?? "4rem",
+                      maxWidth: meta.maxWidth ?? "20rem",
+                    }}
+                    className="break-words whitespace-normal"
+                    // фиксируем ширину ячейки заголовка
+                  >
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </TableHead>
+                );
+              })}
             </TableRow>
           ))}
         </TableHeader>
@@ -103,16 +117,24 @@ export default function DataTable<T>({
               onClick={() => onRowClick?.(row.original)}
               className="cursor-pointer"
             >
-              {row.getVisibleCells().map((cell) => (
-                <TableCell
-                  key={cell.id}
-                  style={{ width: cell.column.getSize() }}
-                  className="max-w-[20rem] min-w-[4rem] overflow-hidden text-ellipsis whitespace-nowrap"
-                  // фиксируем ширину ячейки данных
-                >
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </TableCell>
-              ))}
+              {row.getVisibleCells().map((cell) => {
+                const meta =
+                  (cell.column.columnDef.meta as ColumnMeta | undefined) || {};
+                return (
+                  <TableCell
+                    key={cell.id}
+                    style={{
+                      width: cell.column.getSize(),
+                      minWidth: meta.minWidth ?? "4rem",
+                      maxWidth: meta.maxWidth ?? "20rem",
+                    }}
+                    className="break-words whitespace-normal"
+                    // фиксируем ширину ячейки данных
+                  >
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                );
+              })}
             </TableRow>
           ))}
         </TableBody>


### PR DESCRIPTION
## Summary
- добавить метаданные ширины и перенос строк в DataTable
- задать min/max ширины колонок задач и перенос текста
- форматировать даты задач через Intl.DateTimeFormat

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm build`
- `pnpm run dev`


------
https://chatgpt.com/codex/tasks/task_b_68beee68025c8320b611d24261e184c3