### PR TITLE
feat: add close method to Telegram WebApp type

### DIFF
--- a/apps/web/src/types/telegram.d.ts
+++ b/apps/web/src/types/telegram.d.ts
@@ -11,6 +11,7 @@ declare namespace Telegram {
     initData: string;
     initDataUnsafe: Record<string, unknown>;
     sendData(data: string): void;
+    close(): void;
     translate?(key: string): string;
   }
 }


### PR DESCRIPTION
## Что сделано и зачем
- добавлен метод `close()` в `Telegram.WebApp`, чтобы типы соответствовали возможностям веб-клиента Telegram.
- прогнан локальный типовой тест, чтобы убедиться в целостности деклараций.

## Чек-лист
- [x] `pnpm --filter web test:types`
- [x] `pnpm test`

## Логи команд
```bash
$ pnpm --filter web test:types
> web@0.0.0 test:types /workspace/ERM-Telegram-web-bot/apps/web
> tsc --noEmit --lib ESNext,DOM --types node src/types/task.test.ts

$ pnpm test
> erm-telegram-web-bot@ test /workspace/ERM-Telegram-web-bot
> pnpm test:unit && pnpm test:api && pnpm test:e2e
...
Test Suites: 2 skipped, 26 passed, 26 of 28 total
Tests:       2 skipped, 47 passed, 49 total
...
  13 passing (129ms)
...
  6 passed (21.6s)
```

## Самопроверка
- Метод `close()` описан как синхронный вызов без аргументов, как требует Telegram WebApp API.
- Типовой тест `pnpm --filter web test:types` прошёл после изменения.
- Полный запуск `pnpm test` (unit, api, e2e) завершается успешно.
- Лишние артефакты сборки удалены перед коммитом.


------
https://chatgpt.com/codex/tasks/task_b_68c840b1e21083209bd9c97176a910a7