### PR TITLE
feat: use access level for tasks list

### DIFF
--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -23,7 +23,7 @@ export default class TasksController {
     const { page, limit, ...filters } = req.query;
     let tasks: TaskEx[];
     let total = 0;
-    if (req.user!.role === 'admin') {
+    if (req.user!.access === 2) {
       const res = await this.service.get(
         filters,
         page ? Number(page) : undefined,


### PR DESCRIPTION
## Summary
- use numeric access level to detect admins when listing tasks
- skip mentioned branch for administrators

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c30e8547508320903d68b4eb6ccd1a