### PR TITLE
feat(api): allow managers to access admin panel

### DIFF
--- a/apps/api/src/admin/customAdmin.ts
+++ b/apps/api/src/admin/customAdmin.ts
@@ -29,7 +29,8 @@ export default function initCustomAdmin(app: Express): void {
 
   router.use(authMiddleware());
   router.use((req: RequestWithUser, res: Response, next: NextFunction) => {
-    if (req.user?.role === 'admin') return next();
+    if (req.user?.role === 'manager' || req.user?.role === 'admin')
+      return next();
     res.sendFile(path.join(pub, 'admin-placeholder.html'));
   });
 
@@ -37,5 +38,5 @@ export default function initCustomAdmin(app: Express): void {
     res.sendFile(path.join(pub, 'index.html'));
   });
 
-  app.use('/cp', router);
+  app.use(['/cp', '/mg'], router);
 }


### PR DESCRIPTION
## Summary
- allow managers to access admin panel via /mg path
- permit manager role in admin middleware

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh`
- `curl -I http://localhost:3001/mg/kanban` (returns 403)

------
https://chatgpt.com/codex/tasks/task_b_68c0764e25dc83208dc3bd6ec8d81d02