### PR TITLE
fix(ci): adjust bundle copy path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,13 @@ jobs:
           name: build-artifact
           path: apps/api/public
       - name: Проверка размеров бандлов
-        run: mkdir -p apps/web/dist && cp -r apps/api/public/assets apps/web/dist/ && pnpm size
+        run: mkdir -p apps/web/dist && cp -r apps/api/public/js apps/web/dist/ && pnpm size
       - name: Загрузка sourcemap
         if: github.ref == 'refs/heads/staging'
         uses: actions/upload-artifact@v4
         with:
           name: sourcemaps
-          path: apps/api/public/assets/**/*.map
+          path: apps/api/public/js/**/*.map
 
   e2e-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- fix bundle size check to copy js directory
- upload sourcemaps from js output

## Testing
- `pnpm install`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm run dev`

------
https://chatgpt.com/codex/tasks/task_b_68c51e58b2ec8320be251b3b5d9cdb32