### PR TITLE
feat: silent token refresh and manager role guard

### DIFF
--- a/apps/api/src/auth/auth.ts
+++ b/apps/api/src/auth/auth.ts
@@ -39,7 +39,8 @@ export function generateShortToken(user: Payload): string {
     },
     secretKey,
     {
-      expiresIn: '5m',
+      // короткий токен продлевается каждый запрос, поэтому увеличиваем TTL
+      expiresIn: '15m',
       algorithm: 'HS256',
     },
   );

--- a/apps/api/src/routes/authUser.ts
+++ b/apps/api/src/routes/authUser.ts
@@ -39,6 +39,8 @@ router.post(
 
 router.post('/logout', authCtrl.logout as unknown as RequestHandler);
 
+router.post('/refresh', asyncHandler(authCtrl.refresh));
+
 router.get(
   '/profile',
   authMiddleware(),

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -30,7 +30,7 @@ import { maxUserFiles, maxUserStorage } from '../config/limits';
 import { checkFile } from '../utils/fileCheck';
 import { Roles } from '../auth/roles.decorator';
 import rolesGuard from '../auth/roles.guard';
-import { ACCESS_ADMIN } from '../utils/accessMask';
+import { ACCESS_ADMIN, ACCESS_MANAGER } from '../utils/accessMask';
 
 if (!fs.existsSync(uploadsDir)) fs.mkdirSync(uploadsDir, { recursive: true });
 if (ffmpegPath) ffmpeg.setFfmpegPath(ffmpegPath);
@@ -344,6 +344,8 @@ router.get(
 router.post(
   '/',
   authMiddleware(),
+  Roles(ACCESS_MANAGER) as unknown as RequestHandler,
+  rolesGuard as unknown as RequestHandler,
   upload.any(),
   processUploads,
   normalizeArrays,
@@ -386,6 +388,8 @@ router.delete(
 router.post(
   '/bulk',
   authMiddleware(),
+  Roles(ACCESS_MANAGER) as unknown as RequestHandler,
+  rolesGuard as unknown as RequestHandler,
   ...(validateDto(BulkStatusDto) as RequestHandler[]),
   ...(ctrl.bulk as RequestHandler[]),
 );

--- a/apps/api/tests/tasksRoles.test.ts
+++ b/apps/api/tests/tasksRoles.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Назначение файла: проверка доступа менеджера к созданию задач.
+ * Основные модули: express, supertest, Roles, rolesGuard.
+ */
+process.env.BOT_TOKEN = 't';
+process.env.CHAT_ID = '1';
+process.env.JWT_SECRET = 's';
+process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
+process.env.APP_URL = 'https://localhost';
+
+import express from 'express';
+import request from 'supertest';
+import { Roles } from '../src/auth/roles.decorator';
+import rolesGuard from '../src/auth/roles.guard';
+import { ACCESS_MANAGER, ACCESS_USER } from '../src/utils/accessMask';
+import { stopScheduler } from '../src/services/scheduler';
+import { stopQueue } from '../src/services/messageQueue';
+
+function appWithMask(mask: number) {
+  const app = express();
+  app.post(
+    '/tasks',
+    (req, _res, next) => {
+      (req as any).user = { access: mask, id: 1, username: 'u' };
+      next();
+    },
+    Roles(ACCESS_MANAGER) as unknown as express.RequestHandler,
+    rolesGuard as unknown as express.RequestHandler,
+    (_req, res) => res.sendStatus(201),
+  );
+  return app;
+}
+
+describe('Roles(ACCESS_MANAGER) для задач', () => {
+  test('менеджер создаёт задачу', async () => {
+    const res = await request(appWithMask(ACCESS_MANAGER)).post('/tasks');
+    expect(res.status).toBe(201);
+  });
+
+  test('обычный пользователь получает 403', async () => {
+    const res = await request(appWithMask(ACCESS_USER)).post('/tasks');
+    expect(res.status).toBe(403);
+  });
+});
+
+afterAll(() => {
+  stopScheduler();
+  stopQueue();
+});

--- a/apps/web/src/context/useAuth.ts
+++ b/apps/web/src/context/useAuth.ts
@@ -1,10 +1,27 @@
 // Хук доступа к данным и действиям аутентификации
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import { AuthContext } from "./AuthContext";
 import { AuthActionsContext } from "./AuthActionsContext";
+import authFetch from "../utils/authFetch";
+
+let started = false;
 
 export function useAuth() {
   const state = useContext(AuthContext);
   const actions = useContext(AuthActionsContext);
+  useEffect(() => {
+    if (started || !state.user) return;
+    started = true;
+    const id = setInterval(() => {
+      authFetch("/api/v1/auth/refresh", {
+        method: "POST",
+        noRedirect: true,
+      }).catch(() => {});
+    }, 10 * 60 * 1000);
+    return () => {
+      clearInterval(id);
+      started = false;
+    };
+  }, [state.user]);
   return { ...state, ...actions };
 }


### PR DESCRIPTION
## Summary
- extend short JWT lifetime and add refresh endpoint
- refresh auth token silently on web client
- restrict task creation and bulk updates to managers

## Testing
- `pnpm lint`
- `pnpm test:unit`
- `pnpm test:api`
- `pnpm test:e2e` *(fails: error TS5023 Unknown compiler option '--workspace-concurrency=1')*
- `pnpm build`
- `./scripts/setup_and_test.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c2effcd2c0832082b667483e00a1f0