### PR TITLE
fix: align user route handler typing

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -13,7 +13,7 @@ import { CreateUserDto, UpdateUserDto } from '../dto/users.dto';
 
 const router: Router = Router();
 const limiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 100 });
-const base = [limiter, authMiddleware()] as RequestHandler[];
+const base: RequestHandler[] = [limiter, authMiddleware()];
 const ctrl = container.resolve(UsersController);
 
 router.get(
@@ -21,28 +21,28 @@ router.get(
   ...base,
   Roles(ACCESS_MANAGER),
   rolesGuard,
-  ctrl.list as RequestHandler,
+  ctrl.list,
 );
-router.get(
+router.get<{ id: string }>(
   '/:id',
   ...base,
-  ctrl.get as RequestHandler,
+  ctrl.get,
 );
 router.post(
   '/',
   ...base,
   Roles(ACCESS_ADMIN),
   rolesGuard,
-  ...(validateDto(CreateUserDto) as RequestHandler[]),
-  ...(ctrl.create as RequestHandler[]),
+  ...validateDto(CreateUserDto),
+  ...ctrl.create,
 );
-router.patch(
+router.patch<{ id: string }>(
   '/:id',
   ...base,
   Roles(ACCESS_ADMIN),
   rolesGuard,
-  ...(validateDto(UpdateUserDto) as RequestHandler[]),
-  ...(ctrl.update as RequestHandler[]),
+  ...validateDto(UpdateUserDto),
+  ...ctrl.update,
 );
 
 export default router;


### PR DESCRIPTION
## Summary
- type the shared middleware array in the users router explicitly
- provide typed route declarations so controller handlers match Express expectations without casts

## Testing
- ./scripts/setup_and_test.sh
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_b_68c8612890188320b869efc014ca0c3f