### PR TITLE
fix: skip env checks during build

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -7,8 +7,11 @@ import dotenv from 'dotenv';
 dotenv.config({ path: path.resolve(__dirname, '../..', '.env') });
 
 const required = ['BOT_TOKEN', 'CHAT_ID', 'JWT_SECRET', 'APP_URL'] as const;
-for (const k of required) {
-  if (!process.env[k]) throw new Error(`Переменная ${k} не задана`);
+// Пропускаем проверку при сборке без токена
+if (process.env.NODE_ENV !== 'production-build') {
+  for (const k of required) {
+    if (!process.env[k]) throw new Error(`Переменная ${k} не задана`);
+  }
 }
 
 const mongoUrlEnv = (


### PR DESCRIPTION
## Summary
- skip required env var checks in config during production-build
- load env directly in db defaults script to avoid config dependency

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_68c706ff97508320ac8a72bd3a5500eb