### PR TITLE
fix: подключены типы Telegram в Playwright-тестах

### DIFF
--- a/apps/web/src/services/tasks.ts
+++ b/apps/web/src/services/tasks.ts
@@ -1,5 +1,7 @@
 // Назначение: запросы к API задач
 // Основные модули: authFetch, buildTaskFormData
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="../types/telegram.d.ts" />
 import authFetch from "../utils/authFetch";
 import { buildTaskFormData } from "./buildTaskFormData";
 import type { Task, User } from "shared";

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,6 +11,7 @@ const config: Config = {
   testPathIgnorePatterns: [
     '<rootDir>/tests/e2e/',
     '<rootDir>/tests/api/',
+    '<rootDir>/tests/playwright/',
     '<rootDir>/apps/web/src/types/',
   ],
   setupFiles: ['<rootDir>/tests/setupEnv.ts'],

--- a/tests/playwright/login.flow.spec.ts
+++ b/tests/playwright/login.flow.spec.ts
@@ -2,6 +2,7 @@
  * Назначение файла: сценарий входа с эмуляцией Telegram initData.
  * Основные модули: @playwright/test, express.
  */
+/// <reference path="../../apps/web/src/types/telegram.d.ts" />
 import { test, expect } from '@playwright/test';
 import express from 'express';
 import type { Server } from 'http';

--- a/tests/playwright/tasks.flow.spec.ts
+++ b/tests/playwright/tasks.flow.spec.ts
@@ -2,6 +2,7 @@
  * Назначение файла: сценарий списка задач с эмуляцией Telegram initData.
  * Основные модули: @playwright/test, express.
  */
+/// <reference path="../../apps/web/src/types/telegram.d.ts" />
 import { test, expect } from '@playwright/test';
 import express from 'express';
 import type { Server } from 'http';


### PR DESCRIPTION
## Summary
- подключены типы Telegram в сценариях Playwright
- jest исключает каталог `tests/playwright`
- сервис задач подключает объявления Telegram

## Testing
- `pnpm lint`
- `pnpm test:unit`
- `pnpm test:api`
- `pnpm test:e2e` *(fail: Unknown compiler option '--workspace-concurrency=1')*
- `pnpm build`
- `pnpm run dev` *(fail: Command failed with signal "SIGTERM")*

------
https://chatgpt.com/codex/tasks/task_b_68c402b6d26c8320826a8d850f865431