### PR TITLE
feat(web): handle empty token in parseJwt

### DIFF
--- a/apps/web/src/utils/parseJwt.spec.ts
+++ b/apps/web/src/utils/parseJwt.spec.ts
@@ -1,0 +1,17 @@
+/**
+ * Назначение файла: проверки работы parseJwt.
+ * Основные модули: parseJwt.
+ */
+import parseJwt from "./parseJwt";
+
+describe("parseJwt", () => {
+  test("извлекает payload", () => {
+    const payload = { a: 1 };
+    const token = `aaa.${btoa(JSON.stringify(payload))}.bbb`;
+    expect(parseJwt<typeof payload>(token)).toEqual(payload);
+  });
+
+  test("возвращает null при пустой строке", () => {
+    expect(parseJwt("")).toBeNull();
+  });
+});

--- a/apps/web/src/utils/parseJwt.ts
+++ b/apps/web/src/utils/parseJwt.ts
@@ -6,6 +6,7 @@ export interface JwtPayload {
 
 export default function parseJwt<T = JwtPayload>(token: string): T | null {
   try {
+    if (!token) return null;
     const base = token.split(".")[1];
     const json = atob(base);
     return JSON.parse(json) as T;


### PR DESCRIPTION
## Summary
- handle empty token in `parseJwt`
- add tests for empty token scenario

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm run dev`


------
https://chatgpt.com/codex/tasks/task_b_68c4526861248320849d410746496da6