### PR TITLE
feat: externalize swagger script and tighten CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # История изменений
 
+- Документация Swagger очищена от инлайновых скриптов,
+  CSP разрешает `swagger-ui-bundle.js` по SHA-256.
 - Уточнены `docs/access_mask.md` и `docs/permissions.md`: admin = `ACCESS_ADMIN | ACCESS_MANAGER (6)` и наследует права менеджера.
 - Роль admin наследует права manager через объединение масок.
 - Устаревшие документы перенесены в `docs/archive`, документация обновлена.

--- a/apps/api/src/api/security.ts
+++ b/apps/api/src/api/security.ts
@@ -52,13 +52,13 @@ export default function applySecurity(app: express.Express): void {
     "'self'",
     (_req: IncomingMessage, res: ServerResponse) =>
       `'nonce-${(res as ResWithNonce).locals.cspNonce}'`,
+    "'sha256-2/O23rVGzYb9aZ8tq1s0n2ikD9CzHyqf5NS+VJWXcDI='",
     'https://telegram.org',
     ...parseList(process.env.CSP_SCRIPT_SRC_ALLOWLIST),
   ];
 
   const styleSrc = [
     "'self'",
-    "'unsafe-inline'",
     ...parseList(process.env.CSP_STYLE_SRC_ALLOWLIST),
   ];
 

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -1,3 +1,4 @@
+<!-- Назначение файла: статическая документация Swagger. -->
 <!doctype html>
 <html lang="ru">
   <head>
@@ -11,10 +12,6 @@
   <body>
     <div id="swagger-ui"></div>
     <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
-    <script>
-      window.onload = () => {
-        SwaggerUIBundle({ url: 'openapi.json', dom_id: '#swagger-ui' });
-      };
-    </script>
+    <script src="swagger-ui-init.js" integrity="sha384-bJBi6jmVwd002O1ILI2+RHJvQ/MB6n8VJtV/XsNlPZV3jccDNBKheXkMqIooR7a4"></script>
   </body>
 </html>

--- a/docs/api/swagger-ui-init.ts
+++ b/docs/api/swagger-ui-init.ts
@@ -1,0 +1,5 @@
+// Назначение: инициализация Swagger UI.
+// Основные модули: window, SwaggerUIBundle
+window.onload = () => {
+  SwaggerUIBundle({ url: 'openapi.json', dom_id: '#swagger-ui' });
+};


### PR DESCRIPTION
## Summary
- extract Swagger UI setup into a separate script file and link it from docs
- harden content security policy with SHA-256 hash for swagger-ui bundle

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/pre_pr_check.sh`
- `pnpm build`
- `pnpm run dev`

------
https://chatgpt.com/codex/tasks/task_b_68c5b0f11e688320ae8651f4b838192f