### PR TITLE
feat: load tasks after profile

### DIFF
--- a/apps/web/src/pages/TasksPage.tsx
+++ b/apps/web/src/pages/TasksPage.tsx
@@ -60,9 +60,10 @@ export default function TasksPage() {
   }, [isPrivileged, user, page]);
 
   React.useEffect(() => {
-    if (!canView) return;
+    if (authLoading || !canView) return;
     load();
-  }, [load, version, page, canView]);
+    // после загрузки профиля инициируем загрузку задач
+  }, [authLoading, load, version, page, canView, user?.access]);
   const tasks = React.useMemo(() => all, [all]);
 
   const userMap = React.useMemo(() => {


### PR DESCRIPTION
## Что сделано
- загружаем задачи после получения профиля
- добавлен `user?.access` в зависимости `useEffect`

## Почему
Задачи должны обновляться при смене прав пользователя.

## Проверки
- `pnpm install`
- `./scripts/setup_and_test.sh`
- `pnpm lint`
- `pnpm build`
- `pnpm run dev`
- `./scripts/pre_pr_check.sh`

## Самопроверка
- код отформатирован
- не изменены лишние файлы
- тесты и сборка проходят
- рабочее дерево чистое

## Риски
- при ошибке загрузки профиля задачи не обновятся; откатить коммит

------
https://chatgpt.com/codex/tasks/task_b_68c3176e4d2483209002e2d97734ede1