### PR TITLE
fix: expose React globally for CKEditor

### DIFF
--- a/apps/web/src/components/CKEditorPopup.tsx
+++ b/apps/web/src/components/CKEditorPopup.tsx
@@ -5,6 +5,11 @@ import React, { useState } from "react";
 import DOMPurify from "dompurify";
 import Modal from "./Modal";
 
+// CKEditor 5 ожидает глобальную переменную React, задаём её вручную
+if (typeof window !== "undefined" && !(window as any).React) {
+  (window as any).React = React;
+}
+
 const LazyCKEditor = React.lazy(async () => {
   const [{ CKEditor }, { default: ClassicEditor }] = await Promise.all([
     import("@ckeditor/ckeditor5-react"),


### PR DESCRIPTION
## Summary
- fix CKEditor runtime error by assigning React to window

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh`
- `node -e "const { chromium } = require('@playwright/test'); (async () => { const browser = await chromium.launch(); const context = await browser.newContext({ ignoreHTTPSErrors: true }); const page = await context.newPage(); page.on('pageerror', e => console.log('pageerror', e.message)); await page.goto('https://agromarket.up.railway.app/'); console.log('page loaded'); await browser.close(); })();"`

------
https://chatgpt.com/codex/tasks/task_b_68c26694c9a08320b6e84fd3fd722549