### PR TITLE
feat: вычисление access по роли

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -35,8 +35,6 @@ async function verifyCode(
     if (verified && user && roleId !== config.adminRoleId) {
       user = await updateUser(telegramId, {
         roleId: new Types.ObjectId(config.adminRoleId),
-        role: 'admin',
-        access: 2,
       });
       await writeLog(`Пользователь ${telegramId} повышен до администратора`);
       roleId = config.adminRoleId;
@@ -56,14 +54,7 @@ async function verifyCode(
   }
   let u = user;
   if (!u)
-    u = await createUser(telegramId, username, roleId || config.userRoleId, {
-      access:
-        roleId === config.adminRoleId
-          ? 2
-          : roleId === config.managerRoleId
-            ? 4
-            : 1,
-    });
+    u = await createUser(telegramId, username, roleId || config.userRoleId);
   const role =
     roleId === config.adminRoleId
       ? 'admin'
@@ -100,7 +91,6 @@ async function verifyInitData(initData: string) {
       telegramId,
       userData.username || '',
       config.userRoleId,
-      { access: 1 },
     );
   }
   const role = user.role || 'user';
@@ -126,7 +116,6 @@ async function verifyTmaLogin(initData: ReturnType<typeof verifyInit>) {
       telegramId,
       userData.username || '',
       config.userRoleId,
-      { access: 1 },
     );
   }
   const role = user.role || 'user';
@@ -146,7 +135,10 @@ async function getProfile(id: string | number) {
   return user || null;
 }
 
-async function updateProfile(id: string | number, data: Partial<UserDocument>) {
+async function updateProfile(
+  id: string | number,
+  data: Omit<Partial<UserDocument>, 'access'>,
+) {
   const user = await updateUser(id, data);
   return user || null;
 }

--- a/apps/api/src/dto/users.dto.ts
+++ b/apps/api/src/dto/users.dto.ts
@@ -20,8 +20,6 @@ export class UpdateUserDto {
       body('phone').optional().isString(),
       body('mobNumber').optional().isString(),
       body('email').optional().isEmail(),
-      body('role').optional().isIn(['user', 'admin', 'manager']),
-      body('access').optional().isInt(),
       body('roleId').optional().isMongoId(),
       body('departmentId').optional().isMongoId(),
       body('divisionId').optional().isMongoId(),

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -15,7 +15,7 @@ interface CreateUserBody {
   roleId?: string;
 }
 
-type UpdateUserBody = Partial<UserDocument>;
+type UpdateUserBody = Omit<Partial<UserDocument>, 'access' | 'role'>;
 
 @injectable()
 export default class UsersController {

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -8,12 +8,12 @@ interface UsersRepo {
     id: string | number,
     username?: string,
     roleId?: string,
-    data?: Partial<UserDocument>,
+    data?: Omit<Partial<UserDocument>, 'access' | 'role'>,
   ): Promise<UserDocument>;
   getUser(id: string | number): Promise<UserDocument | null>;
   updateUser(
     id: string | number,
-    data: Partial<UserDocument>,
+    data: Omit<Partial<UserDocument>, 'access'>,
   ): Promise<UserDocument | null>;
 }
 
@@ -32,7 +32,7 @@ class UsersService {
     id: string | number,
     username?: string,
     roleId?: string,
-    data: Partial<UserDocument> = {},
+    data: Omit<Partial<UserDocument>, 'access' | 'role'> = {},
   ) {
     return this.repo.createUser(id, username, roleId, data);
   }
@@ -41,7 +41,7 @@ class UsersService {
     return this.repo.getUser(id);
   }
 
-  update(id: string | number, data: Partial<UserDocument>) {
+  update(id: string | number, data: Omit<Partial<UserDocument>, 'access'>) {
     return this.repo.updateUser(id, data);
   }
 }

--- a/tests/access.roles.spec.ts
+++ b/tests/access.roles.spec.ts
@@ -1,0 +1,19 @@
+/**
+ * Назначение файла: проверка вычисления уровней доступа по ролям.
+ * Основные модули: accessByRole из db/queries.
+ */
+import { accessByRole } from '../apps/api/src/db/queries';
+
+describe('доступ по ролям', () => {
+  test('администратор получает маску 2', () => {
+    expect(accessByRole('admin')).toBe(2);
+  });
+
+  test('менеджер получает маску 4', () => {
+    expect(accessByRole('manager')).toBe(4);
+  });
+
+  test('обычный пользователь получает маску 1', () => {
+    expect(accessByRole('user')).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- рассчитывать числовой доступ по имени роли
- автоматом выставлять role/access по roleId в сервисе пользователей
- добавить тесты масок доступа для ролей

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm test:unit`


------
https://chatgpt.com/codex/tasks/task_b_68c066eff6308320ac038824291bbfc9