### PR TITLE
feat: validate manager access and csrf headers

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -62,6 +62,9 @@ async function verifyCode(
         ? 'manager'
         : 'user';
   const access = accessByRole(role);
+  if (u.access !== access) {
+    await updateUser(telegramId, { role });
+  }
   const token = generateToken({
     id: telegramId,
     username: u.username || '',
@@ -94,7 +97,10 @@ async function verifyInitData(initData: string) {
     );
   }
   const role = user.role || 'user';
-  const access = user.access || 1;
+  const access = accessByRole(role);
+  if (user.access !== access) {
+    await updateUser(telegramId, { role });
+  }
   const token = generateToken({
     id: telegramId,
     username: user.username || '',
@@ -119,7 +125,10 @@ async function verifyTmaLogin(initData: ReturnType<typeof verifyInit>) {
     );
   }
   const role = user.role || 'user';
-  const access = user.access || 1;
+  const access = accessByRole(role);
+  if (user.access !== access) {
+    await updateUser(telegramId, { role });
+  }
   const token = generateShortToken({
     id: telegramId,
     username: user.username || '',

--- a/apps/api/tests/__mocks__/jsonwebtoken.ts
+++ b/apps/api/tests/__mocks__/jsonwebtoken.ts
@@ -1,3 +1,7 @@
 // Назначение: поддельная реализация jsonwebtoken для тестов. Модули: jest.
-const jwtMock = { sign: () => 'token', decode: () => ({ id: 5 }) };
+const jwtMock = {
+  sign: jest.fn(() => 'token'),
+  verify: jest.fn(() => ({})),
+  decode: jest.fn(() => ({ id: 5 })),
+};
 export = jwtMock;

--- a/tests/authFetch.spec.ts
+++ b/tests/authFetch.spec.ts
@@ -28,6 +28,20 @@ describe('authFetch', () => {
     window.location.href = 'http://localhost/';
   });
 
+  test('отправляет токен и куки', async () => {
+    const mockFetch = jest.fn().mockResolvedValue(makeResponse(200));
+    // @ts-ignore
+    global.fetch = mockFetch;
+    await authFetch('/foo', { noRedirect: true });
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/foo',
+      expect.objectContaining({
+        credentials: 'include',
+        headers: expect.objectContaining({ 'X-XSRF-TOKEN': 'token' }),
+      }),
+    );
+  });
+
   test('refreshes on 401', async () => {
     const mockFetch = jest
       .fn()


### PR DESCRIPTION
## Summary
- обновить auth.service: корректировать access менеджера перед выдачей JWT
- расширить мок jsonwebtoken и добавить тест для менеджера
- проверить authFetch на отправку CSRF и cookie

## Testing
- `./scripts/setup_and_test.sh`
- `npx jest tests/authFetch.spec.ts`


------
https://chatgpt.com/codex/tasks/task_b_68c668fe040883208e84becfa7e0c324