### PR TITLE
fix: корректный запуск e2e тестов

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Установка браузеров Playwright
         run: sudo env "PATH=$PATH" npx playwright install --with-deps
       - name: E2E тесты
-        run: pnpm test:e2e -- --project="${{ matrix.project }}"
+        run: pnpm run test:e2e --project="${{ matrix.project }}"
       - name: Сохранение артефактов
         if: ${{ always() }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Что сделано
- исправлен запуск e2e тестов в CI

## Зачем
- команда без `run` подставляла лишний `--`, из-за чего Playwright не находил тесты

## Проверки
- `./scripts/setup_and_test.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c677559bd083209785f8b855847e19