### PR TITLE
fix: кавычки для e2e тестов в CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Установка браузеров Playwright
         run: npx playwright install --with-deps
       - name: E2E тесты
-        run: pnpm test:e2e -- --project=${{ matrix.project }}
+        run: pnpm test:e2e -- --project="${{ matrix.project }}"
       - name: Сохранение артефактов
         if: ${{ always() }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- добавить кавычки в шаге E2E тестов GitHub Actions

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c2c381bed483208252a620b80db073