### PR TITLE
fix: handle empty Google Maps URL

### DIFF
--- a/apps/web/src/utils/parseGoogleAddress.spec.ts
+++ b/apps/web/src/utils/parseGoogleAddress.spec.ts
@@ -1,0 +1,21 @@
+/**
+ * Назначение файла: проверки работы parseGoogleAddress.
+ * Основные модули: parseGoogleAddress.
+ */
+import parseGoogleAddress from "./parseGoogleAddress";
+
+describe("parseGoogleAddress", () => {
+  test("возвращает короткий адрес", () => {
+    const url = "https://www.google.com/maps/place/Some+Place/@0,0,17z";
+    expect(parseGoogleAddress(url)).toBe("Some Place");
+  });
+
+  test("возвращает пустую строку при пустой строке", () => {
+    expect(parseGoogleAddress("")).toBe("");
+  });
+
+  test("возвращает исходное значение при некорректном URL", () => {
+    const invalid = "not a url";
+    expect(parseGoogleAddress(invalid)).toBe(invalid);
+  });
+});

--- a/apps/web/src/utils/parseGoogleAddress.ts
+++ b/apps/web/src/utils/parseGoogleAddress.ts
@@ -1,5 +1,11 @@
-// Извлекает короткий адрес из ссылки Google Maps
+/**
+ * Назначение файла: извлекает короткий адрес из ссылки Google Maps.
+ * Основные модули: parseGoogleAddress.
+ */
 export default function parseGoogleAddress(url: string): string {
+  if (!url) {
+    return url;
+  }
   try {
     const place = url.match(/\/place\/([^/]+)/);
     if (place) {


### PR DESCRIPTION
## Summary
- avoid matching on empty Google Maps URL
- test empty and invalid addresses

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm --dir apps/web run lint`
- `pnpm test:unit apps/web/src/utils/parseGoogleAddress.spec.ts`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c484eee1748320a35d21485501ecd4