### PR TITLE
feat: add mine task filter toggle

### DIFF
--- a/apps/api/public/index.html
+++ b/apps/api/public/index.html
@@ -8,7 +8,7 @@
     <meta property="og:image" content="/hero/index.png">
     <link rel="stylesheet" href="/fonts/fonts.css" integrity="sha384-bjTg4N7TnsipMatz5mxrxao/pM/V7CpDOtVSwYMZCZoBIB9UU7R9kKlUUoBsczFU" crossorigin="anonymous">
     <title>ERM Web App</title>
-    <script type="module" crossorigin="anonymous" src="/assets/index-DRE1dLgP.js" integrity="sha384-PdDRE1Jw2ehMqw5/hzLArpZ9nJy/DaUaQ3GYxNn/LYr7dKdZ2nFypaKNFzfDlpLS"></script>
+    <script type="module" crossorigin="anonymous" src="/assets/index-BIBFFpjG.js" integrity="sha384-o5GXsWTzEttKZqBvomYx3qaFMv1PRd8VlfssOS3LkYs4iAuBV2JMLJnVO1uq89uP"></script>
     <link rel="modulepreload" crossorigin="anonymous" href="/assets/react-DSrzR8JC.js" integrity="sha384-H2sC4wLvMuOhQRrkzTM7Oj+CRyDUag3gn3aiMVN2yZxMX7R861tsNdZF/eqkErN3">
     <link rel="modulepreload" crossorigin="anonymous" href="/assets/prop-types-Chjiymov.js" integrity="sha384-TTycbn5lfLbEA6OJwhiwHeVyv4iieoS2CZZUKZfJv5zs7vUWWwY6vSy2ZybCUkT7">
     <link rel="modulepreload" crossorigin="anonymous" href="/assets/es-toolkit-CXh-ENaP.js" integrity="sha384-feJijAWVxVRhoXsKiKzWmHSTxniGpLXSppr80KMSAAN8LAm1Cc7NLAJ3waNR44xv">

--- a/apps/web/src/components/TaskTable.tsx
+++ b/apps/web/src/components/TaskTable.tsx
@@ -10,7 +10,9 @@ interface TaskTableProps {
   users?: Record<number, any>;
   page: number;
   pageCount?: number;
+  mine?: boolean;
   onPageChange: (p: number) => void;
+  onMineChange?: (v: boolean) => void;
   onRowClick?: (id: string) => void;
   toolbarChildren?: React.ReactNode;
 }
@@ -20,7 +22,9 @@ export default function TaskTable({
   users = {},
   page,
   pageCount,
+  mine = false,
   onPageChange,
+  onMineChange,
   onRowClick,
   toolbarChildren,
 }: TaskTableProps) {
@@ -56,7 +60,21 @@ export default function TaskTable({
         pageCount={pageCount}
         onPageChange={onPageChange}
         onRowClick={(row) => onRowClick?.((row as TaskRow)._id)}
-        toolbarChildren={toolbarChildren}
+        toolbarChildren={
+          <>
+            {typeof onMineChange === "function" && (
+              <label className="flex items-center gap-1 text-sm">
+                <input
+                  type="checkbox"
+                  checked={mine}
+                  onChange={(e) => onMineChange(e.target.checked)}
+                />
+                Мои
+              </label>
+            )}
+            {toolbarChildren}
+          </>
+        }
       />
     </Suspense>
   );


### PR DESCRIPTION
## Summary
- add "mine" state on TasksPage
- toggle to show only own tasks and pass `mine` to API

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm build`
- `pnpm run dev`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c3253936448320806cf2426fa54f20