### PR TITLE
feat: добавить конфигурацию Playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,6 @@ jobs:
         with:
           name: build-artifact
           path: apps/api/public
-      - name: E2E тесты
-        run: pnpm test:e2e
       - name: Проверка размеров бандлов
         run: mkdir -p apps/web/dist && cp -r apps/api/public/assets apps/web/dist/ && pnpm size
       - name: Загрузка sourcemap
@@ -70,3 +68,29 @@ jobs:
         with:
           name: sourcemaps
           path: apps/api/public/assets/**/*.map
+
+  e2e-tests:
+    runs-on: ubuntu-latest
+    needs: lint-test-build
+    strategy:
+      matrix:
+        project: [chromium, firefox, webkit, 'Pixel 7', 'iPhone 14']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Включение corepack
+        run: corepack enable
+      - name: Установка зависимостей
+        run: pnpm install
+      - name: Установка браузеров Playwright
+        run: npx playwright install --with-deps
+      - name: E2E тесты
+        run: pnpm test:e2e -- --project=${{ matrix.project }}
+      - name: Сохранение артефактов
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ matrix.project }}
+          path: playwright-report

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "PNPM_SCRIPT_TIMEOUT=0 pnpm -r dev",
     "lint": "pnpm -r lint",
     "a11y": "ts-node scripts/a11y.ts",
-    "test:e2e": "playwright test tests/e2e",
+    "test:e2e": "playwright test",
     "test:api": "mocha -r ts-node/register -r tests/setupEnv.ts tests/api/**/*.spec.ts",
     "test:unit": "jest",
     "format": "prettier --write .",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,16 @@
+/* Назначение файла: конфигурация Playwright для браузеров и устройств.
+   Основные модули: @playwright/test. */
+
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  workers: process.env.CI ? 1 : undefined,
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+    { name: 'Pixel 7', use: { ...devices['Pixel 7'] } },
+    { name: 'iPhone 14', use: { ...devices['iPhone 14'] } },
+  ],
+});


### PR DESCRIPTION
## Summary
- добавить `playwright.config.ts` с проектами для основных браузеров и устройств
- запускать E2E тесты в матрице CI для параллельных прогонов

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm lint`
- `pnpm test:unit`
- `pnpm test:api`
- `npx playwright install --with-deps`
- `pnpm test:e2e`
- `pnpm build`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c2b2543d1c8320ac72ef32400e7d89