### PR TITLE
fix: ensure chunk uploads stored in user directory

### DIFF
--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -60,8 +60,14 @@ router.get(
           return;
         }
       }
-      const target = path.resolve(uploadsDir, file.path);
-      if (!target.startsWith(uploadsDir + path.sep)) {
+      const uploadsAbs = path.resolve(uploadsDir);
+      const target = path.resolve(uploadsAbs, file.path);
+      const relative = path.relative(uploadsAbs, target);
+      if (
+        relative.startsWith('..') ||
+        path.isAbsolute(relative) ||
+        relative.length === 0
+      ) {
         sendProblem(req, res, {
           type: 'about:blank',
           title: 'Недопустимое имя файла',

--- a/tests/tasks.upload.spec.ts
+++ b/tests/tasks.upload.spec.ts
@@ -1,80 +1,244 @@
 /**
- * Назначение файла: проверка загрузки и скачивания вложений задач.
- * Основные модули: express, supertest, multer, sharp.
+ * Назначение файла: проверка chunk-upload, скачивания и удаления вложений задач.
+ * Основные модули: express, supertest, multer, dataStorage сервис.
  */
 import express = require('express');
-import type { Request, RequestHandler } from 'express';
+import type { RequestHandler } from 'express';
 import request = require('supertest');
 import rateLimit from 'express-rate-limit';
 // @ts-ignore
 import multer from '../apps/api/node_modules/multer';
 import * as path from 'path';
 import * as fs from 'fs';
-import { processUploads } from '../apps/api/src/routes/tasks';
-import { uploadsDir } from '../apps/api/src/config/storage';
+import * as os from 'os';
 
-const storage = multer.diskStorage({
-  destination: (
-    _req: Request,
-    _file: Express.Multer.File,
-    cb: (error: Error | null, dest: string) => void,
-  ) => {
-    const dest = path.join(uploadsDir, '1');
-    fs.mkdirSync(dest, { recursive: true });
-    cb(null, dest);
-  },
-  filename: (
-    _req: Request,
-    file: Express.Multer.File,
-    cb: (error: Error | null, name: string) => void,
-  ) => {
-    cb(null, file.originalname);
-  },
-});
-const upload = multer({ storage });
-const app = express();
-const setUser: RequestHandler = (req, _res, next) => {
-  (req as any).user = { id: 1 };
-  next();
-};
-const limiter = rateLimit({ windowMs: 60 * 1000, max: 50 });
-app.post(
-  '/tasks',
-  setUser,
-  limiter,
-  upload.any() as any,
-  processUploads as unknown as RequestHandler,
-  (req, res) => {
-    res.status(201).json({ attachments: (req.body as any).attachments });
+const { Types } = require('../apps/api/node_modules/mongoose');
+
+const storedFiles: Array<{
+  _id: unknown;
+  userId: number;
+  name: string;
+  path: string;
+  thumbnailPath?: string;
+  type: string;
+  size: number;
+  uploadedAt: Date;
+}> = [];
+
+const currentUserId = 7;
+
+jest.mock('../apps/api/src/services/antivirus', () => ({
+  scanFile: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock('../apps/api/src/services/wgLogEngine', () => ({
+  writeLog: jest.fn(),
+}));
+
+jest.mock('../apps/api/src/middleware/auth', () =>
+  function authMock(): RequestHandler {
+    return (req, _res, next) => {
+      (req as any).user = { id: currentUserId, access: 2 };
+      next();
+    };
   },
 );
-app.use('/uploads', express.static(uploadsDir));
 
-describe('Загрузка и скачивание вложений', () => {
-  // Тест пропущен: в окружении отсутствует поддержка sharp.
-  test.skip('загружает изображение и создаёт миниатюру', async () => {
-    const png = Buffer.from(
-      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wIAAgMBApfo5k0AAAAASUVORK5CYII=',
-      'base64',
+jest.mock('../apps/api/src/db/model', () => {
+  const File = {
+    aggregate: jest.fn(async (pipeline: any[]) => {
+      let files = [...storedFiles];
+      const matchStage = pipeline.find((stage) => stage.$match);
+      if (matchStage?.$match?.userId !== undefined) {
+        files = files.filter((f) => f.userId === matchStage.$match.userId);
+      }
+      if (!files.length) return [];
+      const size = files.reduce((total, f) => total + f.size, 0);
+      return [{ _id: null, count: files.length, size }];
+    }),
+    create: jest.fn(async (data: any) => {
+      const doc = {
+        ...data,
+        _id: new Types.ObjectId(),
+        uploadedAt: new Date(),
+      };
+      storedFiles.push(doc);
+      return doc;
+    }),
+    findById: jest.fn((id: unknown) => ({
+      lean: async () =>
+        storedFiles.find((f) => String(f._id) === String(id)) || null,
+    })),
+    findOneAndDelete: jest.fn((query: any) => ({
+      lean: async () => {
+        const idx = storedFiles.findIndex((f) => f.path === query.path);
+        if (idx === -1) return null;
+        const [doc] = storedFiles.splice(idx, 1);
+        return doc;
+      },
+    })),
+    find: jest.fn((query: any = {}) => ({
+      lean: async () => {
+        let files = [...storedFiles];
+        if (query.userId !== undefined) {
+          files = files.filter((f) => f.userId === query.userId);
+        }
+        if (query.type?.$eq !== undefined) {
+          files = files.filter((f) => f.type === query.type.$eq);
+        }
+        return files;
+      },
+    })),
+  };
+  const Task = {
+    findById: jest.fn(() => ({ lean: async () => null })),
+    updateOne: jest.fn(() => ({ exec: async () => undefined })),
+  };
+  return { File, Task, __store: storedFiles };
+});
+
+let handleChunks: typeof import('../apps/api/src/routes/tasks').handleChunks;
+let uploadsDir: string;
+let deleteFile: typeof import('../apps/api/src/services/dataStorage').deleteFile;
+let filesRouter: express.Router;
+let tempRoot: string;
+let app: express.Express;
+
+async function uploadViaChunks(
+  fileId: string,
+  chunks: Buffer[],
+  filename: string,
+  mimetype: string,
+): Promise<{
+  attachment: {
+    name: string;
+    url: string;
+    thumbnailUrl?: string;
+  };
+  storedPath: string;
+  content: Buffer;
+}> {
+  for (let index = 0; index < chunks.length - 1; index++) {
+    const interim = await request(app)
+      .post('/upload-chunk')
+      .field('fileId', fileId)
+      .field('chunkIndex', String(index))
+      .field('totalChunks', String(chunks.length))
+      .attach('file', chunks[index], {
+        filename,
+        contentType: mimetype,
+      });
+    expect(interim.status).toBe(200);
+    expect(interim.body.received).toBe(index);
+  }
+  const lastIndex = chunks.length - 1;
+  const finalResponse = await request(app)
+    .post('/upload-chunk')
+    .field('fileId', fileId)
+    .field('chunkIndex', String(lastIndex))
+    .field('totalChunks', String(chunks.length))
+    .attach('file', chunks[lastIndex], {
+      filename,
+      contentType: mimetype,
+    });
+  expect(finalResponse.status).toBe(200);
+  const attachment = finalResponse.body as {
+    name: string;
+    url: string;
+    thumbnailUrl?: string;
+  };
+  const stored = storedFiles[storedFiles.length - 1];
+  return {
+    attachment,
+    storedPath: stored.path,
+    content: Buffer.concat(chunks),
+  };
+}
+
+beforeAll(async () => {
+  jest.resetModules();
+  tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'erm-upload-'));
+  process.env.STORAGE_DIR = tempRoot;
+  const tasksModule = await import('../apps/api/src/routes/tasks');
+  handleChunks = tasksModule.handleChunks;
+  ({ uploadsDir } = await import('../apps/api/src/config/storage'));
+  ({ deleteFile } = await import('../apps/api/src/services/dataStorage'));
+  ({ default: filesRouter } = await import('../apps/api/src/routes/files'));
+  app = express();
+  const limiter = rateLimit({ windowMs: 60 * 1000, max: 100 });
+  const setUser: RequestHandler = (req, _res, next) => {
+    (req as any).user = { id: currentUserId };
+    next();
+  };
+  const chunkUpload = multer({ storage: multer.memoryStorage() });
+  app.post(
+    '/upload-chunk',
+    setUser,
+    limiter,
+    chunkUpload.single('file') as unknown as RequestHandler,
+    handleChunks as unknown as RequestHandler,
+  );
+  app.use('/api/v1/files', filesRouter);
+});
+
+beforeEach(() => {
+  storedFiles.length = 0;
+  if (!fs.existsSync(uploadsDir)) {
+    fs.mkdirSync(uploadsDir, { recursive: true });
+  } else {
+    for (const entry of fs.readdirSync(uploadsDir)) {
+      fs.rmSync(path.join(uploadsDir, entry), { recursive: true, force: true });
+    }
+  }
+});
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+describe('Chunk upload', () => {
+  test('загружает файл чанками в каталог пользователя', async () => {
+    const chunks = [Buffer.from('Hello '), Buffer.from('world!')];
+    const { attachment, storedPath, content } = await uploadViaChunks(
+      'chunk-demo',
+      chunks,
+      'report.txt',
+      'text/plain',
     );
-    const res = await request(app)
-      .post('/tasks')
-      .attach('files', png, { filename: 'test.png', contentType: 'image/png' });
-    expect(res.status).toBe(201);
-    const atts = res.body.attachments as {
-      name: string;
-      url: string;
-      thumbnailUrl: string;
-    }[];
-    expect(atts[0].name).toBe('test.png');
-    expect(atts[0].thumbnailUrl).toBeDefined();
-    const fileRes = await request(app).get(atts[0].url);
-    expect(fileRes.status).toBe(200);
-    const thumbRes = await request(app).get(atts[0].thumbnailUrl);
-    expect(thumbRes.status).toBe(200);
-    fs.unlinkSync(path.join(uploadsDir, '1', path.basename(atts[0].url)));
-    fs.unlinkSync(
-      path.join(uploadsDir, '1', path.basename(atts[0].thumbnailUrl)),
+    expect(attachment.name).toBe('report.txt');
+    expect(attachment.url).toMatch(/\/api\/v1\/files\//);
+    const absolute = path.resolve(uploadsDir, storedPath);
+    expect(fs.existsSync(absolute)).toBe(true);
+    expect(fs.readFileSync(absolute).toString()).toBe(content.toString());
+    expect(storedPath.startsWith(`${currentUserId}/`)).toBe(true);
+  });
+
+  test('позволяет скачать собранный файл', async () => {
+    const chunks = [Buffer.from('first '), Buffer.from('second')];
+    const { attachment, content } = await uploadViaChunks(
+      'chunk-download',
+      chunks,
+      'notes.txt',
+      'text/plain',
     );
+    const response = await request(app).get(attachment.url);
+    expect(response.status).toBe(200);
+    expect(response.text).toBe(content.toString());
+  });
+
+  test('удаляет файл и запись через deleteFile', async () => {
+    const chunks = [Buffer.from('A '), Buffer.from('B')];
+    const { attachment, storedPath } = await uploadViaChunks(
+      'chunk-delete',
+      chunks,
+      'todo.txt',
+      'text/plain',
+    );
+    const absolute = path.resolve(uploadsDir, storedPath);
+    await deleteFile(storedPath);
+    expect(fs.existsSync(absolute)).toBe(false);
+    expect(storedFiles).toHaveLength(0);
+    const res = await request(app).get(attachment.url);
+    expect(res.status).toBe(404);
   });
 });


### PR DESCRIPTION
## Summary
- move assembled chunk uploads into the user folder, ensure stored paths and thumbnails are relative to the uploads root
- harden the file download route to validate saved paths before responding
- add Jest coverage for chunk upload, download, and deletion flows

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_b_68ca467576948320aa6422518fc02afa