### PR TITLE
feat(web): clear anon task cache on auth

### DIFF
--- a/apps/web/src/context/AuthProvider.tsx
+++ b/apps/web/src/context/AuthProvider.tsx
@@ -2,6 +2,7 @@
 // Модули: React, services/auth, AuthContext, AuthActionsContext, utils/csrfToken
 import { useEffect, useState, type ReactNode } from "react";
 import { getProfile, logout as apiLogout } from "../services/auth";
+import { clearAnonTasksCache } from "../services/tasks";
 import { AuthContext } from "./AuthContext";
 import { AuthActionsContext } from "./AuthActionsContext";
 import { setCsrfToken } from "../utils/csrfToken";
@@ -12,7 +13,11 @@ interface AuthProviderProps {
 }
 
 export function AuthProvider({ children }: AuthProviderProps) {
-  const [user, setUser] = useState<User | null>(null);
+  const [user, setUserState] = useState<User | null>(null);
+  const setUser = (u: User | null) => {
+    setUserState(u);
+    if (u) clearAnonTasksCache();
+  };
   const [loading, setLoading] = useState(true);
   useEffect(() => {
     const loadCsrf = async () => {
@@ -48,7 +53,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, []);
   const logout = async () => {
     await apiLogout();
-    setUser(null);
+    setUserState(null);
+    clearAnonTasksCache();
   };
   return (
     <AuthContext.Provider value={{ user, loading }}>

--- a/apps/web/src/services/tasks.storage.spec.ts
+++ b/apps/web/src/services/tasks.storage.spec.ts
@@ -30,4 +30,18 @@ describe("fetchTasks", () => {
     expect(res).toEqual(data);
     expect(setItem).toHaveBeenCalled();
   });
+  test("skipCache отключает чтение и запись", async () => {
+    const data = { tasks: [], users: [], total: 0 };
+    (authFetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => data,
+    });
+    const getItem = jest.fn(() => JSON.stringify({ time: Date.now(), data }));
+    const setItem = jest.fn();
+    (globalThis as any).localStorage = { getItem, setItem };
+    const res = await fetchTasks({}, undefined, true);
+    expect(res).toEqual(data);
+    expect(getItem).not.toHaveBeenCalled();
+    expect(setItem).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- clear cached anonymous tasks on login/logout
- add skipCache flag to tasks fetcher
- reset anonymous task cache from auth provider

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh`
- `pnpm --dir apps/web run lint`
- `pnpm test apps/web/src/services/tasks.storage.spec.ts`


------
https://chatgpt.com/codex/tasks/task_b_68c3ca69beb483208d876b68a9a8b526