### PR TITLE
fix: compile ensureDefaults in build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # История изменений
 
+- Команда сборки компилирует `ensureDefaults` в `dist`, чтобы стартовый скрипт находился в Docker и на Railway.
 - Добавлен `nixpacks.toml` для сборки на Railway без режима offline.
 - Функция updateUser синхронизирует roleId по названию роли; добавлен скрипт `syncUserRoles.ts`.
 - Скрипт seed добавляет документ роли manager, миграция `addManagerRole.ts`

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pnpm run dev # запуск api и web без таймаута PNPM
 ## Сборка и проверки
 
 ```bash
-pnpm build       # сборка проекта
+pnpm build       # сборка проекта и компиляция ensureDefaults
 pnpm size        # контроль размера бандла
 pnpm a11y        # проверка контрастности
 pnpm approve-builds  # контроль скриптов зависимостей

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pretest:unit": "pnpm --filter shared build",
     "pretest:api": "pnpm --filter shared build",
     "pretest:e2e": "./scripts/build_with_tmp.sh",
-    "build": "pnpm --filter shared build && pnpm -r --filter '!shared' build && pnpm ts-node -P apps/api/tsconfig.json scripts/db/ensureDefaults.ts",
+    "build": "pnpm --filter shared build && pnpm -r --filter '!shared' build && npx tsc scripts/db/ensureDefaults.ts --module commonjs --target ES2020 --outDir dist --rootDir . --types node && node dist/scripts/db/ensureDefaults.js",
     "dev": "PNPM_SCRIPT_TIMEOUT=0 pnpm -r dev",
     "lint": "pnpm -r lint",
     "a11y": "ts-node scripts/a11y.ts",

--- a/scripts/db/ensureDefaults.ts
+++ b/scripts/db/ensureDefaults.ts
@@ -6,7 +6,7 @@ const dotenv: any = (() => {
   try {
     return require('dotenv');
   } catch {
-    return require('../../apps/api/node_modules/dotenv');
+    return require(path.resolve(process.cwd(), 'apps/api/node_modules/dotenv'));
   }
 })();
 
@@ -14,7 +14,7 @@ const mongoose: any = (() => {
   try {
     return require('mongoose');
   } catch {
-    return require('../../apps/api/node_modules/mongoose');
+    return require(path.resolve(process.cwd(), 'apps/api/node_modules/mongoose'));
   }
 })();
 


### PR DESCRIPTION
## Summary
- compile `scripts/db/ensureDefaults.ts` during build and run compiled script
- note the build step in docs

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_68c7a77446c08320975bd1d09d57dd48