### PR TITLE
feat: обновить проверки масок доступа

### DIFF
--- a/apps/api/tests/auth.test.ts
+++ b/apps/api/tests/auth.test.ts
@@ -19,7 +19,7 @@ jest.mock('../src/db/queries', () => ({
     roleId: '686591126cc86a6bd16c18af',
     role: 'admin',
   })),
-  accessByRole: (r: string) => (r === 'admin' ? 2 : r === 'manager' ? 4 : 1),
+  accessByRole: (r: string) => (r === 'admin' ? 6 : r === 'manager' ? 4 : 1),
 }));
 jest.mock('../src/services/service', () => ({ writeLog: jest.fn() }));
 jest.useFakeTimers().setSystemTime(0);
@@ -46,7 +46,7 @@ test('generateToken returns valid jwt', () => {
     id: 5,
     username: 'a',
     role: 'admin',
-    access: 2,
+    access: 6,
   });
   const data = jwt.decode(token);
   expect(data.id).toBe(5);

--- a/apps/api/tests/authService.test.ts
+++ b/apps/api/tests/authService.test.ts
@@ -18,7 +18,7 @@ jest.mock('../src/db/queries', () => ({
   getUser: jest.fn(() => null),
   createUser: jest.fn(async () => ({ username: 'u' })),
   updateUser: jest.fn(),
-  accessByRole: (r: string) => (r === 'admin' ? 2 : r === 'manager' ? 4 : 1),
+  accessByRole: (r: string) => (r === 'admin' ? 6 : r === 'manager' ? 4 : 1),
 }));
 jest.mock('../src/services/userInfoService', () => ({
   getMemberStatus: jest.fn(async () => 'member'),

--- a/apps/api/tests/loginFlow.test.ts
+++ b/apps/api/tests/loginFlow.test.ts
@@ -23,7 +23,7 @@ jest.mock('../src/db/queries', () => ({
   getUser: jest.fn(async () => null),
   createUser: jest.fn(async () => ({ username: 'u' })),
   updateUser: jest.fn(async () => ({})),
-  accessByRole: (r: string) => (r === 'admin' ? 2 : r === 'manager' ? 4 : 1),
+  accessByRole: (r: string) => (r === 'admin' ? 6 : r === 'manager' ? 4 : 1),
 }));
 
 const authRouter = require('../src/routes/authUser').default;

--- a/apps/api/tests/loginRouteFlow.test.ts
+++ b/apps/api/tests/loginRouteFlow.test.ts
@@ -22,7 +22,7 @@ jest.mock('../src/db/queries', () => ({
   getUser: jest.fn(async () => null),
   createUser: jest.fn(async () => ({ username: 'u' })),
   updateUser: jest.fn(async () => ({})),
-  accessByRole: (r: string) => (r === 'admin' ? 2 : r === 'manager' ? 4 : 1),
+  accessByRole: (r: string) => (r === 'admin' ? 6 : r === 'manager' ? 4 : 1),
 }));
 jest.mock('../src/services/route', () => ({
   getRouteDistance: jest.fn(async () => ({ distance: 100, waypoints: [] })),

--- a/apps/api/tests/loginTasksFlow.test.ts
+++ b/apps/api/tests/loginTasksFlow.test.ts
@@ -41,7 +41,7 @@ jest.mock('../src/db/queries', () => ({
   getUser: jest.fn(async () => ({ roleId: 'm' })),
   createUser: jest.fn(async () => ({ username: 'u', role: 'manager' })),
   updateUser: jest.fn(async () => ({})),
-  accessByRole: (r: string) => (r === 'admin' ? 2 : r === 'manager' ? 4 : 1),
+  accessByRole: (r: string) => (r === 'admin' ? 6 : r === 'manager' ? 4 : 1),
 }));
 
 const authRouter = require('../src/routes/authUser').default;

--- a/apps/api/tests/profile.test.ts
+++ b/apps/api/tests/profile.test.ts
@@ -18,7 +18,7 @@ jest.mock('../src/db/queries', () => ({
     username: 'test',
     ...d,
   })),
-  accessByRole: (r: string) => (r === 'admin' ? 2 : r === 'manager' ? 4 : 1),
+  accessByRole: (r: string) => (r === 'admin' ? 6 : r === 'manager' ? 4 : 1),
 }));
 
 const ctrl = require('../src/auth/auth.controller.ts');

--- a/apps/api/tests/routes.test.ts
+++ b/apps/api/tests/routes.test.ts
@@ -15,7 +15,7 @@ const { stopQueue } = require('../src/services/messageQueue');
 jest.mock('../src/db/queries', () => ({
   listRoutes: jest.fn(async () => [{ _id: '1' }]),
   getUser: jest.fn(async () => ({})),
-  accessByRole: (r: string) => (r === 'admin' ? 2 : r === 'manager' ? 4 : 1),
+  accessByRole: (r: string) => (r === 'admin' ? 6 : r === 'manager' ? 4 : 1),
 }));
 
 const { listRoutes } = require('../src/db/queries');

--- a/apps/api/tests/users.test.ts
+++ b/apps/api/tests/users.test.ts
@@ -18,7 +18,7 @@ jest.mock('../src/db/queries', () => ({
   listUsers: jest.fn(async () => [{ telegram_id: 1, username: 'test' }]),
   createUser: jest.fn(async () => ({ telegram_id: 1, username: 'test' })),
   updateUser: jest.fn(async () => ({ telegram_id: 1, username: 'new' })),
-  accessByRole: (r: string) => (r === 'admin' ? 2 : r === 'manager' ? 4 : 1),
+  accessByRole: (r: string) => (r === 'admin' ? 6 : r === 'manager' ? 4 : 1),
 }));
 
 jest.mock('../src/api/middleware', () => ({
@@ -97,6 +97,14 @@ test('админ получает список пользователей', asyn
     .set('x-access', '2');
   expect(res.status).toBe(200);
   expect(res.body[0].username).toBe('test');
+});
+
+test('менеджер получает 403', async () => {
+  const res = await request(app)
+    .get('/api/v1/users')
+    .set('x-role', 'manager')
+    .set('x-access', '4');
+  expect(res.status).toBe(403);
 });
 
 test('обычный пользователь получает 403', async () => {

--- a/tests/access.roles.spec.ts
+++ b/tests/access.roles.spec.ts
@@ -5,8 +5,8 @@
 import { accessByRole } from '../apps/api/src/db/queries';
 
 describe('доступ по ролям', () => {
-  test('администратор получает маску 2', () => {
-    expect(accessByRole('admin')).toBe(2);
+  test('администратор получает маску 6', () => {
+    expect(accessByRole('admin')).toBe(6);
   });
 
   test('менеджер получает маску 4', () => {


### PR DESCRIPTION
## Summary
- обновлена маска администратора в тестах на роль
- синхронизированы моки accessByRole во всех API тестах
- добавлен сценарий 403 для менеджера в users.test.ts

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c5584b5e1c8320b90a14d2b3b3ee85