### PR TITLE
feat: отправка кодов для менеджера

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -15,6 +15,8 @@ async function sendCode(telegramId: number | string) {
   const roleId = user?.roleId?.toString();
   if (roleId === config.adminRoleId) {
     await otp.sendAdminCode({ telegramId: Number(telegramId) });
+  } else if (roleId === config.managerRoleId) {
+    await otp.sendManagerCode({ telegramId: Number(telegramId) });
   } else {
     await otp.sendCode({ telegramId: Number(telegramId) });
   }

--- a/apps/api/src/services/otp.ts
+++ b/apps/api/src/services/otp.ts
@@ -46,6 +46,18 @@ export async function sendCode({ telegramId }: SendCodePayload): Promise<void> {
   await call('sendMessage', { chat_id: telegramId, text });
 }
 
+export async function sendManagerCode({
+  telegramId,
+}: SendCodePayload): Promise<void> {
+  clean();
+  const code = Math.floor(100000 + Math.random() * 900000).toString();
+  const text = `Код входа для менеджера: ${code}`;
+  const key = String(telegramId);
+  codes.set(key, { code, ts: Date.now() });
+  attempts.delete(key);
+  await call('sendMessage', { chat_id: telegramId, text });
+}
+
 export async function sendAdminCode({
   telegramId,
 }: SendCodePayload): Promise<void> {

--- a/apps/api/tests/authService.test.ts
+++ b/apps/api/tests/authService.test.ts
@@ -8,6 +8,7 @@ process.env.APP_URL = 'https://localhost';
 
 jest.mock('../src/services/otp', () => ({
   sendCode: jest.fn(),
+  sendManagerCode: jest.fn(),
   sendAdminCode: jest.fn(),
   verifyCode: jest.fn(() => true),
   verifyAdminCode: jest.fn(() => true),
@@ -47,6 +48,14 @@ test('sendCode использует adminCodes для админа', async () =>
   });
   await service.sendCode('1');
   expect(otp.sendAdminCode).toHaveBeenCalledWith({ telegramId: 1 });
+});
+
+test('sendCode использует sendManagerCode для менеджера', async () => {
+  queries.getUser.mockResolvedValueOnce({
+    roleId: require('../src/config').managerRoleId,
+  });
+  await service.sendCode('3');
+  expect(otp.sendManagerCode).toHaveBeenCalledWith({ telegramId: 3 });
 });
 
 test('sendCode вызывает sendCode для обычного пользователя', async () => {

--- a/apps/api/tests/otp.test.ts
+++ b/apps/api/tests/otp.test.ts
@@ -9,14 +9,17 @@ jest.mock('../src/services/telegramApi', () => ({ call: jest.fn() }));
 
 const {
   sendCode,
+  sendManagerCode,
   verifyCode,
   codes,
   attempts,
 } = require('../src/services/otp');
+const { call } = require('../src/services/telegramApi');
 
 beforeEach(() => {
   codes.clear();
   attempts.clear();
+  call.mockClear();
 });
 
 test('verifyCode блокирует после пяти ошибочных попыток', async () => {
@@ -26,4 +29,17 @@ test('verifyCode блокирует после пяти ошибочных по�
     expect(verifyCode({ telegramId: 42, code: '0' })).toBe(false);
   }
   expect(verifyCode({ telegramId: 42, code: real })).toBe(false);
+});
+
+test('sendManagerCode отправляет корректный текст для менеджера', async () => {
+  await sendManagerCode({ telegramId: 7 });
+  const stored = codes.get('7');
+  expect(stored).toBeDefined();
+  expect(call).toHaveBeenCalledWith(
+    'sendMessage',
+    expect.objectContaining({
+      chat_id: 7,
+      text: `Код входа для менеджера: ${stored.code}`,
+    }),
+  );
 });


### PR DESCRIPTION
## Что сделано и зачем
- добавлен `sendManagerCode` с отдельным текстом для менеджера и вызов сервиса при авторизации менеджера
- обновлены модульные тесты auth и otp, чтобы проверить выбор менеджерского канала и корректность текста сообщения

## Чек-лист
- [x] `pnpm test`
- [ ] `pnpm lint`
- [ ] `pnpm build`

## Логи
- `pnpm test`

## Самопроверка
- [x] код соответствует инструкциям из AGENTS.md
- [x] покрытие тестами добавлено для новой логики
- [x] артефакты сборки удалены перед коммитом


------
https://chatgpt.com/codex/tasks/task_b_68c86b654a708320ac5f0b70a6629019