### PR TITLE
feat: уточнена проверка size-limit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@
 - Если доступна команда `docker` и есть `docker-compose.yml`, выполняйте `docker compose config`.
 - Настроен Prettier, используйте `pnpm format` перед коммитами.
 - Линтер запускайте `pnpm lint`.
-- Сборка клиента проверяется `pnpm size`; размер `apps/api/public/assets/*.js` не превышает 900 KB.
+- Сборка клиента проверяется `pnpm size`; файлы `index-*.js` в `apps/api/public/assets` и `apps/web/dist/assets` меньше 900 KB.
 - Скрипты зависимостей проверяются `pnpm approve-builds`, CI падает при появлении новых скриптов.
 - Статическую страницу `apps/web/index.html` проверяйте на контраст командой `pnpm a11y` через `@axe-core/cli` и `vite preview`.
 - Сценарии Playwright и Supertest находятся в каталоге `tests` и запускаются командами `pnpm test:e2e` и `pnpm test:api`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # История изменений
 
+- Size-limit проверяет только `index-*.js` в `apps/api/public/assets` и `apps/web/dist/assets`, что предотвращает ложные срабатывания.
 - Добавлена зависимость `svgo` и отключена песочница Chrome в Lighthouse CI.
 - Исправлен путь сборки в Lighthouse CI; отчёт собирается из `apps/api/public`.
 - Добавлена документация по маскам доступа, коллекции `roles` и декоратору `Roles`.

--- a/package.json
+++ b/package.json
@@ -104,11 +104,11 @@
   "packageManager": "pnpm@10.15.0",
   "size-limit": [
     {
-      "path": "apps/api/public/assets/*.js",
+      "path": "apps/api/public/assets/index-*.js",
       "limit": "900 KB"
     },
     {
-      "path": "apps/web/dist/assets/*.js",
+      "path": "apps/web/dist/assets/index-*.js",
       "limit": "900 KB"
     }
   ]


### PR DESCRIPTION
## Summary
- ограничили проверку размера бандла файлами `index-*.js`
- обновили инструкции разработчика

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm --dir apps/web build`
- `mkdir -p apps/web/dist && cp -r apps/api/public/assets apps/web/dist/ && pnpm size`


------
https://chatgpt.com/codex/tasks/task_b_68c407d37804832088344bf9d471aee9