### PR TITLE
feat: refresh token and manager role checks

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -9,6 +9,7 @@ import { Request, Response, CookieOptions } from 'express';
 import config from '../config';
 import type { UserDocument } from '../db/model';
 import { sendProblem } from '../utils/problem';
+import { refreshToken } from './auth';
 
 export const sendCode = async (req: Request, res: Response) => {
   const { telegramId } = req.body;
@@ -102,6 +103,17 @@ export const logout = (_req: Request, res: Response) => {
   }
   res.clearCookie('token', opts);
   res.json({ status: 'ok' });
+};
+
+export const refresh = (req: RequestWithUser, res: Response) => {
+  const old = (req.cookies as Record<string, string> | undefined)?.token;
+  if (!old || !req.user) {
+    res.sendStatus(401);
+    return;
+  }
+  const token = refreshToken(old);
+  setTokenCookie(res, token);
+  res.json({ token });
 };
 
 export const codes = service.codes;

--- a/apps/api/src/auth/auth.ts
+++ b/apps/api/src/auth/auth.ts
@@ -44,3 +44,13 @@ export function generateShortToken(user: Payload): string {
     },
   );
 }
+
+export function refreshToken(token: string): string {
+  const payload = jwt.verify(token, secretKey) as jwt.JwtPayload & Payload;
+  return generateToken({
+    id: payload.id,
+    username: payload.username,
+    role: payload.role,
+    access: payload.access,
+  });
+}

--- a/apps/api/src/auth/roles.guard.ts
+++ b/apps/api/src/auth/roles.guard.ts
@@ -27,4 +27,5 @@ export default function rolesGuard(
     status: 403,
     detail: 'Forbidden',
   });
+  return;
 }

--- a/apps/api/src/routes/authUser.ts
+++ b/apps/api/src/routes/authUser.ts
@@ -38,6 +38,11 @@ router.post(
 );
 
 router.post('/logout', authCtrl.logout as unknown as RequestHandler);
+router.post(
+  '/refresh',
+  authMiddleware(),
+  authCtrl.refresh as unknown as RequestHandler,
+);
 
 router.get(
   '/profile',

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -30,7 +30,7 @@ import { maxUserFiles, maxUserStorage } from '../config/limits';
 import { checkFile } from '../utils/fileCheck';
 import { Roles } from '../auth/roles.decorator';
 import rolesGuard from '../auth/roles.guard';
-import { ACCESS_ADMIN } from '../utils/accessMask';
+import { ACCESS_ADMIN, ACCESS_MANAGER } from '../utils/accessMask';
 
 if (!fs.existsSync(uploadsDir)) fs.mkdirSync(uploadsDir, { recursive: true });
 if (ffmpegPath) ffmpeg.setFfmpegPath(ffmpegPath);
@@ -347,6 +347,8 @@ router.post(
   upload.any(),
   processUploads,
   normalizeArrays,
+  Roles(ACCESS_MANAGER) as unknown as RequestHandler,
+  rolesGuard as unknown as RequestHandler,
   ...(taskFormValidators as unknown as RequestHandler[]),
   ...(validateDto(CreateTaskDto) as RequestHandler[]),
   ...(ctrl.create as RequestHandler[]),
@@ -358,6 +360,8 @@ router.patch(
   upload.any(),
   processUploads,
   normalizeArrays,
+  Roles(ACCESS_MANAGER) as unknown as RequestHandler,
+  rolesGuard as unknown as RequestHandler,
   param('id').isMongoId(),
   checkTaskAccess as unknown as RequestHandler,
   ...(validateDto(UpdateTaskDto) as RequestHandler[]),
@@ -367,6 +371,8 @@ router.patch(
 router.patch(
   '/:id/time',
   authMiddleware(),
+  Roles(ACCESS_MANAGER) as unknown as RequestHandler,
+  rolesGuard as unknown as RequestHandler,
   param('id').isMongoId(),
   ...(validateDto(AddTimeDto) as RequestHandler[]),
   checkTaskAccess as unknown as RequestHandler,
@@ -386,6 +392,8 @@ router.delete(
 router.post(
   '/bulk',
   authMiddleware(),
+  Roles(ACCESS_MANAGER) as unknown as RequestHandler,
+  rolesGuard as unknown as RequestHandler,
   ...(validateDto(BulkStatusDto) as RequestHandler[]),
   ...(ctrl.bulk as RequestHandler[]),
 );

--- a/apps/api/tests/authCsrfRoute.test.ts
+++ b/apps/api/tests/authCsrfRoute.test.ts
@@ -19,6 +19,7 @@ jest.mock('../src/auth/auth.controller.ts', () => ({
   profile: jest.fn((_req, res) => res.json({ ok: true })),
   updateProfile: jest.fn((_req, res) => res.json({ ok: true })),
   logout: jest.fn((_req, res) => res.json({ status: 'ok' })),
+  refresh: jest.fn((_req, res) => res.json({ token: 't' })),
 }));
 
 const authRouter = require('../src/routes/authUser').default;

--- a/apps/api/tests/expensiveRateLimit.test.ts
+++ b/apps/api/tests/expensiveRateLimit.test.ts
@@ -19,6 +19,7 @@ jest.mock('../src/auth/auth.controller.ts', () => ({
   profile: jest.fn((_req, res) => res.json({ ok: true })),
   updateProfile: jest.fn((_req, res) => res.json({ ok: true })),
   logout: jest.fn((_req, res) => res.json({ status: 'ok' })),
+  refresh: jest.fn((_req, res) => res.json({ token: 't' })),
 }));
 
 jest.mock('../src/api/middleware', () => ({

--- a/apps/api/tests/loginTasksFlow.test.ts
+++ b/apps/api/tests/loginTasksFlow.test.ts
@@ -7,6 +7,7 @@ process.env.CHAT_ID = '1';
 process.env.JWT_SECRET = 'secret';
 process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
 process.env.APP_URL = 'https://localhost';
+process.env.MANAGER_ROLE_ID = 'm';
 
 const express = require('express');
 const cookieParser = require('cookie-parser');
@@ -37,8 +38,8 @@ jest.mock('../src/services/tasks', () => ({
 jest.mock('../src/middleware/taskAccess', () => (_req, _res, next) => next());
 
 jest.mock('../src/db/queries', () => ({
-  getUser: jest.fn(async () => null),
-  createUser: jest.fn(async () => ({ username: 'u' })),
+  getUser: jest.fn(async () => ({ roleId: 'm' })),
+  createUser: jest.fn(async () => ({ username: 'u', role: 'manager' })),
   updateUser: jest.fn(async () => ({})),
   accessByRole: (r: string) => (r === 'admin' ? 2 : r === 'manager' ? 4 : 1),
 }));

--- a/apps/api/tests/taskRoles.test.ts
+++ b/apps/api/tests/taskRoles.test.ts
@@ -1,0 +1,32 @@
+// Назначение: проверка прав на создание задач через Roles
+// Основные модули: express, supertest, roles.decorator, roles.guard
+import express = require('express');
+import request = require('supertest');
+import { Roles } from '../src/auth/roles.decorator';
+import rolesGuard from '../src/auth/roles.guard';
+import { ACCESS_MANAGER } from '../src/utils/accessMask';
+
+const app = express();
+app.post(
+  '/tasks',
+  (req, _res, next) => {
+    (req as any).user = { access: Number(req.headers['x-access'] || 1) };
+    next();
+  },
+  Roles(ACCESS_MANAGER) as any,
+  rolesGuard as any,
+  (_req, res) => res.sendStatus(201),
+);
+
+describe('Права менеджера', () => {
+  test('обычному пользователю запрещено', async () => {
+    const res = await request(app).post('/tasks').set('x-access', '1');
+    expect(res.status).toBe(403);
+  });
+  test('менеджеру разрешено', async () => {
+    const res = await request(app)
+      .post('/tasks')
+      .set('x-access', String(ACCESS_MANAGER));
+    expect(res.status).toBe(201);
+  });
+});

--- a/apps/api/tests/tasks.test.ts
+++ b/apps/api/tests/tasks.test.ts
@@ -62,7 +62,8 @@ jest
 
 jest.mock('../src/api/middleware', () => ({
   verifyToken: (req, _res, next) => {
-    req.user = { role: 'admin', id: 1, telegram_id: 1, access: 2 };
+    const access = Number(req.headers['x-access'] || 6);
+    req.user = { role: 'admin', id: 1, telegram_id: 1, access };
     next();
   },
   asyncHandler: (fn) => fn,
@@ -108,6 +109,7 @@ test('создание задачи возвращает 201', async () => {
     }),
   );
 });
+
 
 test('создание задачи через multipart', async () => {
   const res = await request(app)

--- a/apps/web/src/context/useAuth.ts
+++ b/apps/web/src/context/useAuth.ts
@@ -1,10 +1,20 @@
 // Хук доступа к данным и действиям аутентификации
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import { AuthContext } from "./AuthContext";
 import { AuthActionsContext } from "./AuthActionsContext";
+import { refresh } from "../services/auth";
 
 export function useAuth() {
   const state = useContext(AuthContext);
   const actions = useContext(AuthActionsContext);
+  useEffect(() => {
+    const id = setInterval(
+      () => {
+        refresh().catch(() => actions.logout());
+      },
+      4 * 60 * 1000,
+    );
+    return () => clearInterval(id);
+  }, [actions]);
   return { ...state, ...actions };
 }

--- a/apps/web/src/services/auth.ts
+++ b/apps/web/src/services/auth.ts
@@ -34,3 +34,9 @@ export const updateProfile = (data: ProfileData) =>
 
 export const logout = () =>
   authFetch("/api/v1/auth/logout", { method: "POST" }).then(() => undefined);
+
+export const refresh = () =>
+  authFetch("/api/v1/auth/refresh", {
+    method: "POST",
+    noRedirect: true,
+  }).then(() => undefined);

--- a/apps/web/src/utils/authFetch.ts
+++ b/apps/web/src/utils/authFetch.ts
@@ -114,6 +114,19 @@ export default async function authFetch(
       }
     }
   }
+  if (res.status === 401) {
+    try {
+      const r = await fetch("/api/v1/auth/refresh", {
+        method: "POST",
+        credentials: "include",
+      });
+      if (r.ok) {
+        res = await sendRequest(url, opts, onProgress);
+      }
+    } catch {
+      /* игнорируем */
+    }
+  }
   if ((res.status === 401 || res.status === 403) && !noRedirect) {
     window.location.href = "/login?expired=1";
   }


### PR DESCRIPTION
## Summary
- add JWT refresh endpoint and client silent refresh
- restrict task modifications to manager access and cover with tests

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c2effcd2c0832082b667483e00a1f0