### PR TITLE
test: add Collection and API tests with load test coverage

### DIFF
--- a/loadtest/locustfile.py
+++ b/loadtest/locustfile.py
@@ -8,3 +8,15 @@ class QuickTest(HttpUser):
     @task
     def tasks(self):
         self.client.get("/api/v1/tasks")
+
+    @task
+    def fleets(self):
+        self.client.get("/api/v1/fleets")
+
+    @task
+    def departments(self):
+        self.client.get("/api/v1/departments")
+
+    @task
+    def employees(self):
+        self.client.get("/api/v1/employees")

--- a/tests/api/collections.spec.ts
+++ b/tests/api/collections.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * Назначение файла: интеграционные API-тесты CRUD для коллекций.
+ * Основные модули: express, supertest, Collection.
+ */
+import express = require('express');
+import request = require('supertest');
+import { strict as assert } from 'assert';
+import { Collection, Fleet, Department, Employee } from '../../packages/shared/collection-lib';
+
+const app = express();
+app.use(express.json());
+
+const fleets = new Collection<Fleet>();
+const departments = new Collection<Department>();
+const employees = new Collection<Employee>();
+
+app.post('/fleets', (req, res) => {
+  const fleet = fleets.create(req.body);
+  res.status(201).json(fleet);
+});
+app.get('/fleets/:id', (req, res) => {
+  const fleet = fleets.read(req.params.id);
+  if (!fleet) return res.sendStatus(404);
+  res.json(fleet);
+});
+
+app.post('/departments', (req, res) => {
+  const dep = departments.create(req.body);
+  res.status(201).json(dep);
+});
+app.patch('/departments/:id', (req, res) => {
+  const dep = departments.update(req.params.id, req.body);
+  if (!dep) return res.sendStatus(404);
+  res.json(dep);
+});
+
+app.post('/employees', (req, res) => {
+  const emp = employees.create(req.body);
+  res.status(201).json(emp);
+});
+app.delete('/employees/:id', (req, res) => {
+  const ok = employees.delete(req.params.id);
+  res.sendStatus(ok ? 204 : 404);
+});
+
+describe('API коллекций', () => {
+  it('создаёт и читает флот', async () => {
+    const create = await request(app).post('/fleets').send({ id: 'f1', name: 'Флот' });
+    assert.equal(create.status, 201);
+    const read = await request(app).get('/fleets/f1');
+    assert.equal(read.body.name, 'Флот');
+  });
+
+  it('обновляет отдел', async () => {
+    await request(app).post('/departments').send({ id: 'd1', fleetId: 'f1', name: 'Отдел' });
+    const upd = await request(app).patch('/departments/d1').send({ name: 'Отдел-2' });
+    assert.equal(upd.body.name, 'Отдел-2');
+  });
+
+  it('удаляет сотрудника', async () => {
+    await request(app).post('/employees').send({ id: 'e1', departmentId: 'd1', name: 'Иван' });
+    const del = await request(app).delete('/employees/e1');
+    assert.equal(del.status, 204);
+  });
+});

--- a/tests/collection.spec.ts
+++ b/tests/collection.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * Назначение файла: unit-тесты Collection<T>.
+ * Основные модули: Collection из packages/shared/collection-lib.
+ */
+import {
+  Collection,
+  Fleet,
+  Department,
+  Employee,
+} from '../packages/shared/collection-lib';
+
+describe('Collection', () => {
+  test('создаёт и читает элемент', () => {
+    const fleets = new Collection<Fleet>();
+    const fleet = fleets.create({ id: '1', name: 'Флот-1' });
+    expect(fleets.read('1')).toEqual(fleet);
+  });
+
+  test('обновляет существующий элемент', () => {
+    const deps = new Collection<Department>();
+    deps.create({ id: 'd1', fleetId: 'f1', name: 'Отдел-1' });
+    const updated = deps.update('d1', { name: 'Отдел-1b' });
+    expect(updated?.name).toBe('Отдел-1b');
+  });
+
+  test('удаляет элемент', () => {
+    const emps = new Collection<Employee>();
+    emps.create({ id: 'e1', departmentId: 'd1', name: 'Иван' });
+    expect(emps.delete('e1')).toBe(true);
+    expect(emps.read('e1')).toBeUndefined();
+  });
+
+  test('выводит список элементов', () => {
+    const fleets = new Collection<Fleet>();
+    fleets.create({ id: 'f1', name: 'Флот-1' });
+    fleets.create({ id: 'f2', name: 'Флот-2' });
+    const list = fleets.list();
+    expect(list).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for generic Collection
- add integration API tests for fleets, departments, employees
- extend locust load test with collection endpoints

## Testing
- `pnpm lint`
- `pnpm test:unit tests/collection.spec.ts`
- `pnpm test:api tests/api/collections.spec.ts`
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68bf3c447ba883208148790a3e91c658