### PR TITLE
feat: add selectors for management forms

### DIFF
--- a/apps/web/src/components/DepartmentManager.test.tsx
+++ b/apps/web/src/components/DepartmentManager.test.tsx
@@ -1,0 +1,15 @@
+/** @jest-environment jsdom */
+// Назначение файла: проверяет наличие селекторов в DepartmentManager.
+// Основные модули: React, @testing-library/react, DepartmentManager.
+import React from "react";
+import { render } from "@testing-library/react";
+import DepartmentManager from "./DepartmentManager";
+
+describe("DepartmentManager", () => {
+  it("рендерит поле названия", () => {
+    const { container } = render(<DepartmentManager onSubmit={() => {}} />);
+    expect(
+      container.querySelector(DepartmentManager.selectors.nameInput),
+    ).not.toBeNull();
+  });
+});

--- a/apps/web/src/components/DepartmentManager.tsx
+++ b/apps/web/src/components/DepartmentManager.tsx
@@ -1,0 +1,53 @@
+// Компонент управления департаментом, содержит форму с селекторами
+// Модули: React
+import React from "react";
+
+export type DepartmentManagerProps = {
+  onSubmit: (data: { name: string }) => void;
+};
+
+type DepartmentManagerComponent = React.FC<DepartmentManagerProps> & {
+  selectors: {
+    form: string;
+    nameInput: string;
+  };
+};
+
+const DepartmentManager: DepartmentManagerComponent = ({ onSubmit }) => {
+  const [name, setName] = React.useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit({ name });
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      data-testid="department-form"
+      className="space-y-2"
+    >
+      <label className="block text-sm font-medium" htmlFor="department-name">
+        Название департамента
+      </label>
+      <input
+        id="department-name"
+        data-testid="department-name"
+        className="h-10 w-full rounded border px-3"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        required
+      />
+      <button type="submit" className="h-8 rounded bg-blue-600 px-3 text-white">
+        Сохранить
+      </button>
+    </form>
+  );
+};
+
+DepartmentManager.selectors = {
+  form: '[data-testid="department-form"]',
+  nameInput: '[data-testid="department-name"]',
+};
+
+export default DepartmentManager;

--- a/apps/web/src/components/EmployeeManager.test.tsx
+++ b/apps/web/src/components/EmployeeManager.test.tsx
@@ -1,0 +1,15 @@
+/** @jest-environment jsdom */
+// Назначение файла: проверяет наличие селекторов в EmployeeManager.
+// Основные модули: React, @testing-library/react, EmployeeManager.
+import React from "react";
+import { render } from "@testing-library/react";
+import EmployeeManager from "./EmployeeManager";
+
+describe("EmployeeManager", () => {
+  it("рендерит поле имени", () => {
+    const { container } = render(<EmployeeManager onSubmit={() => {}} />);
+    expect(
+      container.querySelector(EmployeeManager.selectors.nameInput),
+    ).not.toBeNull();
+  });
+});

--- a/apps/web/src/components/EmployeeManager.tsx
+++ b/apps/web/src/components/EmployeeManager.tsx
@@ -1,0 +1,53 @@
+// Компонент управления сотрудником, содержит форму с селекторами
+// Модули: React
+import React from "react";
+
+export type EmployeeManagerProps = {
+  onSubmit: (data: { name: string }) => void;
+};
+
+type EmployeeManagerComponent = React.FC<EmployeeManagerProps> & {
+  selectors: {
+    form: string;
+    nameInput: string;
+  };
+};
+
+const EmployeeManager: EmployeeManagerComponent = ({ onSubmit }) => {
+  const [name, setName] = React.useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit({ name });
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      data-testid="employee-form"
+      className="space-y-2"
+    >
+      <label className="block text-sm font-medium" htmlFor="employee-name">
+        Имя сотрудника
+      </label>
+      <input
+        id="employee-name"
+        data-testid="employee-name"
+        className="h-10 w-full rounded border px-3"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        required
+      />
+      <button type="submit" className="h-8 rounded bg-blue-600 px-3 text-white">
+        Сохранить
+      </button>
+    </form>
+  );
+};
+
+EmployeeManager.selectors = {
+  form: '[data-testid="employee-form"]',
+  nameInput: '[data-testid="employee-name"]',
+};
+
+export default EmployeeManager;

--- a/apps/web/src/components/FleetManager.test.tsx
+++ b/apps/web/src/components/FleetManager.test.tsx
@@ -1,0 +1,15 @@
+/** @jest-environment jsdom */
+// Назначение файла: проверяет наличие селекторов в FleetManager.
+// Основные модули: React, @testing-library/react, FleetManager.
+import React from "react";
+import { render } from "@testing-library/react";
+import FleetManager from "./FleetManager";
+
+describe("FleetManager", () => {
+  it("рендерит поле названия", () => {
+    const { container } = render(<FleetManager onSubmit={() => {}} />);
+    expect(
+      container.querySelector(FleetManager.selectors.nameInput),
+    ).not.toBeNull();
+  });
+});

--- a/apps/web/src/components/FleetManager.tsx
+++ b/apps/web/src/components/FleetManager.tsx
@@ -1,0 +1,53 @@
+// Компонент управления флотом, содержит форму с селекторами
+// Модули: React
+import React from "react";
+
+export type FleetManagerProps = {
+  onSubmit: (data: { name: string }) => void;
+};
+
+type FleetManagerComponent = React.FC<FleetManagerProps> & {
+  selectors: {
+    form: string;
+    nameInput: string;
+  };
+};
+
+const FleetManager: FleetManagerComponent = ({ onSubmit }) => {
+  const [name, setName] = React.useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit({ name });
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      data-testid="fleet-form"
+      className="space-y-2"
+    >
+      <label className="block text-sm font-medium" htmlFor="fleet-name">
+        Название флота
+      </label>
+      <input
+        id="fleet-name"
+        data-testid="fleet-name"
+        className="h-10 w-full rounded border px-3"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        required
+      />
+      <button type="submit" className="h-8 rounded bg-blue-600 px-3 text-white">
+        Сохранить
+      </button>
+    </form>
+  );
+};
+
+FleetManager.selectors = {
+  form: '[data-testid="fleet-form"]',
+  nameInput: '[data-testid="fleet-name"]',
+};
+
+export default FleetManager;


### PR DESCRIPTION
## Summary
- add FleetManager, DepartmentManager, and EmployeeManager components with form field selectors
- include basic tests for selectors

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh`
- `timeout 5s pnpm run dev` *(fails: Command failed after timeout)*

------
https://chatgpt.com/codex/tasks/task_b_68bf38234c348320990aa3fc32c89b50