### PR TITLE
feat: включить SPA на /mg

### DIFF
--- a/apps/api/src/admin/customAdmin.ts
+++ b/apps/api/src/admin/customAdmin.ts
@@ -1,4 +1,4 @@
-// Назначение: кастомный бекенд админки без базовой аутентификации
+// Назначение: кастомный бекенд админки без базовой аутентификации для путей /cp и /mg
 // Модули: express, path, middleware/auth
 import path from 'path';
 import express, { Express, NextFunction, Response } from 'express';
@@ -10,6 +10,7 @@ import type { RequestWithUser } from '../types/request';
 export default function initCustomAdmin(app: Express): void {
   const router = express.Router();
   const pub = path.join(__dirname, '../../public');
+  const spaPaths = ['/cp', '/mg'];
 
   const adminRateLimiter = createRateLimiter({
     windowMs: 15 * 60 * 1000,
@@ -38,5 +39,5 @@ export default function initCustomAdmin(app: Express): void {
     res.sendFile(path.join(pub, 'index.html'));
   });
 
-  app.use(['/cp', '/mg'], router);
+  app.use(spaPaths, router);
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,38 @@
+# Назначение: конфигурация Nginx для отдачи SPA и проксирования API
+# Модули: http, proxy
+worker_processes 1;
+
+events { worker_connections 1024; }
+
+http {
+  include       mime.types;
+  default_type  application/octet-stream;
+  sendfile        on;
+  keepalive_timeout  65;
+
+  server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /api/ {
+      proxy_pass http://api:3000/api/;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location /mg/ {
+      try_files $uri /index.html;
+    }
+
+    location /cp/ {
+      try_files $uri /index.html;
+    }
+
+    location / {
+      try_files $uri /index.html;
+    }
+  }
+}


### PR DESCRIPTION
## Описание
- добавлен список путей `/cp` и `/mg` для админского роутера
- добавлен пример `nginx.conf` с проксированием API и отдачей SPA по `/mg/*`

## Чеклист
- [x] `pnpm format`
- [x] `./scripts/setup_and_test.sh`
- [x] `./scripts/pre_pr_check.sh`

## Риски
- конфиг nginx нуждается в адаптации под конкретную инфраструктуру
- откат: удалить `nginx.conf` и вернуть изменения в `customAdmin.ts`


------
https://chatgpt.com/codex/tasks/task_b_68c11c3026bc83208fd056ecd5479bb0