### PR TITLE
ci: установить Chrome для Lighthouse CI

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -23,5 +23,7 @@ jobs:
         run: pnpm install
       - name: Сборка клиента
         run: pnpm --dir apps/web build
+      - name: Установка Chrome
+        uses: browser-actions/setup-chrome@v1
       - name: Lighthouse CI
         run: npx lhci autorun


### PR DESCRIPTION
## Summary
- add Chrome installation step in LHCI workflow

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm run dev`
- `npx lhci autorun` (fails: Chrome installation not found)


------
https://chatgpt.com/codex/tasks/task_b_68c298cb65f883208a6713b1fe394c73