### PR TITLE
test: fix user preview expectations

### DIFF
--- a/apps/api/tests/createUser.test.ts
+++ b/apps/api/tests/createUser.test.ts
@@ -13,13 +13,13 @@ const createCursor = () => ({
   exec: jest.fn().mockResolvedValue(null),
 });
 
-const findOneMock = jest.fn(createCursor);
+const mockFindOne = jest.fn(createCursor);
 
 jest.mock('../src/db/model', () => ({
   User: {
     create: jest.fn(async (doc) => doc),
     exists: jest.fn(async () => false),
-    findOne: findOneMock,
+    findOne: mockFindOne,
   },
   Role: { findById: jest.fn(async () => null) },
 }));
@@ -30,8 +30,8 @@ const model = require('../src/db/model');
 
 describe('createUser', () => {
   beforeEach(() => {
-    findOneMock.mockReset();
-    findOneMock.mockImplementation(createCursor);
+    mockFindOne.mockReset();
+    mockFindOne.mockImplementation(createCursor);
   });
 
   test('новый пользователь получает имя из username', async () => {
@@ -48,7 +48,7 @@ describe('createUser', () => {
       .mockResolvedValueOnce(false)
       .mockResolvedValueOnce(false)
       .mockResolvedValue(false);
-    findOneMock.mockReturnValueOnce({
+    mockFindOne.mockReturnValueOnce({
       sort: jest.fn().mockReturnThis(),
       lean: jest.fn().mockReturnThis(),
       exec: jest.fn().mockResolvedValue({ telegram_id: 10 }),

--- a/apps/api/tests/users.test.ts
+++ b/apps/api/tests/users.test.ts
@@ -102,7 +102,51 @@ app.post(
   checkRole(ACCESS_ADMIN),
   ...validateDto(CreateUserDto),
   asyncHandler(async (req, res) => {
-    res.json(await createUser(req.body.id, req.body.username, req.body.roleId));
+    const rawId = req.body.id;
+    const rawUsername = req.body.username;
+    const rawRoleId = req.body.roleId;
+
+    const normalizedId =
+      typeof rawId === 'string'
+        ? rawId.trim() || undefined
+        : rawId !== undefined
+        ? rawId
+        : undefined;
+
+    const normalizedUsername =
+      typeof rawUsername === 'string'
+        ? rawUsername.trim() || undefined
+        : rawUsername !== undefined
+        ? String(rawUsername)
+        : undefined;
+
+    const normalizedRoleId =
+      typeof rawRoleId === 'string'
+        ? rawRoleId.trim() || undefined
+        : rawRoleId;
+
+    if (req.query.preview === 'true' || req.query.preview === '1') {
+      const generatedPreview = await generateUserCredentials(
+        normalizedId,
+        normalizedUsername,
+      );
+      res.json({
+        telegram_id: generatedPreview.telegramId,
+        username: generatedPreview.username,
+      });
+      return;
+    }
+
+    const generated = await generateUserCredentials(
+      normalizedId,
+      normalizedUsername,
+    );
+    const createdUser = await createUser(
+      generated.telegramId,
+      generated.username,
+      normalizedRoleId,
+    );
+    res.status(201).json(createdUser);
   }),
 );
 app.patch(


### PR DESCRIPTION
## Summary
- обновил мок-роут в автотестах пользователей, чтобы эмулировать генерацию учётных данных и выставлять 201 статус
- переименовал findOneMock в mockFindOne в тестах createUser для совместимости с jest 30

## Testing
- pnpm lint
- pnpm build
- pnpm test


------
https://chatgpt.com/codex/tasks/task_b_68c9c745dda08320b17035c2fd62f089