### PR TITLE
fix: add confirmed header support to rate limiter

### DIFF
--- a/apps/api/src/utils/rateLimiter.ts
+++ b/apps/api/src/utils/rateLimiter.ts
@@ -25,6 +25,26 @@ const drops = new client.Counter({
 });
 
 
+function hasConfirmedHeader(value: unknown): boolean {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.some((item) => hasConfirmedHeader(item));
+  }
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value === 1;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    return normalized === 'true' || normalized === '1' || normalized === 'yes';
+  }
+  return false;
+}
+
 function extractTelegramId(value: unknown): string | undefined {
   if (typeof value === 'number' && Number.isFinite(value)) {
     return String(value);


### PR DESCRIPTION
## Что сделано
- добавлена утилита `hasConfirmedHeader`, которая безопасно определяет подтверждённый запрос в rate limiter
- настроен пропуск лимитера при наличии заголовка `X-Confirmed-Action`

## Зачем
- исправляет падения API из-за отсутствующей функции и позволяет подтверждённым запросам обходить ограничение

## Логи
- `pnpm lint`
- `pnpm test`

## Чек-лист
- [x] Линтер `pnpm lint`
- [x] Тесты `pnpm test`
- [x] Сборка `pnpm build` (выполняется в составе `pnpm test`)
- [x] Обратная совместимость не нарушена

## Самопроверка
- проверил отсутствия мусорных файлов в git
- убедился, что e2e-тесты проходят после установки браузеров и зависимостей


------
https://chatgpt.com/codex/tasks/task_b_68c93d0fcaa883209fb71a55ee4de327