### PR TITLE
fix: изоляция сборки e2e

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,8 @@
 - `install_bot_deps.sh` скачивает pnpm через curl или GitHub при сбоях corepack и npm.
 - `.npmrc` перенаправляет scope `@jsr` на npmjs.org, чтобы установка зависимостей не требовала токена.
 - Перед коммитом запускайте `./scripts/setup_and_test.sh`.
+- Для e2e-тестов сборку выполняйте через `scripts/build_with_tmp.sh`,
+  чтобы процессы не делили `apps/api/public/assets`.
 - Перед пулл-реквестом выполняйте `./scripts/pre_pr_check.sh`, он создаёт `.env` из `.env.example`, проверяет сборку и запуск бота, автоматически исправляя ошибки и повторяя до успеха, запускает аудит зависимостей и записывает лог в `/tmp/apps/api_start.log`.
 - Lighthouse CI использует GitHub App, токен хранится в секрете `LHCI_GITHUB_APP_TOKEN`, отчёты размещаются во временном публичном хранилище.
 - Скрипт `pre_pr_check.sh` поднимает MongoDB в памяти; `scripts/check_mongo.mjs` пропускает проверку при `CI=true`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
 - Реализован скрипт `start_api_with_memdb.sh` для запуска API с MongoDB в памяти, инструкция в README.
 - Быстрый старт использует `./scripts/create_env_from_exports.sh`, добавлен `start_api_with_memdb.sh`.
 - В корневые devDependencies добавлен `express-rate-limit`, исправлен сбой теста `tasks.upload.spec.ts`.
+- Сборка перед e2e-тестами выполняется скриптом `build_with_tmp.sh`,
+  создающим уникальный TMPDIR и блокирующим параллельные процессы.
 - Скрипт `pre_pr_check.sh` поднимает MongoDB в памяти, `check_mongo.mjs` пропускает проверку при `CI=true`, обновлена документация переменной `MONGO_DATABASE_URL`.
 - `SESSION_SECRET` в `.env.example` пуст, добавлена команда генерации и предупреждение о коммите.
 - Исправлен запуск клиента: инициализация откладывается до `DOMContentLoaded`,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "pretest": "pnpm --filter shared build",
     "pretest:unit": "pnpm --filter shared build",
     "pretest:api": "pnpm --filter shared build",
-    "pretest:e2e": "pnpm build",
+    "pretest:e2e": "./scripts/build_with_tmp.sh",
     "build": "pnpm --filter packages/shared build && pnpm -r --filter '!packages/shared' build",
     "dev": "PNPM_SCRIPT_TIMEOUT=0 pnpm -r dev",
     "lint": "pnpm -r lint",

--- a/scripts/build_client.sh
+++ b/scripts/build_client.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
-# Назначение скрипта: установка зависимостей и сборка фронтенда.
-# Модули: npm, bash.
+# Назначение скрипта: установка зависимостей и сборка фронтенда в отдельном TMPDIR.
+# Модули: npm, mktemp, bash.
 set -e
 cd "$(dirname "$0")/.."
+TMP_DIR=$(mktemp -d)
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
 if [ ! -d apps/web/node_modules ]; then
-  npm --prefix apps/web install > /tmp/npm_install.log 2>&1 && tail -n 20 /tmp/npm_install.log
+  TMPDIR="$TMP_DIR" npm --prefix apps/web install > /tmp/npm_install.log 2>&1 && tail -n 20 /tmp/npm_install.log
 fi
-npm --prefix apps/api run build-client > /tmp/npm_build.log 2>&1 && tail -n 20 /tmp/npm_build.log
+TMPDIR="$TMP_DIR" npm --prefix apps/api run build-client > /tmp/npm_build.log 2>&1 && tail -n 20 /tmp/npm_build.log
 

--- a/scripts/build_with_tmp.sh
+++ b/scripts/build_with_tmp.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Назначение скрипта: сборка пакетов с уникальным временным каталогом.
+# Основные модули: pnpm, mktemp, flock.
+set -e
+cd "$(dirname "$0")/.."
+TMP_DIR=$(mktemp -d)
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+(
+  flock -x 9
+  TMPDIR="$TMP_DIR" pnpm build --workspace-concurrency=1
+) 9>/tmp/pnpm_build.lock


### PR DESCRIPTION
## Summary
- вынесена сборка в scripts/build_with_tmp.sh с уникальным TMPDIR и блокировкой
- build_client.sh и pretest:e2e используют отдельные временные каталоги
- инструкции и changelog дополнены

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c2c5e9af008320bf74cfe5bbabbddd