### PR TITLE
fix: убрать new Function из зависимостей

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,9 @@
       "unrs-resolver"
     ],
     "patchedDependencies": {
-      "use-isomorphic-layout-effect@1.2.1": "patches/use-isomorphic-layout-effect@1.2.1.patch"
+      "use-isomorphic-layout-effect@1.2.1": "patches/use-isomorphic-layout-effect@1.2.1.patch",
+      "core-js@3.45.1": "patches/core-js@3.45.1.patch",
+      "jss@10.10.0": "patches/jss@10.10.0.patch"
     }
   },
   "packageManager": "pnpm@10.15.0",

--- a/patches/core-js@3.45.1.patch
+++ b/patches/core-js@3.45.1.patch
@@ -1,0 +1,9 @@
+diff --git a/internals/global-this.js b/internals/global-this.js
+index 7c6967d..c112233 100644
+--- a/internals/global-this.js
++++ b/internals/global-this.js
+@@ -14,3 +14,1 @@
+-   check(typeof this == 'object' && this) ||
+-   // eslint-disable-next-line no-new-func -- fallback
+-   (function () { return this; })() || Function('return this')();
++   check(typeof this == 'object' && this);

--- a/patches/jss@10.10.0.patch
+++ b/patches/jss@10.10.0.patch
@@ -1,0 +1,20 @@
+diff --git a/dist/jss.esm.js b/dist/jss.esm.js
+index 45d9d5a..cb8e123 100644
+--- a/dist/jss.esm.js
++++ b/dist/jss.esm.js
+@@ -1507,1 +1507,1 @@
+-var globalThis$1 = typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' && window.Math === Math ? window : typeof self !== 'undefined' && self.Math === Math ? self : Function('return this')();
++var globalThis$1 = typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' && window.Math === Math ? window : typeof self !== 'undefined' && self.Math === Math ? self : undefined;
+diff --git a/src/utils/globalThis.js b/src/utils/globalThis.js
+index 1234567..89abcde 100644
+--- a/src/utils/globalThis.js
++++ b/src/utils/globalThis.js
+@@ -13,7 +13,7 @@
+ export default typeof globalThis !== 'undefined'
+   ? globalThis
+   : typeof window !== 'undefined' && window.Math === Math
+   ? window
+   : typeof self !== 'undefined' && self.Math === Math
+   ? self
+-  : Function('return this')()
++  : undefined

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ overrides:
   ckeditor5@>=46.0.0 <46.0.3: '>=46.0.3'
 
 patchedDependencies:
+  core-js@3.45.1:
+    hash: 21f3f10e671d061a857d73204620370aa39855c43a46bd33566bcf823a5318a0
+    path: patches/core-js@3.45.1.patch
+  jss@10.10.0:
+    hash: c85562a897a01415b4d205f06e26e2e9e5351a601ce972c644a721e435639087
+    path: patches/jss@10.10.0.patch
   use-isomorphic-layout-effect@1.2.1:
     hash: 42b57e75ec198e3ef0d8df5b612133c58465d104911d927dfec13aa4bfa80fd6
     path: patches/use-isomorphic-layout-effect@1.2.1.patch
@@ -11280,6 +11286,8 @@ snapshots:
       '@ckeditor/ckeditor5-core': 46.0.3
       '@ckeditor/ckeditor5-upload': 46.0.3
       ckeditor5: 46.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-alignment@46.0.2':
     dependencies:
@@ -11572,8 +11580,6 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 46.0.2
       '@ckeditor/ckeditor5-watchdog': 46.0.2
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-core@46.0.3':
     dependencies:
@@ -11626,6 +11632,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 46.0.3
       ckeditor5: 46.0.3
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-editor-classic@41.4.2':
     dependencies:
@@ -11671,6 +11679,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 46.0.3
       ckeditor5: 46.0.3
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-editor-inline@46.0.2':
     dependencies:
@@ -11689,6 +11699,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 46.0.3
       ckeditor5: 46.0.3
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-editor-multi-root@46.0.2':
     dependencies:
@@ -11698,8 +11710,6 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 46.0.2
       ckeditor5: 46.0.3
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-editor-multi-root@46.0.3':
     dependencies:
@@ -11814,6 +11824,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 46.0.3
       ckeditor5: 46.0.3
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-font@46.0.2':
     dependencies:
@@ -11823,8 +11835,6 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 46.0.2
       '@ckeditor/ckeditor5-utils': 46.0.2
       ckeditor5: 46.0.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-font@46.0.3':
     dependencies:
@@ -11922,6 +11932,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 46.0.3
       '@ckeditor/ckeditor5-widget': 46.0.3
       ckeditor5: 46.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-html-embed@46.0.2':
     dependencies:
@@ -11957,8 +11969,6 @@ snapshots:
       '@ckeditor/ckeditor5-widget': 46.0.2
       ckeditor5: 46.0.3
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-html-support@46.0.3':
     dependencies:
@@ -12037,8 +12047,6 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 46.0.2
       '@ckeditor/ckeditor5-utils': 46.0.2
       ckeditor5: 46.0.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-indent@46.0.3':
     dependencies:
@@ -12125,8 +12133,6 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 46.0.2
       '@ckeditor/ckeditor5-utils': 46.0.2
       ckeditor5: 46.0.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-list@46.0.3':
     dependencies:
@@ -12223,8 +12229,6 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 46.0.3
       '@ckeditor/ckeditor5-widget': 46.0.3
       ckeditor5: 46.0.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-mention@46.0.2':
     dependencies:
@@ -12261,8 +12265,6 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 46.0.3
       '@ckeditor/ckeditor5-utils': 46.0.3
       ckeditor5: 46.0.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-page-break@46.0.2':
     dependencies:
@@ -12281,8 +12283,6 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 46.0.3
       '@ckeditor/ckeditor5-widget': 46.0.3
       ckeditor5: 46.0.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-paragraph@41.4.2':
     dependencies:
@@ -12351,8 +12351,6 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 46.0.3
       '@ckeditor/ckeditor5-utils': 46.0.3
       ckeditor5: 46.0.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-restricted-editing@46.0.2':
     dependencies:
@@ -12403,8 +12401,6 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 46.0.3
       '@ckeditor/ckeditor5-utils': 46.0.3
       ckeditor5: 46.0.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-source-editing@46.0.2':
     dependencies:
@@ -12453,8 +12449,6 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 46.0.2
       ckeditor5: 46.0.3
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-style@46.0.3':
     dependencies:
@@ -12467,8 +12461,6 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 46.0.3
       ckeditor5: 46.0.3
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-table@41.4.2':
     dependencies:
@@ -12501,8 +12493,6 @@ snapshots:
       '@ckeditor/ckeditor5-widget': 46.0.3
       ckeditor5: 46.0.3
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-theme-lark@46.0.2':
     dependencies:
@@ -12554,8 +12544,6 @@ snapshots:
       color-parse: 2.0.2
       es-toolkit: 1.39.5
       vanilla-colorful: 0.7.2
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-ui@46.0.3':
     dependencies:
@@ -12606,8 +12594,6 @@ snapshots:
     dependencies:
       '@ckeditor/ckeditor5-ui': 46.0.2
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-utils@46.0.3':
     dependencies:
@@ -12623,8 +12609,6 @@ snapshots:
       '@ckeditor/ckeditor5-engine': 46.0.2
       '@ckeditor/ckeditor5-utils': 46.0.2
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-watchdog@46.0.3':
     dependencies:
@@ -12673,8 +12657,6 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 46.0.3
       ckeditor5: 46.0.3
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -13608,7 +13590,7 @@ snapshots:
       clsx: 1.2.1
       csstype: 2.6.21
       hoist-non-react-statics: 3.3.2
-      jss: 10.10.0
+      jss: 10.10.0(patch_hash=c85562a897a01415b4d205f06e26e2e9e5351a601ce972c644a721e435639087)
       jss-plugin-camel-case: 10.10.0
       jss-plugin-default-unit: 10.10.0
       jss-plugin-global: 10.10.0
@@ -16146,7 +16128,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.3
       '@types/raf': 3.4.3
-      core-js: 3.45.1
+      core-js: 3.45.1(patch_hash=21f3f10e671d061a857d73204620370aa39855c43a46bd33566bcf823a5318a0)
       raf: 3.4.1
       regenerator-runtime: 0.13.11
       rgbcolor: 1.0.1
@@ -16649,7 +16631,7 @@ snapshots:
     dependencies:
       browserslist: 4.25.3
 
-  core-js@3.45.1:
+  core-js@3.45.1(patch_hash=21f3f10e671d061a857d73204620370aa39855c43a46bd33566bcf823a5318a0):
     optional: true
 
   core-util-is@1.0.2: {}
@@ -16707,7 +16689,7 @@ snapshots:
   css-jss@10.10.0:
     dependencies:
       '@babel/runtime': 7.28.4
-      jss: 10.10.0
+      jss: 10.10.0(patch_hash=c85562a897a01415b4d205f06e26e2e9e5351a601ce972c644a721e435639087)
       jss-preset-default: 10.10.0
 
   css-line-break@2.1.0:
@@ -19010,7 +18992,7 @@ snapshots:
       fflate: 0.8.2
     optionalDependencies:
       canvg: 3.0.11
-      core-js: 3.45.1
+      core-js: 3.45.1(patch_hash=21f3f10e671d061a857d73204620370aa39855c43a46bd33566bcf823a5318a0)
       dompurify: 3.2.6
       html2canvas: 1.4.1
 
@@ -19025,74 +19007,74 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.4
       hyphenate-style-name: 1.1.0
-      jss: 10.10.0
+      jss: 10.10.0(patch_hash=c85562a897a01415b4d205f06e26e2e9e5351a601ce972c644a721e435639087)
 
   jss-plugin-compose@10.10.0:
     dependencies:
       '@babel/runtime': 7.28.4
-      jss: 10.10.0
+      jss: 10.10.0(patch_hash=c85562a897a01415b4d205f06e26e2e9e5351a601ce972c644a721e435639087)
       tiny-warning: 1.0.3
 
   jss-plugin-default-unit@10.10.0:
     dependencies:
       '@babel/runtime': 7.28.4
-      jss: 10.10.0
+      jss: 10.10.0(patch_hash=c85562a897a01415b4d205f06e26e2e9e5351a601ce972c644a721e435639087)
 
   jss-plugin-expand@10.10.0:
     dependencies:
       '@babel/runtime': 7.28.4
-      jss: 10.10.0
+      jss: 10.10.0(patch_hash=c85562a897a01415b4d205f06e26e2e9e5351a601ce972c644a721e435639087)
 
   jss-plugin-extend@10.10.0:
     dependencies:
       '@babel/runtime': 7.28.4
-      jss: 10.10.0
+      jss: 10.10.0(patch_hash=c85562a897a01415b4d205f06e26e2e9e5351a601ce972c644a721e435639087)
       tiny-warning: 1.0.3
 
   jss-plugin-global@10.10.0:
     dependencies:
       '@babel/runtime': 7.28.4
-      jss: 10.10.0
+      jss: 10.10.0(patch_hash=c85562a897a01415b4d205f06e26e2e9e5351a601ce972c644a721e435639087)
 
   jss-plugin-nested@10.10.0:
     dependencies:
       '@babel/runtime': 7.28.4
-      jss: 10.10.0
+      jss: 10.10.0(patch_hash=c85562a897a01415b4d205f06e26e2e9e5351a601ce972c644a721e435639087)
       tiny-warning: 1.0.3
 
   jss-plugin-props-sort@10.10.0:
     dependencies:
       '@babel/runtime': 7.28.4
-      jss: 10.10.0
+      jss: 10.10.0(patch_hash=c85562a897a01415b4d205f06e26e2e9e5351a601ce972c644a721e435639087)
 
   jss-plugin-rule-value-function@10.10.0:
     dependencies:
       '@babel/runtime': 7.28.4
-      jss: 10.10.0
+      jss: 10.10.0(patch_hash=c85562a897a01415b4d205f06e26e2e9e5351a601ce972c644a721e435639087)
       tiny-warning: 1.0.3
 
   jss-plugin-rule-value-observable@10.10.0:
     dependencies:
       '@babel/runtime': 7.28.4
-      jss: 10.10.0
+      jss: 10.10.0(patch_hash=c85562a897a01415b4d205f06e26e2e9e5351a601ce972c644a721e435639087)
       symbol-observable: 1.2.0
 
   jss-plugin-template@10.10.0:
     dependencies:
       '@babel/runtime': 7.28.4
-      jss: 10.10.0
+      jss: 10.10.0(patch_hash=c85562a897a01415b4d205f06e26e2e9e5351a601ce972c644a721e435639087)
       tiny-warning: 1.0.3
 
   jss-plugin-vendor-prefixer@10.10.0:
     dependencies:
       '@babel/runtime': 7.28.4
       css-vendor: 2.0.8
-      jss: 10.10.0
+      jss: 10.10.0(patch_hash=c85562a897a01415b4d205f06e26e2e9e5351a601ce972c644a721e435639087)
 
   jss-preset-default@10.10.0:
     dependencies:
       '@babel/runtime': 7.28.4
-      jss: 10.10.0
+      jss: 10.10.0(patch_hash=c85562a897a01415b4d205f06e26e2e9e5351a601ce972c644a721e435639087)
       jss-plugin-camel-case: 10.10.0
       jss-plugin-compose: 10.10.0
       jss-plugin-default-unit: 10.10.0
@@ -19106,7 +19088,7 @@ snapshots:
       jss-plugin-template: 10.10.0
       jss-plugin-vendor-prefixer: 10.10.0
 
-  jss@10.10.0:
+  jss@10.10.0(patch_hash=c85562a897a01415b4d205f06e26e2e9e5351a601ce972c644a721e435639087):
     dependencies:
       '@babel/runtime': 7.28.4
       csstype: 3.1.3
@@ -20758,7 +20740,7 @@ snapshots:
       css-jss: 10.10.0
       hoist-non-react-statics: 3.3.2
       is-in-browser: 1.1.3
-      jss: 10.10.0
+      jss: 10.10.0(patch_hash=c85562a897a01415b4d205f06e26e2e9e5351a601ce972c644a721e435639087)
       jss-preset-default: 10.10.0
       prop-types: 15.8.1
       react: 18.2.0


### PR DESCRIPTION
## Summary
- патч для `core-js`: убрана динамическая функция в `global-this`
- патч для `jss`: безопасное определение `globalThis` без `new Function`

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_68c19a691f1483208b1b4c31caee0b60