### PR TITLE
feat(api): allow manager list users

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -13,30 +13,29 @@ import { CreateUserDto, UpdateUserDto } from '../dto/users.dto';
 
 const router: Router = Router();
 const limiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 100 });
-const adminMiddlewares = [
-  limiter,
-  authMiddleware(),
-  Roles(ACCESS_ADMIN),
-  rolesGuard,
-] as RequestHandler[];
-const managerMiddlewares = [
-  limiter,
-  authMiddleware(),
-  Roles(ACCESS_MANAGER),
-  rolesGuard,
-] as RequestHandler[];
+const base = [limiter, authMiddleware()] as RequestHandler[];
 const ctrl = container.resolve(UsersController);
 
-router.get('/', ...managerMiddlewares, ctrl.list as RequestHandler);
+router.get(
+  '/',
+  ...base,
+  Roles(ACCESS_MANAGER),
+  rolesGuard,
+  ctrl.list as RequestHandler,
+);
 router.post(
   '/',
-  ...adminMiddlewares,
+  ...base,
+  Roles(ACCESS_ADMIN),
+  rolesGuard,
   ...(validateDto(CreateUserDto) as RequestHandler[]),
   ...(ctrl.create as RequestHandler[]),
 );
 router.patch(
   '/:id',
-  ...adminMiddlewares,
+  ...base,
+  Roles(ACCESS_ADMIN),
+  rolesGuard,
   ...(validateDto(UpdateUserDto) as RequestHandler[]),
   ...(ctrl.update as RequestHandler[]),
 );

--- a/tests/api/users.access.spec.ts
+++ b/tests/api/users.access.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * Назначение файла: проверка доступа менеджера и администратора к маршрутам пользователей.
+ * Основные модули: express, supertest, middleware Roles и rolesGuard.
+ */
+import express = require('express');
+import request = require('supertest');
+import { Roles } from '../../apps/api/src/auth/roles.decorator';
+import rolesGuard from '../../apps/api/src/auth/roles.guard';
+import {
+  ACCESS_ADMIN,
+  ACCESS_MANAGER,
+} from '../../apps/api/src/utils/accessMask';
+
+const app = express();
+const auth = (req: any, _res: any, next: any) => {
+  const role = req.headers['x-role'];
+  const access = role === 'admin' ? 6 : role === 'manager' ? 4 : 1;
+  req.user = { access };
+  next();
+};
+
+app.get('/users', auth, Roles(ACCESS_MANAGER), rolesGuard, (_req, res) =>
+  res.sendStatus(200),
+);
+app.post('/users', auth, Roles(ACCESS_ADMIN), rolesGuard, (_req, res) =>
+  res.sendStatus(200),
+);
+app.patch('/users/:id', auth, Roles(ACCESS_ADMIN), rolesGuard, (_req, res) =>
+  res.sendStatus(200),
+);
+
+describe('доступ к роутам пользователей', () => {
+  it('менеджер может получать список', async () => {
+    await request(app).get('/users').set('x-role', 'manager').expect(200);
+  });
+  it('админ может получать список', async () => {
+    await request(app).get('/users').set('x-role', 'admin').expect(200);
+  });
+  it('менеджер не может создавать', async () => {
+    await request(app).post('/users').set('x-role', 'manager').expect(403);
+  });
+  it('админ может создавать', async () => {
+    await request(app).post('/users').set('x-role', 'admin').expect(200);
+  });
+  it('менеджер не может обновлять', async () => {
+    await request(app).patch('/users/1').set('x-role', 'manager').expect(403);
+  });
+  it('админ может обновлять', async () => {
+    await request(app).patch('/users/1').set('x-role', 'admin').expect(200);
+  });
+});


### PR DESCRIPTION
## Summary
- allow managers to query user list
- keep creating and editing users restricted to admins
- add API tests for manager and admin roles

## Testing
- `./scripts/setup_and_test.sh`
- `TS_NODE_PROJECT=tests/tsconfig.json pnpm test:api tests/api/users.access.spec.ts`
- `./scripts/pre_pr_check.sh`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68c579e7d59c8320ae59e85530d66d91