### PR TITLE
fix: указать TS_NODE_PROJECT для тестов API

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "pnpm -r lint",
     "a11y": "ts-node scripts/a11y.ts",
     "test:e2e": "playwright test",
-    "test:api": "mocha -r ts-node/register -r tests/setupEnv.ts tests/api/**/*.spec.ts",
+    "test:api": "TS_NODE_PROJECT=apps/api/tsconfig.json mocha -r ts-node/register -r tests/setupEnv.ts tests/api/**/*.spec.ts",
     "test:unit": "jest",
     "format": "prettier --write .",
     "test": "pnpm test:unit && pnpm test:api && pnpm test:e2e",


### PR DESCRIPTION
## Summary
- указываем TS_NODE_PROJECT для mocha в скрипте тестов API

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm test:api`
- `pnpm lint`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c67372c0988320b335f46b6f254ef8