### PR TITLE
fix: auth limiter key and docker fetch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:20 AS build
 WORKDIR /app
 
 # Установка зависимостей
-COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml .npmrc ./
 COPY apps/api/package.json apps/api/
 COPY apps/web/package.json apps/web/
 COPY packages/shared/package.json packages/shared/

--- a/apps/api/src/utils/rateLimiter.ts
+++ b/apps/api/src/utils/rateLimiter.ts
@@ -24,6 +24,48 @@ const drops = new client.Counter({
   labelNames: ['name', 'key'],
 });
 
+function extractTelegramId(value: unknown): string | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) return trimmed;
+  }
+  return undefined;
+}
+
+function resolveTelegramId(req: RequestWithUser): string | undefined {
+  const fromUser = req.user?.telegram_id;
+  const userTelegramId = extractTelegramId(fromUser);
+  if (userTelegramId) return userTelegramId;
+
+  const body = req.body as Record<string, unknown> | undefined;
+  const query = req.query as Record<string, unknown> | undefined;
+  const params = req.params as Record<string, unknown> | undefined;
+  const session = (req as unknown as {
+    session?: Record<string, unknown>;
+  }).session;
+
+  const candidates: unknown[] = [
+    body?.telegramId,
+    body?.telegram_id,
+    query?.telegramId,
+    query?.telegram_id,
+    params?.telegramId,
+    params?.telegram_id,
+    session?.telegramId,
+    session?.telegram_id,
+  ];
+
+  for (const candidate of candidates) {
+    const id = extractTelegramId(candidate);
+    if (id) return id;
+  }
+
+  return undefined;
+}
+
 export default function createRateLimiter({
   windowMs,
   max,
@@ -37,10 +79,11 @@ export default function createRateLimiter({
       req.user?.role === 'admin' && adminMax
         ? adminMax
         : max) as unknown as RateLimitLibOptions['max'],
-    keyGenerator: ((req: RequestWithUser) =>
-      `${name}:${
-        req.user?.telegram_id ?? ipKeyGenerator(req.ip as string)
-      }`) as unknown as RateLimitLibOptions['keyGenerator'],
+    keyGenerator: ((req: RequestWithUser) => {
+      const telegramId = resolveTelegramId(req);
+      const key = telegramId ?? ipKeyGenerator(req.ip as string);
+      return `${name}:${key}`;
+    }) as unknown as RateLimitLibOptions['keyGenerator'],
     standardHeaders: true,
     legacyHeaders: true,
     skip: ((req: RequestWithUser) =>
@@ -59,8 +102,8 @@ export default function createRateLimiter({
           };
         }
       ).rateLimit;
-      const key = req.user?.telegram_id ?? ipKeyGenerator(req.ip as string);
-      drops.inc({ name, key });
+      const keyBase = resolveTelegramId(req) ?? ipKeyGenerator(req.ip as string);
+      drops.inc({ name, key: keyBase });
       const reset = info?.resetTime;
       if (reset instanceof Date) {
         const retryAfter = Math.ceil((reset.getTime() - Date.now()) / 1000);
@@ -79,7 +122,7 @@ export default function createRateLimiter({
       if (resetTime !== undefined)
         res.setHeader('X-RateLimit-Reset', resetTime.toString());
       writeLog(
-        `Превышен лимит ${req.method} ${req.originalUrl} key:${key} ` +
+        `Превышен лимит ${req.method} ${req.originalUrl} key:${keyBase} ` +
           `limit:${limit} remaining:${remaining} reset:${resetTime}`,
         'warn',
       ).catch(() => {});

--- a/apps/api/tests/expensiveRateLimit.test.ts
+++ b/apps/api/tests/expensiveRateLimit.test.ts
@@ -100,6 +100,25 @@ test('валидная капча пропускает лимитер auth', asy
   }
 });
 
+test('подтверждённый запрос обходит лимитер auth', async () => {
+  await new Promise((resolve) => setTimeout(resolve, 250));
+  for (let i = 0; i < 2; i++) {
+    const res = await request(app)
+      .post('/api/v1/auth/send_code')
+      .send({ telegramId: 1 });
+    expect(res.status).toBe(200);
+  }
+  const limited = await request(app)
+    .post('/api/v1/auth/send_code')
+    .send({ telegramId: 1 });
+  expect(limited.status).toBe(429);
+
+  const confirmed = await request(app)
+    .post('/api/v1/auth/send_code')
+    .send({ telegramId: 2 });
+  expect(confirmed.status).toBe(200);
+});
+
 test('лимитер table возвращает 429 и затем 200', async () => {
   let res = await request(app).get('/api/v1/route/table?points=1,1;2,2');
   expect(res.status).toBe(200);


### PR DESCRIPTION
## Summary
- resolve request telegram id from session, body, query and params to use as rate limiter key and log value
- extend rate limiter tests with scenario where another telegram id bypasses prior throttling
- copy `.npmrc` into docker build context to allow pnpm fetch in CI

## Testing
- pnpm lint
- pnpm exec playwright install --with-deps
- pnpm test

------
https://chatgpt.com/codex/tasks/task_b_68c92f7e1d9c8320b357c9dd6360c7a1