### PR TITLE
feat: сохраняем сборку в каталоге js

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -68,6 +68,8 @@ export default defineConfig(() => {
       emptyOutDir: true,
       outDir: "../api/public",
       manifest: true,
+      // JS-файлы сохраняем в каталоге js
+      assetsDir: "js",
 
       // Sourcemap включены для всех сборок
       sourcemap: true,

--- a/scripts/pre_pr_check.sh
+++ b/scripts/pre_pr_check.sh
@@ -52,7 +52,7 @@ cp .env apps/.env
 ./scripts/audit_deps.sh
 
 ./scripts/build_client.sh >/dev/null
-if [ ! -f apps/api/public/.vite/manifest.json ] || ! ls apps/api/public/assets/index*.js >/dev/null 2>&1; then
+if [ ! -f apps/api/public/.vite/manifest.json ] || ! ls apps/api/public/js/index*.js >/dev/null 2>&1; then
   echo "Отсутствует собранный JS-бандл" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- выводим сборку веб‑клиента в каталог js
- обновляем pre_pr_check для проверки нового пути

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm --filter web build`
- `firebase deploy --only hosting` *(fails: Not in a Firebase app directory)*
- `curl -I https://agronautic.web.app/js/TasksPage-C2AfWlAR.js` *(404)*
- `./scripts/pre_pr_check.sh` *(fails: kill (No such process))*

------
https://chatgpt.com/codex/tasks/task_b_68c5008fa8988320a6adb3f6bb69bcb0