### PR TITLE
feat: auto-generate user credentials on create

### DIFF
--- a/apps/api/src/di/interfaces.ts
+++ b/apps/api/src/di/interfaces.ts
@@ -22,11 +22,15 @@ export interface ITasksService {
 export interface IUsersService {
   list(): Promise<unknown[]>;
   create(
-    id: string,
+    id: string | number | undefined,
     username?: string,
     roleId?: string,
     data?: unknown,
   ): Promise<unknown>;
+  generate(
+    id?: string | number,
+    username?: string,
+  ): Promise<{ telegramId: number; username: string }>;
   get(id: string | number): Promise<unknown | null>;
   update(id: string, data: unknown): Promise<unknown | null>;
 }

--- a/apps/api/src/dto/users.dto.ts
+++ b/apps/api/src/dto/users.dto.ts
@@ -5,8 +5,8 @@ import { body } from 'express-validator';
 export class CreateUserDto {
   static rules() {
     return [
-      body('id').isInt(),
-      body('username').isString().notEmpty(),
+      body('id').optional({ checkFalsy: true }).isInt(),
+      body('username').optional({ checkFalsy: true }).isString(),
       body('roleId').optional().isMongoId(),
     ];
   }

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -10,6 +10,10 @@ interface UsersRepo {
     roleId?: string,
     data?: Omit<Partial<UserDocument>, 'access' | 'role'>,
   ): Promise<UserDocument>;
+  generateUserCredentials(
+    id?: string | number,
+    username?: string,
+  ): Promise<{ telegramId: number; username: string }>;
   getUser(id: string | number): Promise<UserDocument | null>;
   updateUser(
     id: string | number,
@@ -28,13 +32,24 @@ class UsersService {
     return this.repo.listUsers();
   }
 
-  create(
-    id: string | number,
+  async create(
+    id?: string | number,
     username?: string,
     roleId?: string,
     data: Omit<Partial<UserDocument>, 'access' | 'role'> = {},
   ) {
-    return this.repo.createUser(id, username, roleId, data);
+    const { telegramId, username: resolvedUsername } =
+      await this.repo.generateUserCredentials(id, username);
+    return this.repo.createUser(
+      telegramId,
+      resolvedUsername,
+      roleId,
+      data,
+    );
+  }
+
+  generate(id?: string | number, username?: string) {
+    return this.repo.generateUserCredentials(id, username);
   }
 
   get(id: string | number) {

--- a/apps/api/tests/createUser.test.ts
+++ b/apps/api/tests/createUser.test.ts
@@ -7,8 +7,20 @@ process.env.JWT_SECRET = 's';
 process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
 process.env.APP_URL = 'https://localhost';
 
+const createCursor = () => ({
+  sort: jest.fn().mockReturnThis(),
+  lean: jest.fn().mockReturnThis(),
+  exec: jest.fn().mockResolvedValue(null),
+});
+
+const findOneMock = jest.fn(createCursor);
+
 jest.mock('../src/db/model', () => ({
-  User: { create: jest.fn(async (doc) => doc) },
+  User: {
+    create: jest.fn(async (doc) => doc),
+    exists: jest.fn(async () => false),
+    findOne: findOneMock,
+  },
   Role: { findById: jest.fn(async () => null) },
 }));
 
@@ -17,10 +29,32 @@ const config = require('../src/config');
 const model = require('../src/db/model');
 
 describe('createUser', () => {
+  beforeEach(() => {
+    findOneMock.mockReset();
+    findOneMock.mockImplementation(createCursor);
+  });
+
   test('новый пользователь получает имя из username', async () => {
     model.User.create = jest.fn(async (doc) => doc);
+    model.User.exists = jest.fn(async () => false);
     const u = await createUser(1, 'test');
     expect(u.name).toBe('test');
     expect(u.roleId).toBe(config.userRoleId);
+  });
+
+  test('генерирует id и username при пустом вводе', async () => {
+    model.User.exists = jest
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValue(false);
+    findOneMock.mockReturnValueOnce({
+      sort: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockReturnThis(),
+      exec: jest.fn().mockResolvedValue({ telegram_id: 10 }),
+    });
+    const result = await require('../src/db/queries').generateUserCredentials();
+    expect(result.telegramId).toBe(11);
+    expect(result.username).toBe('employee11');
   });
 });

--- a/apps/web/src/services/users.ts
+++ b/apps/web/src/services/users.ts
@@ -26,7 +26,7 @@ export const fetchUsers = () =>
   authFetch("/api/v1/users").then((r) => (r.ok ? r.json() : []));
 
 export const createUser = (
-  id: number | string,
+  id?: number | string,
   username?: string,
   roleId?: string,
 ) =>
@@ -47,6 +47,41 @@ export const createUser = (
             detail?: string;
           };
           message = data.error || data.detail || data.message || message;
+        } catch {
+          message = body;
+        }
+      }
+      throw new Error(message);
+    }
+    return r.json();
+  });
+
+export interface GeneratedUserCredentials {
+  telegram_id: number;
+  username: string;
+}
+
+export const previewUserCredentials = (
+  id?: number | string,
+  username?: string,
+): Promise<GeneratedUserCredentials> =>
+  authFetch(`/api/v1/users?preview=1`, {
+    method: "POST",
+    confirmed: true,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ id, username }),
+  }).then(async (r) => {
+    if (!r.ok) {
+      const body = await r.text().catch(() => "");
+      let message = "Не удалось получить сгенерированные данные";
+      if (body) {
+        try {
+          const parsed = JSON.parse(body) as {
+            error?: string;
+            detail?: string;
+            message?: string;
+          };
+          message = parsed.error || parsed.detail || parsed.message || message;
         } catch {
           message = body;
         }


### PR DESCRIPTION
## Summary
- add reusable credential generation helpers in the users repository and expose a preview branch in the controller
- allow the service, DI interfaces and DTO to work without a preset telegram id and validate uniqueness before persisting
- prefill the employee creation form with server generated credentials and provide a client helper for preview requests
- extend unit and route tests to cover automatic credential allocation and preview responses

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_b_68c9bcd0e0b8832085c8025211c94517