### PR TITLE
ci: enable Lighthouse CI status reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
   lint-test-build:
     runs-on: ubuntu-latest
     needs: audit-deps
+    permissions:
+      statuses: write # Разрешение на запись статусов
+    env:
+      LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }} # Токен Lighthouse CI
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- allow Lighthouse CI to report commit status via `LHCI_GITHUB_APP_TOKEN`

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c13c2cc2388320994629468b43462b