### PR TITLE
fix: stabilize e2e tests

### DIFF
--- a/tests/e2e/intake.rules.spec.ts
+++ b/tests/e2e/intake.rules.spec.ts
@@ -5,11 +5,12 @@
 import { test, expect } from '@playwright/test';
 import express from 'express';
 import type { Server } from 'http';
+import type { AddressInfo } from 'net';
 import { applyIntakeRules } from '../../apps/api/src/intake/rules';
 import type { TaskDocument } from '../../apps/api/src/db/model';
 
 let server: Server;
-const base = 'http://localhost:3003';
+let base: string;
 
 const app = express();
 app.use(express.json());
@@ -23,7 +24,9 @@ app.post('/tasks', (req, res) => {
 });
 
 test.beforeAll(() => {
-  server = app.listen(3003);
+  server = app.listen(0);
+  const { port } = server.address() as AddressInfo;
+  base = `http://localhost:${port}`;
 });
 
 test.afterAll(() => {

--- a/tests/e2e/logout.spec.ts
+++ b/tests/e2e/logout.spec.ts
@@ -13,6 +13,7 @@ process.env.JWT_SECRET = 'secret';
 process.env.APP_URL = 'https://example.org';
 process.env.MONGO_DATABASE_URL =
   'mongodb://admin:admin@localhost:27017/ermdb?authSource=admin';
+process.env.NODE_ENV = 'test';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { logout } =


### PR DESCRIPTION
## Summary
- avoid port collisions in intake rules tests
- ensure logout e2e test runs with test environment

## Testing
- `pnpm test:unit`
- `pnpm lint`
- `pnpm test:e2e` *(fails: browserType.launch: Executable doesn't exist; run `pnpm exec playwright install`)*

------
https://chatgpt.com/codex/tasks/task_b_68c2baef95c48320b32aa556e365fe40