### PR TITLE
feat: allow managers to list tasks

### DIFF
--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -23,7 +23,7 @@ export default class TasksController {
     const { page, limit, ...filters } = req.query;
     let tasks: TaskEx[];
     let total = 0;
-    if (req.user!.access === 2) {
+    if (['admin', 'manager'].includes(req.user!.role || '')) {
       const res = await this.service.get(
         filters,
         page ? Number(page) : undefined,

--- a/apps/api/tests/tasks.test.ts
+++ b/apps/api/tests/tasks.test.ts
@@ -62,8 +62,9 @@ jest
 
 jest.mock('../src/api/middleware', () => ({
   verifyToken: (req, _res, next) => {
+    const role = String(req.headers['x-role'] || 'admin');
     const access = Number(req.headers['x-access'] || 6);
-    req.user = { role: 'admin', id: 1, telegram_id: 1, access };
+    req.user = { role, id: 1, telegram_id: 1, access };
     next();
   },
   asyncHandler: (fn) => fn,
@@ -109,7 +110,6 @@ test('создание задачи возвращает 201', async () => {
     }),
   );
 });
-
 
 test('создание задачи через multipart', async () => {
   const res = await request(app)
@@ -168,6 +168,14 @@ test('получение списка задач возвращает польз
   const res = await request(app).get('/api/v1/tasks');
   expect(res.body.users['1'].name).toBe('User');
   expect(Array.isArray(res.body.tasks)).toBe(true);
+  expect(res.body.total).toBe(1);
+});
+
+test('получение всех задач для роли manager', async () => {
+  Task.find.mockReturnValueOnce([
+    { _id: '1', assignees: [1], controllers: [], created_by: 1 },
+  ]);
+  const res = await request(app).get('/api/v1/tasks').set('x-role', 'manager');
   expect(res.body.total).toBe(1);
 });
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -6,11 +6,11 @@
 
 В `apps/api/src/utils/accessMask.ts` определены константы масок:
 
-| Константа     | Значение | Описание                      |
-| ------------- | -------- | ----------------------------- |
-| `ACCESS_USER` | `1`      | Обычный пользователь          |
-| `ACCESS_ADMIN`| `2`      | Администратор                |
-| `ACCESS_MANAGER` | `4`   | Менеджер или промежуточная роль |
+| Константа        | Значение | Описание                        |
+| ---------------- | -------- | ------------------------------- |
+| `ACCESS_USER`    | `1`      | Обычный пользователь            |
+| `ACCESS_ADMIN`   | `2`      | Администратор                   |
+| `ACCESS_MANAGER` | `4`      | Менеджер или промежуточная роль |
 
 Функция `hasAccess(mask, required)` проверяет наличие прав, а `accessByRole(name)` из `apps/api/src/db/queries.ts` вычисляет маску по названию роли.
 
@@ -27,11 +27,15 @@
 
 Поле `permissions` содержит список разрешённых действий или областей системы. Маска доступа не хранится и определяется по полю `name`.
 
+Роли `admin` и `manager` получают полный список задач без фильтров.
+
 ## Примеры использования декоратора `Roles`
 
 ### Обычный пользователь
+
 ```ts
-router.get('/profile',
+router.get(
+  '/profile',
   authMiddleware(),
   Roles(ACCESS_USER),
   rolesGuard,
@@ -40,8 +44,10 @@ router.get('/profile',
 ```
 
 ### Администратор
+
 ```ts
-router.get('/roles',
+router.get(
+  '/roles',
   authMiddleware(),
   Roles(ACCESS_ADMIN),
   rolesGuard,
@@ -50,8 +56,10 @@ router.get('/roles',
 ```
 
 ### Менеджер
+
 ```ts
-router.post('/tasks',
+router.post(
+  '/tasks',
   authMiddleware(),
   Roles(ACCESS_MANAGER),
   rolesGuard,


### PR DESCRIPTION
## Summary
- permit managers to view full task list like admins
- cover manager task listing with tests
- document manager rights in task permissions

## Testing
- `pnpm install`
- `pnpm lint`
- `./scripts/setup_and_test.sh`
- `pnpm build`
- `pnpm run dev` *(fails: Command failed after manual termination)*
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c3cf7355988320b9271c66c38ce282