### PR TITLE
feat: defer task loading until profile ready

### DIFF
--- a/apps/web/src/pages/TasksPage.tsx
+++ b/apps/web/src/pages/TasksPage.tsx
@@ -64,7 +64,7 @@ export default function TasksPage() {
   }, [isPrivileged, user, page, mine]);
 
   React.useEffect(() => {
-    if (authLoading || !canView) return;
+    if (authLoading || !canView || !user?.access) return;
     load();
     // после загрузки профиля инициируем загрузку задач
   }, [authLoading, load, version, page, mine, canView, user?.access]);


### PR DESCRIPTION
## Summary
- ensure task list loads only after profile access is available
- watch `user?.access` in TasksPage effect

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh`
- `timeout 5s pnpm run dev` *(fails: Command failed with signal "SIGTERM")*

------
https://chatgpt.com/codex/tasks/task_b_68c3b350dbb083209cf3549185dbf5e7