### PR TITLE
fix: install Playwright browsers with preserved PATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Проверка build-скриптов
         run: pnpm approve-builds
       - name: Установка браузеров Playwright
-        run: npx playwright install --with-deps
+        run: sudo env "PATH=$PATH" npx playwright install --with-deps
       - name: Линтеры
         run: pnpm lint
       - name: Юнит и API тесты
@@ -85,7 +85,7 @@ jobs:
       - name: Установка зависимостей
         run: pnpm install
       - name: Установка браузеров Playwright
-        run: npx playwright install --with-deps
+        run: sudo env "PATH=$PATH" npx playwright install --with-deps
       - name: E2E тесты
         run: pnpm test:e2e -- --project="${{ matrix.project }}"
       - name: Сохранение артефактов

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # История изменений
 
+- В CI установка браузеров Playwright выполняется через `sudo env "PATH=$PATH"`, что устраняет ошибку `node: not found`.
 - Size-limit проверяет только `index-*.js` в `apps/api/public/assets` и `apps/web/dist/assets`, что предотвращает ложные срабатывания.
 - Добавлена зависимость `svgo` и отключена песочница Chrome в Lighthouse CI.
 - Исправлен путь сборки в Lighthouse CI; отчёт собирается из `apps/api/public`.


### PR DESCRIPTION
## Summary
- fix Playwright browser installation in CI by preserving PATH when elevating privileges
- document CI fix in changelog

## Testing
- `pnpm lint`
- `pnpm test:unit`
- `pnpm test:api`
- `pnpm exec playwright test`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c410761ad0832097aadf3e9afd5a07