### PR TITLE
feat: add profile dropdown menu

### DIFF
--- a/apps/web/src/components/ProfileDropdown.tsx
+++ b/apps/web/src/components/ProfileDropdown.tsx
@@ -1,0 +1,62 @@
+// Назначение: выпадающее меню профиля пользователя.
+// Основные модули: React, Radix Dropdown Menu, useAuth.
+import React from "react";
+import { Link } from "react-router-dom";
+import { UserCircleIcon } from "@heroicons/react/24/outline";
+
+import { useAuth } from "../context/useAuth";
+import { Button } from "./ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "./ui/dropdown-menu";
+
+interface ProfileDropdownProps {
+  children?: React.ReactNode;
+}
+
+export default function ProfileDropdown({
+  children,
+}: ProfileDropdownProps) {
+  const { user, logout } = useAuth();
+
+  if (!user) {
+    return null;
+  }
+
+  const name = user.name || user.telegram_username || user.username || "Профиль";
+  const profileLink = `/employees/${user.id}`;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Профиль"
+          className="size-12"
+        >
+          {children ?? <UserCircleIcon className="h-5 w-5" />}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-48">
+        <DropdownMenuItem asChild>
+          <Link to={profileLink} className="truncate">
+            {name}
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onSelect={() => {
+            void logout();
+          }}
+        >
+          Выход
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/src/layouts/Header.tsx
+++ b/apps/web/src/layouts/Header.tsx
@@ -3,9 +3,9 @@
 import React from "react";
 import { useSidebar } from "../context/useSidebar";
 import { useAuth } from "../context/useAuth";
-import NotificationDropdown from "../components/NotificationDropdown";
+import ProfileDropdown from "../components/ProfileDropdown";
 import ThemeToggle from "../components/ThemeToggle";
-import { Bars3Icon, BellIcon } from "@heroicons/react/24/outline";
+import { Bars3Icon, UserCircleIcon } from "@heroicons/react/24/outline";
 import { useTranslation } from "react-i18next";
 
 export default function Header() {
@@ -43,9 +43,9 @@ export default function Header() {
         {user && (
           <>
             <ThemeToggle />
-            <NotificationDropdown notifications={[t("newMessage")]}>
-              <BellIcon className="h-5 w-5" />
-            </NotificationDropdown>
+            <ProfileDropdown>
+              <UserCircleIcon className="h-5 w-5" />
+            </ProfileDropdown>
           </>
         )}
       </div>


### PR DESCRIPTION
## Что сделано и зачем
- добавлен компонент ProfileDropdown со ссылкой на карточку сотрудника и кнопкой выхода, чтобы заменить уведомления в шапке
- Header рендерит профильное меню с иконкой пользователя вместо колокольчика для доступа к профилю

## Чек-лист
- [x] pnpm lint
- [x] pnpm test:unit
- [x] pnpm build

## Логи
<details>
<summary>pnpm lint</summary>

```
pnpm lint
> erm-telegram-web-bot@ lint /workspace/ERM-Telegram-web-bot
> pnpm -r lint
```

</details>
<details>
<summary>pnpm test:unit</summary>

```
> erm-telegram-web-bot@ test:unit /workspace/ERM-Telegram-web-bot
> jest

Test Suites: 1 skipped, 21 passed, 21 of 28 total
Tests:       1 skipped, 41 passed, 42 total
Snapshots:   0 total
```

</details>
<details>
<summary>pnpm build</summary>

```
apps/web build: ✓ built in 2m 25s
apps/web build: Done
```

</details>

## Самопроверка
- меню скрывается при отсутствии пользователя
- ссылка профиля ведёт на /employees/<id>
- кнопка «Выход» вызывает useAuth().logout
- дропдаун использует стандартные ui-компоненты


------
https://chatgpt.com/codex/tasks/task_b_68c844fdbfbc83209143eb2f0f0408e0