### PR TITLE
fix: fallback mongoose import in ensureDefaults

### DIFF
--- a/scripts/db/ensureDefaults.ts
+++ b/scripts/db/ensureDefaults.ts
@@ -1,6 +1,11 @@
 // Назначение: проверяет наличие обязательных ролей и создаёт их при отсутствии
 // Модули: mongoose, Role, config
-import mongoose from 'mongoose';
+let mongoose: typeof import('mongoose');
+try {
+  mongoose = require('mongoose');
+} catch {
+  mongoose = require('../../apps/api/node_modules/mongoose');
+}
 import { Role } from '../../apps/api/src/db/model';
 import config from '../../apps/api/src/config';
 


### PR DESCRIPTION
## Summary
- ensureDefaults tries local mongoose path if not hoisted

## Testing
- `pnpm lint`
- `pnpm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/webkit-2191/pw_run.sh)*
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_b_68c6e3a9b758832093d599bbe92d23ea