### PR TITLE
feat: refine task table layout

### DIFF
--- a/apps/web/src/columns/taskColumns.tsx
+++ b/apps/web/src/columns/taskColumns.tsx
@@ -27,25 +27,24 @@ const formatDate = (v?: string) =>
 export type TaskRow = Task & Record<string, any>;
 
 export default function taskColumns(
-  selectable: boolean,
   users: Record<number, any>,
 ): ColumnDef<TaskRow, any>[] {
   const cols: ColumnDef<TaskRow, any>[] = [
     {
       header: "Номер",
       accessorKey: "task_number",
-      meta: { minWidth: "6rem", maxWidth: "8rem" },
+      meta: { minWidth: "4rem", maxWidth: "6rem" },
     },
     {
       header: "Дата создания",
       accessorKey: "createdAt",
-      meta: { minWidth: "12rem", maxWidth: "14rem" },
+      meta: { minWidth: "10rem", maxWidth: "12rem" },
       cell: (p) => formatDate(p.getValue<string>()),
     },
     {
       header: "Название",
       accessorKey: "title",
-      meta: { minWidth: "12rem", maxWidth: "24rem" },
+      meta: { minWidth: "10rem", maxWidth: "20rem" },
       cell: (p) => {
         const v = p.getValue<string>() || "";
         return <span title={v}>{v}</span>;
@@ -54,7 +53,7 @@ export default function taskColumns(
     {
       header: "Статус",
       accessorKey: "status",
-      meta: { minWidth: "8rem", maxWidth: "10rem" },
+      meta: { minWidth: "6rem", maxWidth: "8rem" },
       cell: (p) => {
         const value = p.getValue<string>() || "";
         return <span className={statusColorMap[value] || ""}>{value}</span>;
@@ -63,29 +62,29 @@ export default function taskColumns(
     {
       header: "Приоритет",
       accessorKey: "priority",
-      meta: { minWidth: "8rem", maxWidth: "10rem" },
+      meta: { minWidth: "6rem", maxWidth: "8rem" },
     },
     {
       header: "Начало",
       accessorKey: "start_date",
-      meta: { minWidth: "12rem", maxWidth: "14rem" },
+      meta: { minWidth: "10rem", maxWidth: "12rem" },
       cell: (p) => formatDate(p.getValue<string>()),
     },
     {
       header: "Срок",
       accessorKey: "due_date",
-      meta: { minWidth: "12rem", maxWidth: "14rem" },
+      meta: { minWidth: "10rem", maxWidth: "12rem" },
       cell: (p) => formatDate(p.getValue<string>()),
     },
     {
       header: "Тип",
       accessorKey: "task_type",
-      meta: { minWidth: "8rem", maxWidth: "10rem" },
+      meta: { minWidth: "6rem", maxWidth: "8rem" },
     },
     {
       header: "Старт",
       accessorKey: "startCoordinates",
-      meta: { minWidth: "12rem", maxWidth: "16rem" },
+      meta: { minWidth: "10rem", maxWidth: "14rem" },
       cell: (p) => {
         const v = p.getValue<any>();
         const text = v ? `${v.lat}, ${v.lng}` : "";
@@ -95,7 +94,7 @@ export default function taskColumns(
     {
       header: "Финиш",
       accessorKey: "finishCoordinates",
-      meta: { minWidth: "12rem", maxWidth: "16rem" },
+      meta: { minWidth: "10rem", maxWidth: "14rem" },
       cell: (p) => {
         const v = p.getValue<any>();
         const text = v ? `${v.lat}, ${v.lng}` : "";
@@ -105,12 +104,12 @@ export default function taskColumns(
     {
       header: "Км",
       accessorKey: "route_distance_km",
-      meta: { minWidth: "6rem", maxWidth: "8rem" },
+      meta: { minWidth: "4rem", maxWidth: "6rem" },
     },
     {
       header: "Исполнители",
       accessorKey: "assignees",
-      meta: { minWidth: "12rem", maxWidth: "20rem" },
+      meta: { minWidth: "10rem", maxWidth: "16rem" },
       cell: ({ row }) => {
         const ids: number[] =
           row.original.assignees ||
@@ -139,26 +138,5 @@ export default function taskColumns(
       },
     },
   ];
-  if (selectable) {
-    cols.unshift({
-      id: "select",
-      header: ({ table }) => (
-        <input
-          type="checkbox"
-          checked={table.getIsAllPageRowsSelected()}
-          onChange={(e) => table.toggleAllPageRowsSelected(e.target.checked)}
-        />
-      ),
-      cell: ({ row }) => (
-        <input
-          type="checkbox"
-          checked={row.getIsSelected()}
-          onChange={(e) => row.toggleSelected(e.target.checked)}
-        />
-      ),
-      enableSorting: false,
-      enableHiding: false,
-    });
-  }
   return cols;
 }

--- a/apps/web/src/components/DataTable.tsx
+++ b/apps/web/src/components/DataTable.tsx
@@ -26,8 +26,8 @@ interface DataTableProps<T> {
   pageCount?: number;
   onPageChange: (page: number) => void;
   onPageSizeChange?: (size: number) => void;
-  onSelectionChange?: (rows: T[]) => void;
   onRowClick?: (row: T) => void;
+  toolbarChildren?: React.ReactNode;
 }
 
 interface ColumnMeta {
@@ -43,10 +43,9 @@ export default function DataTable<T>({
   pageCount,
   onPageChange,
   onPageSizeChange,
-  onSelectionChange,
   onRowClick,
+  toolbarChildren,
 }: DataTableProps<T>) {
-  const [rowSelection, setRowSelection] = React.useState({});
   const [columnVisibility, setColumnVisibility] = React.useState({});
   const [columnOrder, setColumnOrder] = React.useState<string[]>([]);
 
@@ -54,13 +53,10 @@ export default function DataTable<T>({
     data,
     columns,
     state: {
-      rowSelection,
       columnVisibility,
       columnOrder,
       pagination: { pageIndex, pageSize },
     },
-    enableRowSelection: true,
-    onRowSelectionChange: setRowSelection,
     onColumnVisibilityChange: setColumnVisibility,
     onColumnOrderChange: setColumnOrder,
     getCoreRowModel: getCoreRowModel(),
@@ -68,16 +64,11 @@ export default function DataTable<T>({
     pageCount,
   });
 
-  React.useEffect(() => {
-    if (onSelectionChange) {
-      const selected = table.getSelectedRowModel().rows.map((r) => r.original);
-      onSelectionChange(selected as T[]);
-    }
-  }, [rowSelection, table, onSelectionChange]);
-
   return (
     <div className="space-y-2">
-      <TableToolbar table={table as TableType<T>} />
+      <TableToolbar table={table as TableType<T>}>
+        {toolbarChildren}
+      </TableToolbar>
       <Table>
         <TableHeader>
           {table.getHeaderGroups().map((hg) => (
@@ -92,7 +83,7 @@ export default function DataTable<T>({
                     style={{
                       width: header.getSize(),
                       minWidth: meta.minWidth ?? "4rem",
-                      maxWidth: meta.maxWidth ?? "20rem",
+                      maxWidth: meta.maxWidth ?? "16rem",
                     }}
                     className="break-words whitespace-normal"
                     // фиксируем ширину ячейки заголовка
@@ -113,7 +104,6 @@ export default function DataTable<T>({
           {table.getRowModel().rows.map((row) => (
             <TableRow
               key={row.id}
-              data-state={row.getIsSelected() ? "selected" : undefined}
               onClick={() => onRowClick?.(row.original)}
               className="cursor-pointer"
             >
@@ -126,7 +116,7 @@ export default function DataTable<T>({
                     style={{
                       width: cell.column.getSize(),
                       minWidth: meta.minWidth ?? "4rem",
-                      maxWidth: meta.maxWidth ?? "20rem",
+                      maxWidth: meta.maxWidth ?? "16rem",
                     }}
                     className="break-words whitespace-normal"
                     // фиксируем ширину ячейки данных

--- a/apps/web/src/components/GlobalSearch.tsx
+++ b/apps/web/src/components/GlobalSearch.tsx
@@ -34,7 +34,7 @@ export default function GlobalSearch() {
         onKeyDown={onKey}
         placeholder={t("search")}
         aria-label={t("search")}
-        className="h-9 w-64 pr-8 pl-8"
+        className="h-8 w-52 pr-8 pl-8"
       />
       {query && (
         <button

--- a/apps/web/src/components/SearchFilters.tsx
+++ b/apps/web/src/components/SearchFilters.tsx
@@ -22,7 +22,7 @@ export default function SearchFilters() {
       <summary className="cursor-pointer rounded border px-2 py-1 select-none">
         Фильтры
       </summary>
-      <div className="absolute z-10 mt-1 flex w-64 flex-col gap-2 rounded border bg-white p-2 shadow">
+      <div className="absolute z-10 mt-1 flex w-56 flex-col gap-2 rounded border bg-white p-2 shadow">
         <div>
           <span className="block text-sm font-medium">Статус</span>
           {TASK_STATUSES.map((s) => (

--- a/apps/web/src/components/TableToolbar.tsx
+++ b/apps/web/src/components/TableToolbar.tsx
@@ -1,14 +1,16 @@
 // Назначение файла: общий тулбар таблицы с экспортом, поиском и фильтрацией
 // Модули: React, @tanstack/react-table, jspdf
+import React from "react";
 import type { Table } from "@tanstack/react-table";
 import GlobalSearch from "./GlobalSearch";
 import SearchFilters from "./SearchFilters";
 
 interface Props<T> {
   table: Table<T>;
+  children?: React.ReactNode;
 }
 
-export default function TableToolbar<T>({ table }: Props<T>) {
+export default function TableToolbar<T>({ table, children }: Props<T>) {
   const columns = table.getAllLeafColumns();
 
   const exportCsv = () => {
@@ -109,6 +111,7 @@ export default function TableToolbar<T>({ table }: Props<T>) {
           ))}
         </div>
       </details>
+      {children}
     </div>
   );
 }

--- a/apps/web/src/components/TaskTable.tsx
+++ b/apps/web/src/components/TaskTable.tsx
@@ -8,24 +8,24 @@ import useTasks from "../context/useTasks";
 interface TaskTableProps {
   tasks: TaskRow[];
   users?: Record<number, any>;
-  onSelectionChange?: (ids: string[]) => void;
   page: number;
   pageCount?: number;
   onPageChange: (p: number) => void;
   onRowClick?: (id: string) => void;
+  toolbarChildren?: React.ReactNode;
 }
 
 export default function TaskTable({
   tasks,
   users = {},
-  onSelectionChange,
   page,
   pageCount,
   onPageChange,
   onRowClick,
+  toolbarChildren,
 }: TaskTableProps) {
   const { query, filters } = useTasks();
-  const columns = React.useMemo(() => taskColumns(true, users), [users]);
+  const columns = React.useMemo(() => taskColumns(users), [users]);
 
   return (
     <Suspense fallback={<div>Загрузка таблицы...</div>}>
@@ -55,10 +55,8 @@ export default function TaskTable({
         pageSize={25}
         pageCount={pageCount}
         onPageChange={onPageChange}
-        onSelectionChange={(rows) =>
-          onSelectionChange?.((rows as TaskRow[]).map((r) => r._id))
-        }
         onRowClick={(row) => onRowClick?.((row as TaskRow)._id)}
+        toolbarChildren={toolbarChildren}
       />
     </Suspense>
   );

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+// Назначение файла: базовые элементы таблицы на Tailwind
+// Модули: React, util cn
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
@@ -57,7 +59,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
     <tr
       data-slot="table-row"
       className={cn(
-        "hover:bg-muted/50 data-[state=selected]:bg-muted h-12 border-b transition-colors",
+        "hover:bg-muted/50 data-[state=selected]:bg-muted h-10 border-b transition-colors",
         className,
       )}
       {...props}
@@ -70,7 +72,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "text-foreground h-12 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
       )}
       {...props}
@@ -83,7 +85,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "h-12 p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "h-10 p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- move task actions into table toolbar and drop mass operations
- shrink controls and table spacing for denser layout
- remove row selection and checkbox column

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68bfd4b7161083209442c27f390b1450