### PR TITLE
fix(web): ensure root element exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # История изменений
 
+- Главный скрипт создаёт `#root`, если он отсутствует,
+  устраняя ошибку `Cannot set properties of undefined`.
 - Маршрут `/api-docs` удалён; документация Swagger собирается статически в `docs/api`.
 - Удалены зависимости `quill` и `react-quill`; компонент CKEditor очищает HTML через DOMPurify.
 - Экспорт PDF выполняется библиотекой `pdf-lib`, зависимость `jspdf` удалена; политика CSP не требует `unsafe-eval`.

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -6,9 +6,12 @@ import i18n from "./i18n";
 import "./index.css";
 
 function bootstrap() {
-  const root = document.getElementById("root");
+  // гарантируем наличие корневого элемента
+  let root = document.getElementById("root");
   if (!root) {
-    throw new Error("Element #root not found");
+    root = document.createElement("div");
+    root.id = "root";
+    document.body.appendChild(root);
   }
 
   const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## Summary
- ensure the client bootstrap creates a `#root` node when missing to avoid runtime crash
- document root creation fix in changelog

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c260963e58832087995d82277fb5b7