### PR TITLE
fix: обработка пустых заголовков в authFetch

### DIFF
--- a/apps/web/src/utils/authFetch.spec.ts
+++ b/apps/web/src/utils/authFetch.spec.ts
@@ -1,0 +1,42 @@
+/* eslint-env jest */
+// Назначение: проверка authFetch при отсутствии заголовков ответа
+// Основные модули: authFetch, XMLHttpRequest
+import authFetch from "./authFetch";
+
+jest.mock("./csrfToken", () => ({
+  getCsrfToken: () => "token",
+  setCsrfToken: () => undefined,
+}));
+
+jest.mock("./toast", () => ({
+  showToast: () => undefined,
+}));
+
+class MockXHR {
+  response = "ok";
+  status = 200;
+  statusText = "OK";
+  withCredentials = false;
+  upload = { onprogress: () => undefined };
+  onload: () => void = () => undefined;
+  onerror: () => void = () => undefined;
+  onabort: () => void = () => undefined;
+  open() {}
+  setRequestHeader() {}
+  getAllResponseHeaders() {
+    return "";
+  }
+  send() {
+    this.onload();
+  }
+}
+
+(globalThis as any).XMLHttpRequest = MockXHR as any;
+
+describe("authFetch", () => {
+  it("возвращает пустой Headers при отсутствии заголовков", async () => {
+    const res = await authFetch("/test", { onProgress: () => undefined });
+    expect(res.headers).toBeInstanceOf(Headers);
+    expect(res.headers.get("x-test")).toBeNull();
+  });
+});

--- a/apps/web/src/utils/authFetch.ts
+++ b/apps/web/src/utils/authFetch.ts
@@ -30,15 +30,17 @@ async function sendRequest(
       );
       xhr.upload.onprogress = onProgress;
       xhr.onload = () => {
+        const raw = xhr.getAllResponseHeaders();
         const headers = new Headers();
-        xhr
-          .getAllResponseHeaders()
-          .trim()
-          .split(/\r?\n/)
-          .forEach((line) => {
-            const [key, val] = line.split(": ");
-            if (key) headers.append(key, val);
-          });
+        if (typeof raw === "string" && raw.trim()) {
+          raw
+            .trim()
+            .split(/\r?\n/)
+            .forEach((line) => {
+              const [key, val] = line.split(": ");
+              if (key) headers.append(key, val);
+            });
+        }
         resolve(
           new Response(xhr.response, {
             status: xhr.status,


### PR DESCRIPTION
## Summary
- обработан пустой результат getAllResponseHeaders
- добавлен тест без заголовков ответа

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm test:unit apps/web/src/utils/authFetch.spec.ts`


------
https://chatgpt.com/codex/tasks/task_b_68c46b46579c8320aaa0a95ee3fc2b7c