### PR TITLE
feat: guard tasks page by permission

### DIFF
--- a/apps/web/src/types/user.ts
+++ b/apps/web/src/types/user.ts
@@ -20,4 +20,6 @@ export interface User {
   role?: string;
   /** Уровень доступа */
   access?: number;
+  /** Список разрешений пользователя */
+  permissions?: string[];
 }


### PR DESCRIPTION
## Summary
- check user permissions before rendering tasks page
- show a notice when user lacks tasks permission
- extend user type with permissions list

## Testing
- `pnpm prettier --write apps/web/src/pages/TasksPage.tsx apps/web/src/types/user.ts`
- `./scripts/setup_and_test.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c3020b0af88320827bfdb989b6dc1e