### PR TITLE
test: ensure collection indexes in repository tests

### DIFF
--- a/apps/api/tests/collectionRepo.test.ts
+++ b/apps/api/tests/collectionRepo.test.ts
@@ -1,8 +1,9 @@
 // Назначение: проверка фильтрации и пагинации в collectionRepo
-// Модули: mongodb-memory-server, mongoose, collectionRepo
+// Модули: mongodb-memory-server, mongoose, collectionRepo, ensureIndexes
 import mongoose from 'mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { create, list } from '../src/db/repos/collectionRepo';
+import { ensureCollectionItemIndexes } from '../../../scripts/db/ensureIndexes';
 
 jest.setTimeout(30000);
 
@@ -12,6 +13,7 @@ describe('collectionRepo', () => {
   beforeAll(async () => {
     mongod = await MongoMemoryServer.create();
     await mongoose.connect(mongod.getUri());
+    await ensureCollectionItemIndexes(mongoose.connection);
   });
 
   afterAll(async () => {


### PR DESCRIPTION
## Summary
- ensure MongoDB text index is created in collection repository tests
- add index initialization to prevent `$text` query errors

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_68c2ab45cac8832099d527f6cebb382a