### PR TITLE
feat: populate employee relations

### DIFF
--- a/apps/api/src/routes/employees.ts
+++ b/apps/api/src/routes/employees.ts
@@ -30,11 +30,9 @@ router.get('/', ...middlewares, async (req, res) => {
       ? req.query.fields.split(',').join(' ')
       : undefined;
 
-  const employees = await Employee.find({}, fields).populate([
-    { path: 'departmentId', select: 'name' },
-    { path: 'divisionId', select: 'name' },
-    { path: 'positionId', select: 'name' },
-  ]);
+  const employees = await Employee.find({}, fields).populate(
+    'departmentId divisionId positionId',
+  );
   res.json(employees);
 });
 
@@ -44,6 +42,7 @@ router.post(
   ...(validateDto(CreateEmployeeDto) as RequestHandler[]),
   async (req, res) => {
     const employee = await Employee.create(req.body);
+    await employee.populate('departmentId divisionId positionId');
     res.status(201).json(employee);
   },
 );
@@ -61,6 +60,7 @@ router.put(
       res.sendStatus(404);
       return;
     }
+    await employee.populate('departmentId divisionId positionId');
     res.json(employee);
   },
 );

--- a/apps/web/src/components/EmployeeManager.tsx
+++ b/apps/web/src/components/EmployeeManager.tsx
@@ -1,5 +1,5 @@
 // Компонент управления сотрудником, содержит форму с селекторами
-// Модули: React
+// Модули: React, services/collections
 import React from "react";
 import {
   fetchCollectionItems,
@@ -42,7 +42,7 @@ const EmployeeManager: EmployeeManagerComponent = ({ onSubmit }) => {
     fetchCollectionItems("divisions", "", 1, 100).then((d) =>
       setDivisions(d.items),
     );
-    fetchCollectionItems("roles", "", 1, 100).then((d) =>
+    fetchCollectionItems("positions", "", 1, 100).then((d) =>
       setPositions(d.items),
     );
   }, []);


### PR DESCRIPTION
## Summary
- populate department, division and position references in employee routes
- fetch position list in EmployeeManager from collections

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm run dev`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c10e4ea0208320ba09077f686b45df