### PR TITLE
feat: upsert default roles

### DIFF
--- a/apps/api/src/db/model.ts
+++ b/apps/api/src/db/model.ts
@@ -341,6 +341,7 @@ const roleSchema = new Schema<RoleDocument>({
   name: String,
   permissions: [String],
 });
+roleSchema.index({ name: 1 }, { name: 'role_name_unique', unique: true });
 
 export interface UserAttrs {
   telegram_id: number;

--- a/scripts/db/ensureDefaults.ts
+++ b/scripts/db/ensureDefaults.ts
@@ -86,9 +86,12 @@ async function ensureDefaults(): Promise<void> {
   ];
 
   for (const r of roles) {
-    const exists = await Role.exists({ _id: r._id });
-    if (!exists) {
-      await Role.create(r);
+    const res = await Role.updateOne(
+      { _id: r._id },
+      { $setOnInsert: r },
+      { upsert: true },
+    );
+    if (res.upsertedCount) {
       console.log(`Добавлена роль ${r.name}`);
     }
   }

--- a/tests/ensureDefaults.spec.ts
+++ b/tests/ensureDefaults.spec.ts
@@ -1,0 +1,33 @@
+// Назначение: проверка идемпотентности ensureDefaults
+// Основные модули: mongoose, ensureDefaults
+jest.mock('mongoose', () => {
+  const updateOne = jest.fn().mockResolvedValue({ upsertedCount: 1 });
+  const model = jest.fn(() => ({ updateOne }));
+  const connection = {
+    db: { admin: () => ({ ping: jest.fn().mockResolvedValue(undefined) }) },
+  };
+  return {
+    Schema: class {},
+    model,
+    connect: jest.fn().mockImplementation(async () => ({ connection })),
+    disconnect: jest.fn().mockResolvedValue(undefined),
+    connection,
+    __updateOne: updateOne,
+  };
+});
+
+import ensureDefaults from '../scripts/db/ensureDefaults';
+const mongoose = require('mongoose') as any;
+
+describe('ensureDefaults', () => {
+  test('повторный запуск не создаёт дубли', async () => {
+    process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
+    await ensureDefaults();
+    await ensureDefaults();
+    expect(mongoose.__updateOne).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      expect.objectContaining({ upsert: true }),
+    );
+  });
+});

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -18,7 +18,9 @@
       "@testing-library/jest-dom",
       "express",
       "multer",
-      "../apps/web/src/types/telegram"
+      "../apps/web/src/types/telegram",
+      "mongodb-memory-server",
+      "mongoose"
     ],
     "typeRoots": ["../node_modules/@types", "../apps/api/src/types"]
   }


### PR DESCRIPTION
## Summary
- ensure default roles use Mongo upsert
- enforce unique role names and test idempotent defaults

## Testing
- `./scripts/setup_and_test.sh`
- `pnpm test:unit`
- `pnpm lint`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c809c3b3d08320a878e2eb54da63a3