### PR TITLE
fix: ссылка ERM в боте и корректные координаты

### DIFF
--- a/apps/api/src/bot/bot.ts
+++ b/apps/api/src/bot/bot.ts
@@ -26,7 +26,7 @@ process.on('uncaughtException', (err) => {
 async function showMainMenu(ctx: Context): Promise<void> {
   await ctx.reply(
     messages.menuPrompt,
-    Markup.keyboard([['Регистрация']]).resize(),
+    Markup.keyboard([['Регистрация', 'ERM']]).resize(),
   );
 }
 
@@ -57,6 +57,9 @@ bot.start(async (ctx) => {
 
 bot.command('register', checkAndRegister);
 bot.hears('Регистрация', checkAndRegister);
+bot.hears('ERM', async (ctx) => {
+  await ctx.reply(messages.ermLink);
+});
 
 const MAX_RETRIES = 5;
 

--- a/apps/api/src/messages.ts
+++ b/apps/api/src/messages.ts
@@ -38,6 +38,7 @@ const messages = {
   fullMapLink: 'Полная ссылка',
   mapCoords: 'Координаты',
   mapLinkError: 'Не удалось получить ссылку',
+  ermLink: 'Ссылка на приложение: https://agromarket.up.railway.app',
   help: `Доступные команды:\n/start - запуск бота\n/register - регистрация`,
 } as const;
 

--- a/apps/web/src/columns/taskColumns.tsx
+++ b/apps/web/src/columns/taskColumns.tsx
@@ -87,7 +87,10 @@ export default function taskColumns(
       meta: { minWidth: "10rem", maxWidth: "14rem" },
       cell: (p) => {
         const v = p.getValue<any>();
-        const text = v ? `${v.lat}, ${v.lng}` : "";
+        const text =
+          v && typeof v.lat === "number" && typeof v.lng === "number"
+            ? `${v.lat}, ${v.lng}`
+            : "";
         return <span title={text}>{text}</span>;
       },
     },
@@ -97,7 +100,10 @@ export default function taskColumns(
       meta: { minWidth: "10rem", maxWidth: "14rem" },
       cell: (p) => {
         const v = p.getValue<any>();
-        const text = v ? `${v.lat}, ${v.lng}` : "";
+        const text =
+          v && typeof v.lat === "number" && typeof v.lng === "number"
+            ? `${v.lat}, ${v.lng}`
+            : "";
         return <span title={text}>{text}</span>;
       },
     },


### PR DESCRIPTION
## Summary
- показать координаты только при наличии широты и долготы
- добавить кнопку ERM в боте с ссылкой на веб‑приложение

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `./scripts/pre_pr_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c820a519b48320993973c2721598e2