### PR TITLE
chore: ensure default roles

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -44,10 +44,12 @@
 
 ### Миграция роли manager
 
-Для существующих баз данных выполните:
+Скрипт `scripts/db/ensureDefaults.ts` проверяет наличие обязательных ролей и
+добавляет отсутствующие. Он выполняется автоматически во время `pnpm build`,
+при необходимости его можно запустить вручную:
 
 ```bash
-pnpm ts-node scripts/db/addManagerRole.ts
+pnpm ts-node scripts/db/ensureDefaults.ts
 ```
 
 ### Синхронизация ролей пользователей

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pretest:unit": "pnpm --filter shared build",
     "pretest:api": "pnpm --filter shared build",
     "pretest:e2e": "./scripts/build_with_tmp.sh",
-    "build": "pnpm --filter shared build && pnpm -r --filter '!shared' build",
+    "build": "pnpm --filter shared build && pnpm -r --filter '!shared' build && pnpm ts-node -P apps/api/tsconfig.json scripts/db/ensureDefaults.ts",
     "dev": "PNPM_SCRIPT_TIMEOUT=0 pnpm -r dev",
     "lint": "pnpm -r lint",
     "a11y": "ts-node scripts/a11y.ts",

--- a/scripts/db/ensureDefaults.ts
+++ b/scripts/db/ensureDefaults.ts
@@ -1,0 +1,65 @@
+// Назначение: проверяет наличие обязательных ролей и создаёт их при отсутствии
+// Модули: mongoose, Role, config
+import mongoose from 'mongoose';
+import { Role } from '../../apps/api/src/db/model';
+import config from '../../apps/api/src/config';
+
+async function ensureDefaults(): Promise<void> {
+  const timeout = 5000;
+  try {
+    await mongoose.connect(config.mongoUrl, {
+      serverSelectionTimeoutMS: timeout,
+    });
+    const db = mongoose.connection.db;
+    if (!db) throw new Error('нет доступа к db');
+    await db.admin().ping();
+  } catch (e) {
+    const err = e as { message?: string };
+    console.warn(
+      'Не удалось подключиться к MongoDB, пропускаем инициализацию:',
+      err.message,
+    );
+    await mongoose.disconnect().catch(() => undefined);
+    return;
+  }
+
+  const ids: Record<string, string> = {
+    ADMIN_ROLE_ID: config.adminRoleId,
+    USER_ROLE_ID: config.userRoleId,
+    MANAGER_ROLE_ID: config.managerRoleId,
+  };
+  for (const [key, value] of Object.entries(ids)) {
+    if (!process.env[key]) {
+      console.warn(
+        `Переменная ${key} не задана, используем значение по умолчанию ${value}`,
+      );
+    }
+  }
+
+  const roles = [
+    { _id: config.userRoleId, name: 'user' },
+    { _id: config.adminRoleId, name: 'admin' },
+    { _id: config.managerRoleId, name: 'manager' },
+  ];
+
+  for (const r of roles) {
+    const exists = await Role.exists({ _id: r._id });
+    if (!exists) {
+      await Role.create(r);
+      console.log(`Добавлена роль ${r.name}`);
+    }
+  }
+
+  await mongoose.disconnect();
+}
+
+if (require.main === module) {
+  ensureDefaults()
+    .catch((e: unknown) => {
+      const err = e as { message?: string };
+      console.error('Ошибка инициализации:', err.message);
+    })
+    .finally(() => process.exit());
+}
+
+export default ensureDefaults;


### PR DESCRIPTION
## Summary
- add ensureDefaults script to create missing roles in MongoDB
- run ensureDefaults after package build
- document automatic role creation

## Testing
- `pnpm lint`
- `pnpm test` *(fails: browserType.launch: Executable doesn't exist...)*
- `pnpm build` *(fails: apps/web build: Failed)*

------
https://chatgpt.com/codex/tasks/task_b_68c6c0baf2a48320bfc70121dfdcd7da