### PR TITLE
fix: correct pnpm build flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pretest:unit": "pnpm --filter shared build",
     "pretest:api": "pnpm --filter shared build",
     "pretest:e2e": "./scripts/build_with_tmp.sh",
-    "build": "pnpm --filter packages/shared build && pnpm -r --filter '!packages/shared' build",
+    "build": "pnpm --filter shared build && pnpm -r --filter '!shared' build",
     "dev": "PNPM_SCRIPT_TIMEOUT=0 pnpm -r dev",
     "lint": "pnpm -r lint",
     "a11y": "ts-node scripts/a11y.ts",

--- a/scripts/build_with_tmp.sh
+++ b/scripts/build_with_tmp.sh
@@ -10,5 +10,5 @@ cleanup() {
 trap cleanup EXIT
 (
   flock -x 9
-  TMPDIR="$TMP_DIR" pnpm build --workspace-concurrency=1
+  TMPDIR="$TMP_DIR" pnpm --workspace-concurrency=1 build
 ) 9>/tmp/pnpm_build.lock


### PR DESCRIPTION
## Summary
- ensure pnpm concurrency flag precedes build command to avoid leaking to tsc
- fix package filter to use shared package name

## Testing
- `pnpm install`
- `./scripts/setup_and_test.sh`
- `pnpm build`
- `timeout 5s pnpm run dev` *(fails: Command failed with signal "SIGTERM" after timeout)*
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c433192fdc8320b285df2f61dadd37