### PR TITLE
feat: clear tasks cache after updates

### DIFF
--- a/apps/web/src/pages/TasksPage.tsx
+++ b/apps/web/src/pages/TasksPage.tsx
@@ -35,6 +35,7 @@ export default function TasksPage() {
     fetchTasks(
       { page: page + 1, limit: 25, mine: mine ? 1 : undefined },
       user?.telegram_id,
+      true,
     )
       .then((data) => {
         const tasks = data.tasks as TaskExtra[];

--- a/apps/web/src/services/tasks.ts
+++ b/apps/web/src/services/tasks.ts
@@ -34,6 +34,7 @@ export const createTask = (
       if (id && window.Telegram?.WebApp) {
         window.Telegram.WebApp.sendData(`task_created:${id}`);
       }
+      clearTasksCache();
       return result;
     },
   );
@@ -55,6 +56,9 @@ export const updateTask = (
     method: "PATCH",
     body,
     onProgress,
+  }).then((r) => {
+    if (r.ok) clearTasksCache();
+    return r;
   });
 };
 
@@ -66,6 +70,13 @@ export interface TasksResponse {
   users: User[] | Record<string, User>;
   total: number;
 }
+
+export const clearTasksCache = () => {
+  // Удаляем все ключи кеша задач
+  Object.keys(localStorage)
+    .filter((k) => k.startsWith("tasks_"))
+    .forEach((k) => localStorage.removeItem(k));
+};
 
 export const clearAnonTasksCache = () => {
   Object.keys(localStorage)


### PR DESCRIPTION
## Summary
- add clearTasksCache utility for tasks service
- invalidate cache after createTask and updateTask
- force tasks page to refetch latest data

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_68c6bd3b71c88320b2cf7acf9b612b6d