### PR TITLE
feat: notify on forbidden

### DIFF
--- a/apps/web/src/context/ToastProvider.tsx
+++ b/apps/web/src/context/ToastProvider.tsx
@@ -27,6 +27,16 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({
     },
     [],
   );
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const { message, type } = (
+        e as CustomEvent<{ message: string; type?: "success" | "error" }>
+      ).detail;
+      addToast(message, type);
+    };
+    window.addEventListener("toast", handler);
+    return () => window.removeEventListener("toast", handler);
+  }, [addToast]);
   return (
     <ToastContext.Provider value={{ toasts, addToast, removeToast }}>
       {children}

--- a/apps/web/src/utils/authFetch.ts
+++ b/apps/web/src/utils/authFetch.ts
@@ -2,6 +2,7 @@
 // Назначение: обёртка для запросов с CSRF-токеном и прогрессом загрузки
 // Основные модули: fetch, XMLHttpRequest, window.location, localStorage
 import { getCsrfToken, setCsrfToken } from "./csrfToken";
+import { showToast } from "./toast";
 
 interface FetchOptions extends globalThis.RequestInit {
   headers?: Record<string, string>;
@@ -127,7 +128,10 @@ export default async function authFetch(
       /* игнорируем */
     }
   }
-  if ((res.status === 401 || res.status === 403) && !noRedirect) {
+  if (res.status === 403) {
+    showToast("Недостаточно прав", "error");
+  }
+  if (res.status === 401 && !noRedirect) {
     window.location.href = "/login?expired=1";
   }
   return res;

--- a/apps/web/src/utils/toast.ts
+++ b/apps/web/src/utils/toast.ts
@@ -1,0 +1,8 @@
+// Назначение: отправка событий тоста вне React
+// Основные модули: window, CustomEvent
+export function showToast(
+  message: string,
+  type: "success" | "error" = "error",
+) {
+  window.dispatchEvent(new CustomEvent("toast", { detail: { message, type } }));
+}

--- a/tests/authFetch.spec.ts
+++ b/tests/authFetch.spec.ts
@@ -1,0 +1,57 @@
+/** @jest-environment jsdom */
+// Назначение: unit-тесты для authFetch
+// Основные модули: jest, authFetch, Response
+import authFetch from '../apps/web/src/utils/authFetch';
+
+jest.mock('../apps/web/src/utils/csrfToken', () => ({
+  getCsrfToken: () => 'token',
+  setCsrfToken: () => undefined,
+}));
+
+function makeResponse(status: number, body: any = null): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    json: async () => body,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  } as Response;
+}
+
+describe('authFetch', () => {
+  afterEach(() => {
+    (global.fetch as jest.Mock | undefined)?.mockReset?.();
+    window.location.href = 'http://localhost/';
+  });
+
+  test('refreshes on 401', async () => {
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValueOnce(makeResponse(401))
+      .mockResolvedValueOnce(makeResponse(200))
+      .mockResolvedValueOnce(makeResponse(401));
+    // @ts-ignore
+    global.fetch = mockFetch;
+    const res = await authFetch('/foo', { noRedirect: true });
+    expect(res.status).toBe(401);
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/auth/refresh',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(window.location.href).toBe('http://localhost/');
+  });
+
+  test('shows toast on 403', async () => {
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValueOnce(makeResponse(403))
+      .mockResolvedValueOnce(makeResponse(200, { csrfToken: 't2' }))
+      .mockResolvedValueOnce(makeResponse(403));
+    // @ts-ignore
+    global.fetch = mockFetch;
+    const handler = jest.fn();
+    window.addEventListener('toast', handler as EventListener);
+    await authFetch('/foo');
+    expect(handler).toHaveBeenCalled();
+    expect(window.location.href).toBe('http://localhost/');
+  });
+});


### PR DESCRIPTION
## Summary
- show toast instead of redirect on forbidden responses
- listen to toast events via provider
- cover authFetch for 401/403 cases

## Testing
- `docker compose config` *(fails: env file .env not found)*
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm run dev`
- `./scripts/pre_pr_check.sh`

------
https://chatgpt.com/codex/tasks/task_b_68c306674de883208b559265c29a4872