### PR TITLE
feat: добавить уровень доступа ролей

### DIFF
--- a/apps/api/src/db/queries.ts
+++ b/apps/api/src/db/queries.ts
@@ -8,6 +8,7 @@ import {
   TaskDocument,
   UserDocument,
   RoleDocument,
+  RoleAttrs,
   TaskTemplate,
   TaskTemplateDocument,
 } from './model';
@@ -341,8 +342,16 @@ export async function updateUser(
   );
 }
 
-export async function listRoles(): Promise<RoleDocument[]> {
-  return Role.find();
+// Возвращает роли с вычисленным уровнем доступа
+export interface RoleWithAccess extends RoleAttrs {
+  _id: Types.ObjectId;
+  access: number;
+}
+
+export async function listRoles(): Promise<RoleWithAccess[]> {
+  const roles =
+    await Role.find().lean<(RoleAttrs & { _id: Types.ObjectId })[]>();
+  return roles.map((r) => ({ ...r, access: accessByRole(r.name || '') }));
 }
 
 export async function getRole(id: string): Promise<RoleDocument | null> {

--- a/apps/api/tests/admin.test.ts
+++ b/apps/api/tests/admin.test.ts
@@ -16,7 +16,7 @@ const { ACCESS_ADMIN } = require('../src/utils/accessMask');
 jest.mock('../src/services/service', () => ({
   listLogs: jest.fn(async () => [{ _id: '1', message: 'log' }]),
   writeLog: jest.fn(async () => ({})),
-  listRoles: jest.fn(async () => [{ _id: 'r1', name: 'admin' }]),
+  listRoles: jest.fn(async () => [{ _id: 'r1', name: 'admin', access: 2 }]),
   updateRole: jest.fn(async (id, p) => ({ _id: id, permissions: p })),
 }));
 

--- a/apps/web/src/pages/Settings/UserForm.tsx
+++ b/apps/web/src/pages/Settings/UserForm.tsx
@@ -33,6 +33,7 @@ interface Props {
 interface Role {
   _id: string;
   name: string;
+  access: number;
 }
 
 export default function UserForm({ form, onChange, onSubmit, onReset }: Props) {
@@ -57,8 +58,12 @@ export default function UserForm({ form, onChange, onSubmit, onReset }: Props) {
 
   const handleRoleChange = (value: string) => {
     const r = roles.find((x) => x.name === value);
-    const access = value === "admin" ? 2 : value === "manager" ? 4 : 1;
-    onChange({ ...form, role: value, roleId: r?._id, access });
+    onChange({
+      ...form,
+      role: value,
+      roleId: r?._id,
+      access: r?.access ?? 1,
+    });
   };
 
   const submit = (e: React.FormEvent) => {

--- a/apps/web/src/services/roles.ts
+++ b/apps/web/src/services/roles.ts
@@ -2,7 +2,13 @@
 // Основные модули: authFetch
 import authFetch from "../utils/authFetch";
 
-export const fetchRoles = () =>
+export interface Role {
+  _id: string;
+  name: string;
+  access: number;
+}
+
+export const fetchRoles = (): Promise<Role[]> =>
   authFetch("/api/v1/roles").then((r) => (r.ok ? r.json() : []));
 
 export const updateRole = (id: string, permissions: number) =>


### PR DESCRIPTION
## Summary
- вернуть `access` для каждой роли
- использовать `access` в форме пользователя

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm build`
- `timeout 5s pnpm run dev`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c080a020548320867b857819549662