### PR TITLE
feat: show manager links for admin

### DIFF
--- a/apps/web/src/layouts/Sidebar.tsx
+++ b/apps/web/src/layouts/Sidebar.tsx
@@ -41,7 +41,7 @@ export default function Sidebar() {
   const { user } = useAuth();
   const role = user?.role || "user";
   const items = React.useMemo(() => {
-    if (role === "admin") return [...baseItems, ...adminItems];
+    if (role === "admin") return [...baseItems, ...adminItems, ...managerItems];
     if (role === "manager") return [...baseItems, ...managerItems];
     return baseItems;
   }, [role]);


### PR DESCRIPTION
## Summary
- show manager navigation items when admin is logged in

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(failed: apps/web build: Failed)*
- `./scripts/pre_pr_check.sh`
- `pnpm run dev` *(failed: Command failed with signal "SIGTERM")*

------
https://chatgpt.com/codex/tasks/task_b_68c164d904508320b5516a6ebcc54cc2