### PR TITLE
feat: add manager role and new user fields

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -57,10 +57,20 @@ async function verifyCode(
   let u = user;
   if (!u)
     u = await createUser(telegramId, username, roleId || config.userRoleId, {
-      access: roleId === config.adminRoleId ? 2 : 1,
+      access:
+        roleId === config.adminRoleId
+          ? 2
+          : roleId === config.managerRoleId
+            ? 4
+            : 1,
     });
-  const role = roleId === config.adminRoleId ? 'admin' : 'user';
-  const access = role === 'admin' ? 2 : 1;
+  const role =
+    roleId === config.adminRoleId
+      ? 'admin'
+      : roleId === config.managerRoleId
+        ? 'manager'
+        : 'user';
+  const access = role === 'admin' ? 2 : role === 'manager' ? 4 : 1;
   const token = generateToken({
     id: telegramId,
     username: u.username || '',

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -68,6 +68,8 @@ export const adminRoleId =
   process.env.ADMIN_ROLE_ID || '686591126cc86a6bd16c18af';
 export const userRoleId =
   process.env.USER_ROLE_ID || '686633fdf6896f1ad3fa063e';
+export const managerRoleId =
+  process.env.MANAGER_ROLE_ID || '686633fdf6896f1ad3fa063f';
 
 const config = {
   botToken,
@@ -82,6 +84,7 @@ const config = {
   cookieDomain,
   adminRoleId,
   userRoleId,
+  managerRoleId,
 };
 
 export default config;

--- a/apps/api/src/db/model.ts
+++ b/apps/api/src/db/model.ts
@@ -341,11 +341,14 @@ export interface UserAttrs {
   phone?: string;
   mobNumber?: string;
   email: string;
-  role?: 'user' | 'admin';
+  role?: 'user' | 'admin' | 'manager';
   access: number;
   roleId?: Types.ObjectId;
   receive_reminders?: boolean;
   verified_at?: Date;
+  departmentId?: Types.ObjectId;
+  divisionId?: Types.ObjectId;
+  positionId?: Types.ObjectId;
 }
 
 export interface UserDocument extends UserAttrs, Document {}
@@ -363,10 +366,13 @@ const userSchema = new Schema<UserDocument>({
   // Сохраняем уникальное значение на основе telegram_id.
   email: { type: String, unique: true },
   // Роль пользователя хранится строкой, по умолчанию обычный пользователь
-  role: { type: String, enum: ['user', 'admin'], default: 'user' },
-  // Маска доступа: 1 - пользователь, 2 - администратор
+  role: { type: String, enum: ['user', 'admin', 'manager'], default: 'user' },
+  // Маска доступа: 1 - пользователь, 2 - администратор, 4 - менеджер
   access: { type: Number, default: 1 },
   roleId: { type: Schema.Types.ObjectId, ref: 'Role' },
+  departmentId: { type: Schema.Types.ObjectId, ref: 'CollectionItem' },
+  divisionId: { type: Schema.Types.ObjectId, ref: 'CollectionItem' },
+  positionId: { type: Schema.Types.ObjectId, ref: 'CollectionItem' },
   // Настройка получения напоминаний планировщиком
   receive_reminders: { type: Boolean, default: true },
   // Дата прохождения верификации через Bot API

--- a/apps/api/src/db/models/employee.ts
+++ b/apps/api/src/db/models/employee.ts
@@ -4,6 +4,8 @@ import { Schema, model, Document, Types } from 'mongoose';
 
 export interface EmployeeAttrs {
   departmentId: Types.ObjectId;
+  divisionId?: Types.ObjectId;
+  positionId?: Types.ObjectId;
   name: string;
 }
 
@@ -15,6 +17,8 @@ const employeeSchema = new Schema<EmployeeDocument>({
     ref: 'Department',
     required: true,
   },
+  divisionId: { type: Schema.Types.ObjectId, ref: 'CollectionItem' },
+  positionId: { type: Schema.Types.ObjectId, ref: 'CollectionItem' },
   name: { type: String, required: true },
 });
 

--- a/apps/api/src/dto/employees.dto.ts
+++ b/apps/api/src/dto/employees.dto.ts
@@ -6,6 +6,8 @@ export class CreateEmployeeDto {
   static rules() {
     return [
       body('departmentId').isMongoId(),
+      body('divisionId').optional().isMongoId(),
+      body('positionId').optional().isMongoId(),
       body('name').isString().notEmpty(),
     ];
   }
@@ -15,6 +17,8 @@ export class UpdateEmployeeDto {
   static rules() {
     return [
       body('departmentId').optional().isMongoId(),
+      body('divisionId').optional().isMongoId(),
+      body('positionId').optional().isMongoId(),
       body('name').optional().isString().notEmpty(),
     ];
   }

--- a/apps/api/src/dto/users.dto.ts
+++ b/apps/api/src/dto/users.dto.ts
@@ -20,9 +20,12 @@ export class UpdateUserDto {
       body('phone').optional().isString(),
       body('mobNumber').optional().isString(),
       body('email').optional().isEmail(),
-      body('role').optional().isIn(['user', 'admin']),
+      body('role').optional().isIn(['user', 'admin', 'manager']),
       body('access').optional().isInt(),
       body('roleId').optional().isMongoId(),
+      body('departmentId').optional().isMongoId(),
+      body('divisionId').optional().isMongoId(),
+      body('positionId').optional().isMongoId(),
       body('receive_reminders').optional().isBoolean(),
       body('verified_at').optional().isISO8601(),
     ];

--- a/apps/api/src/middleware/taskAccess.ts
+++ b/apps/api/src/middleware/taskAccess.ts
@@ -1,7 +1,12 @@
 // Назначение: проверка права пользователя изменять задачу
 // Основные модули: express, accessMask, tasks, service
 import { Response, NextFunction } from 'express';
-import { hasAccess, ACCESS_ADMIN, ACCESS_USER } from '../utils/accessMask';
+import {
+  hasAccess,
+  ACCESS_ADMIN,
+  ACCESS_USER,
+  ACCESS_MANAGER,
+} from '../utils/accessMask';
 import * as service from '../services/tasks';
 import { writeLog } from '../services/service';
 import type { RequestWithUser, TaskInfo } from '../types/request';
@@ -26,6 +31,7 @@ export default async function checkTaskAccess(
   const id = Number(req.user?.id);
   if (
     hasAccess(mask, ACCESS_ADMIN) ||
+    hasAccess(mask, ACCESS_MANAGER) ||
     task.created_by === id ||
     task.assigned_user_id === id ||
     task.controller_user_id === id ||

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -28,6 +28,9 @@ import { scanFile } from '../services/antivirus';
 import { writeLog } from '../services/wgLogEngine';
 import { maxUserFiles, maxUserStorage } from '../config/limits';
 import { checkFile } from '../utils/fileCheck';
+import { Roles } from '../auth/roles.decorator';
+import rolesGuard from '../auth/roles.guard';
+import { ACCESS_ADMIN } from '../utils/accessMask';
 
 if (!fs.existsSync(uploadsDir)) fs.mkdirSync(uploadsDir, { recursive: true });
 if (ffmpegPath) ffmpeg.setFfmpegPath(ffmpegPath);
@@ -374,6 +377,8 @@ router.delete(
   '/:id',
   authMiddleware(),
   param('id').isMongoId(),
+  Roles(ACCESS_ADMIN) as unknown as RequestHandler,
+  rolesGuard as unknown as RequestHandler,
   checkTaskAccess as unknown as RequestHandler,
   ctrl.remove as RequestHandler,
 );

--- a/apps/api/src/utils/formatUser.ts
+++ b/apps/api/src/utils/formatUser.ts
@@ -2,7 +2,13 @@
 // Основные модули: отсутствуют
 import type { User } from 'shared';
 
-export type UserLike = Partial<User> & {
+export type UserLike = Partial<
+  Omit<User, 'roleId' | 'departmentId' | 'divisionId' | 'positionId'>
+> & {
+  roleId?: unknown;
+  departmentId?: unknown;
+  divisionId?: unknown;
+  positionId?: unknown;
   telegram_username?: string | null;
   toObject?: () => UserLike;
 };
@@ -12,5 +18,12 @@ export default function formatUser(user: UserLike | null): UserLike | null {
   const obj: UserLike = user.toObject ? user.toObject() : { ...user };
   obj.telegram_username = obj.username;
   obj.username = String(obj.telegram_id ?? '');
+  if ((obj as any).roleId) (obj as any).roleId = String((obj as any).roleId);
+  if ((obj as any).departmentId)
+    (obj as any).departmentId = String((obj as any).departmentId);
+  if ((obj as any).divisionId)
+    (obj as any).divisionId = String((obj as any).divisionId);
+  if ((obj as any).positionId)
+    (obj as any).positionId = String((obj as any).positionId);
   return obj;
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -31,6 +31,7 @@ import { TasksProvider } from "./context/TasksContext";
 import Toasts from "./components/Toasts";
 import ProtectedRoute from "./components/ProtectedRoute";
 import AdminRoute from "./components/AdminRoute";
+import ManagerRoute from "./components/ManagerRoute";
 import TaskDialogRoute from "./components/TaskDialogRoute";
 import ErrorBoundary from "./components/ErrorBoundary";
 
@@ -59,6 +60,30 @@ function Content() {
               <ProtectedRoute>
                 <TasksPage />
               </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/mg/kanban"
+            element={
+              <ManagerRoute>
+                <TaskKanban />
+              </ManagerRoute>
+            }
+          />
+          <Route
+            path="/mg/reports"
+            element={
+              <ManagerRoute>
+                <Reports />
+              </ManagerRoute>
+            }
+          />
+          <Route
+            path="/mg/routes"
+            element={
+              <ManagerRoute>
+                <RoutesPage />
+              </ManagerRoute>
             }
           />
           <Route

--- a/apps/web/src/components/EmployeeManager.tsx
+++ b/apps/web/src/components/EmployeeManager.tsx
@@ -1,24 +1,52 @@
 // Компонент управления сотрудником, содержит форму с селекторами
 // Модули: React
 import React from "react";
+import { fetchCollectionItems } from "../services/collections";
 
 export type EmployeeManagerProps = {
-  onSubmit: (data: { name: string }) => void;
+  onSubmit: (data: {
+    name: string;
+    departmentId?: string;
+    divisionId?: string;
+    positionId?: string;
+  }) => void;
 };
 
 type EmployeeManagerComponent = React.FC<EmployeeManagerProps> & {
   selectors: {
     form: string;
     nameInput: string;
+    departmentSelect: string;
+    divisionSelect: string;
+    positionSelect: string;
   };
 };
 
 const EmployeeManager: EmployeeManagerComponent = ({ onSubmit }) => {
   const [name, setName] = React.useState("");
+  const [departmentId, setDepartmentId] = React.useState("");
+  const [divisionId, setDivisionId] = React.useState("");
+  const [positionId, setPositionId] = React.useState("");
+  const [departments, setDepartments] = React.useState<any[]>([]);
+  const [divisions, setDivisions] = React.useState<any[]>([]);
+  const [positions, setPositions] = React.useState<any[]>([]);
+
+  React.useEffect(() => {
+    if (typeof fetch === "undefined") return;
+    fetchCollectionItems("departments", "", 1, 100).then((d) =>
+      setDepartments(d.items),
+    );
+    fetchCollectionItems("divisions", "", 1, 100).then((d) =>
+      setDivisions(d.items),
+    );
+    fetchCollectionItems("roles", "", 1, 100).then((d) =>
+      setPositions(d.items),
+    );
+  }, []);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    onSubmit({ name });
+    onSubmit({ name, departmentId, divisionId, positionId });
   };
 
   return (
@@ -38,6 +66,54 @@ const EmployeeManager: EmployeeManagerComponent = ({ onSubmit }) => {
         onChange={(e) => setName(e.target.value)}
         required
       />
+      <label className="block text-sm font-medium" htmlFor="employee-dept">
+        Департамент
+      </label>
+      <select
+        id="employee-dept"
+        className="h-10 w-full rounded border px-3"
+        value={departmentId}
+        onChange={(e) => setDepartmentId(e.target.value)}
+      >
+        <option value=""></option>
+        {departments.map((d) => (
+          <option key={d._id} value={d._id}>
+            {d.name}
+          </option>
+        ))}
+      </select>
+      <label className="block text-sm font-medium" htmlFor="employee-div">
+        Отдел
+      </label>
+      <select
+        id="employee-div"
+        className="h-10 w-full rounded border px-3"
+        value={divisionId}
+        onChange={(e) => setDivisionId(e.target.value)}
+      >
+        <option value=""></option>
+        {divisions.map((d) => (
+          <option key={d._id} value={d._id}>
+            {d.name}
+          </option>
+        ))}
+      </select>
+      <label className="block text-sm font-medium" htmlFor="employee-pos">
+        Должность
+      </label>
+      <select
+        id="employee-pos"
+        className="h-10 w-full rounded border px-3"
+        value={positionId}
+        onChange={(e) => setPositionId(e.target.value)}
+      >
+        <option value=""></option>
+        {positions.map((p) => (
+          <option key={p._id} value={p._id}>
+            {p.name}
+          </option>
+        ))}
+      </select>
       <button type="submit" className="h-8 rounded bg-blue-600 px-3 text-white">
         Сохранить
       </button>
@@ -48,6 +124,9 @@ const EmployeeManager: EmployeeManagerComponent = ({ onSubmit }) => {
 EmployeeManager.selectors = {
   form: '[data-testid="employee-form"]',
   nameInput: '[data-testid="employee-name"]',
+  departmentSelect: "#employee-dept",
+  divisionSelect: "#employee-div",
+  positionSelect: "#employee-pos",
 };
 
 export default EmployeeManager;

--- a/apps/web/src/components/ManagerRoute.tsx
+++ b/apps/web/src/components/ManagerRoute.tsx
@@ -1,0 +1,15 @@
+// Маршрут для менеджера или администратора
+// Модули: React Router, хук useAuth
+import { type ReactElement } from "react";
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../context/useAuth";
+import Loader from "./Loader";
+
+export default function ManagerRoute({ children }: { children: ReactElement }) {
+  const { user, loading } = useAuth();
+  if (loading) return <Loader />;
+  if (!user) return <Navigate to="/login" />;
+  if (user.role !== "admin" && user.role !== "manager")
+    return <Navigate to="/tasks" />;
+  return children;
+}

--- a/apps/web/src/components/TaskDialog.tsx
+++ b/apps/web/src/components/TaskDialog.tsx
@@ -44,6 +44,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
   const isEdit = Boolean(id);
   const { user } = useAuth();
   const isAdmin = user?.role === "admin";
+  const canEditAll = isAdmin || user?.role === "manager";
   const { t } = useTranslation();
   const [editing, setEditing] = React.useState(true);
   const [expanded, setExpanded] = React.useState(false);
@@ -271,7 +272,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
   ]);
 
   React.useEffect(() => {
-    if (isAdmin) {
+    if (canEditAll) {
       authFetch("/api/v1/users")
         .then((r) => (r.ok ? r.json() : []))
         .then((list) => {
@@ -282,7 +283,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
       setCreator(String((user as UserBrief).telegram_id));
       setUsers([user as UserBrief]);
     }
-  }, [user, isAdmin]);
+  }, [user, canEditAll]);
 
   React.useEffect(() => {
     if (!isEdit || !id) return;

--- a/apps/web/src/layouts/Sidebar.tsx
+++ b/apps/web/src/layouts/Sidebar.tsx
@@ -29,13 +29,21 @@ const adminItems = [
   { to: "/cp/storage", label: "Файлы", icon: RectangleStackIcon },
 ];
 
+const managerItems = [
+  { to: "/mg/kanban", label: "Канбан", icon: ClipboardDocumentListIcon },
+  { to: "/mg/reports", label: "Отчёты", icon: ChartPieIcon },
+  { to: "/mg/routes", label: "Маршруты", icon: MapIcon },
+];
+
 export default function Sidebar() {
   const { open, toggle, collapsed, toggleCollapsed } = useSidebar();
   const { pathname } = useLocation();
   const { user } = useAuth();
   const role = user?.role || "user";
   const items = React.useMemo(() => {
-    return role === "admin" ? [...baseItems, ...adminItems] : baseItems;
+    if (role === "admin") return [...baseItems, ...adminItems];
+    if (role === "manager") return [...baseItems, ...managerItems];
+    return baseItems;
   }, [role]);
   return (
     <aside

--- a/apps/web/src/pages/Settings/CollectionsPage.tsx
+++ b/apps/web/src/pages/Settings/CollectionsPage.tsx
@@ -44,7 +44,9 @@ const emptyUser: UserFormData = {
   role: "user",
   access: 1,
   roleId: "",
-  receive_reminders: true,
+  departmentId: "",
+  divisionId: "",
+  positionId: "",
 };
 
 interface ItemForm {

--- a/apps/web/src/pages/TasksPage.tsx
+++ b/apps/web/src/pages/TasksPage.tsx
@@ -21,6 +21,8 @@ export default function TasksPage() {
   const { version, refresh } = useTasks();
   const { user } = useAuth();
   const isAdmin = user?.role === "admin";
+  const isManager = user?.role === "manager";
+  const isPrivileged = isAdmin || isManager;
 
   const load = React.useCallback(() => {
     setLoading(true);
@@ -32,7 +34,7 @@ export default function TasksPage() {
         const tasks = (
           Array.isArray(data) ? data : data.tasks || []
         ) as TaskExtra[];
-        const filteredTasks = isAdmin
+        const filteredTasks = isPrivileged
           ? tasks
           : tasks.filter((t) => {
               const assigned =
@@ -50,14 +52,14 @@ export default function TasksPage() {
         setUsers(list);
       })
       .finally(() => setLoading(false));
-    if (isAdmin) {
+    if (isPrivileged) {
       authFetch("/api/v1/users")
         .then((r) => (r.ok ? r.json() : []))
         .then((list) =>
           setUsers(Array.isArray(list) ? list : Object.values(list || {})),
         );
     }
-  }, [isAdmin, user, page]);
+  }, [isPrivileged, user, page]);
 
   React.useEffect(load, [load, version, page]);
   const tasks = React.useMemo(() => all, [all]);

--- a/packages/shared/collection-lib/types.ts
+++ b/packages/shared/collection-lib/types.ts
@@ -16,4 +16,6 @@ export interface Department extends BaseItem {
 
 export interface Employee extends BaseItem {
   departmentId: string;
+  divisionId?: string;
+  positionId?: string;
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -15,4 +15,9 @@ export interface User {
   name?: string;
   phone?: string;
   role?: string;
+  access?: number;
+  roleId?: string;
+  departmentId?: string;
+  divisionId?: string;
+  positionId?: string;
 }


### PR DESCRIPTION
## Summary
- support manager role with access 4 and mapping
- extend user and employee forms with department, division and position
- expose /mg routes for managers and restrict task deletion to admins

## Testing
- `pnpm test`
- `./scripts/pre_pr_check.sh`

------
https://chatgpt.com/codex/tasks/task_b_68c04c135c7883208fd7677a550bb0e0