### PR TITLE
refactor: корректный импорт path в ensureDefaults

### DIFF
--- a/scripts/db/ensureDefaults.ts
+++ b/scripts/db/ensureDefaults.ts
@@ -1,6 +1,6 @@
 // Назначение: проверяет наличие обязательных ролей и создаёт их при отсутствии
 // Модули: mongoose, dotenv, path
-import path from 'path';
+import * as path from 'path'; // модуль для работы с путями
 
 const dotenv: any = (() => {
   try {


### PR DESCRIPTION
## Summary
- исправлен импорт `path` в скрипте `ensureDefaults`

## Testing
- `pnpm install`
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(failed: apps/web build: Failed)*
- `pnpm run dev`
- `pnpm ts-node scripts/db/ensureDefaults.ts`


------
https://chatgpt.com/codex/tasks/task_b_68c71ce605788320b9f1d964110f6022