### PR TITLE
feat: require fleet token and update forms

### DIFF
--- a/apps/api/src/db/models/fleet.ts
+++ b/apps/api/src/db/models/fleet.ts
@@ -4,12 +4,14 @@ import { Schema, model, Document } from 'mongoose';
 
 export interface FleetAttrs {
   name: string;
+  token: string;
 }
 
 export interface FleetDocument extends FleetAttrs, Document {}
 
 const fleetSchema = new Schema<FleetDocument>({
   name: { type: String, required: true },
+  token: { type: String, required: true },
 });
 
 export const Fleet = model<FleetDocument>('Fleet', fleetSchema);

--- a/apps/api/src/dto/fleets.dto.ts
+++ b/apps/api/src/dto/fleets.dto.ts
@@ -4,13 +4,19 @@ import { body } from 'express-validator';
 
 export class CreateFleetDto {
   static rules() {
-    return [body('name').isString().notEmpty()];
+    return [
+      body('name').isString().notEmpty(),
+      body('token').isString().notEmpty(),
+    ];
   }
 }
 
 export class UpdateFleetDto {
   static rules() {
-    return [body('name').optional().isString().notEmpty()];
+    return [
+      body('name').optional().isString().notEmpty(),
+      body('token').optional().isString().notEmpty(),
+    ];
   }
 }
 

--- a/apps/web/src/components/FleetManager.test.tsx
+++ b/apps/web/src/components/FleetManager.test.tsx
@@ -6,10 +6,25 @@ import { render } from "@testing-library/react";
 import FleetManager from "./FleetManager";
 
 describe("FleetManager", () => {
-  it("рендерит поле названия", () => {
+  it("рендерит поля названия и токена", () => {
     const { container } = render(<FleetManager onSubmit={() => {}} />);
     expect(
       container.querySelector(FleetManager.selectors.nameInput),
     ).not.toBeNull();
+    expect(
+      container.querySelector(FleetManager.selectors.tokenInput),
+    ).not.toBeNull();
+  });
+
+  it("отображает кнопки управления токеном", () => {
+    const { container } = render(<FleetManager onSubmit={() => {}} />);
+    expect(
+      container.querySelector(FleetManager.selectors.toggleTokenButton),
+    ).not.toBeNull();
+    const copyButton = container.querySelector(
+      FleetManager.selectors.copyTokenButton,
+    ) as HTMLButtonElement | null;
+    expect(copyButton).not.toBeNull();
+    expect(copyButton?.disabled).toBe(true);
   });
 });

--- a/apps/web/src/components/FleetManager.tsx
+++ b/apps/web/src/components/FleetManager.tsx
@@ -3,22 +3,44 @@
 import React from "react";
 
 export type FleetManagerProps = {
-  onSubmit: (data: { name: string }) => void;
+  onSubmit: (data: { name: string; token: string }) => void;
 };
 
 type FleetManagerComponent = React.FC<FleetManagerProps> & {
   selectors: {
     form: string;
     nameInput: string;
+    tokenInput: string;
+    toggleTokenButton: string;
+    copyTokenButton: string;
   };
 };
 
 const FleetManager: FleetManagerComponent = ({ onSubmit }) => {
   const [name, setName] = React.useState("");
+  const [token, setToken] = React.useState("");
+  const [showToken, setShowToken] = React.useState(false);
+  const [copied, setCopied] = React.useState(false);
+
+  const canCopy = React.useMemo(
+    () => typeof navigator !== "undefined" && Boolean(navigator.clipboard),
+    [],
+  );
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    onSubmit({ name });
+    onSubmit({ name, token });
+  };
+
+  const handleCopy = async () => {
+    if (!canCopy || !token) return;
+    try {
+      await navigator.clipboard.writeText(token);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
   };
 
   return (
@@ -38,6 +60,40 @@ const FleetManager: FleetManagerComponent = ({ onSubmit }) => {
         onChange={(e) => setName(e.target.value)}
         required
       />
+      <label className="block text-sm font-medium" htmlFor="fleet-token">
+        Token
+      </label>
+      <div className="flex gap-2">
+        <input
+          id="fleet-token"
+          data-testid="fleet-token"
+          className="h-10 w-full rounded border px-3"
+          type={showToken ? "text" : "password"}
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          required
+        />
+        <button
+          type="button"
+          data-testid="fleet-toggle-token"
+          className="h-10 rounded border px-3"
+          onClick={() => setShowToken((prev) => !prev)}
+        >
+          {showToken ? "Скрыть" : "Показать"}
+        </button>
+        <button
+          type="button"
+          data-testid="fleet-copy-token"
+          className="h-10 rounded border px-3"
+          onClick={handleCopy}
+          disabled={!canCopy || !token}
+        >
+          Копировать
+        </button>
+      </div>
+      {copied && (
+        <span className="text-xs text-green-600">Токен скопирован</span>
+      )}
       <button type="submit" className="h-8 rounded bg-blue-600 px-3 text-white">
         Сохранить
       </button>
@@ -48,6 +104,9 @@ const FleetManager: FleetManagerComponent = ({ onSubmit }) => {
 FleetManager.selectors = {
   form: '[data-testid="fleet-form"]',
   nameInput: '[data-testid="fleet-name"]',
+  tokenInput: '[data-testid="fleet-token"]',
+  toggleTokenButton: '[data-testid="fleet-toggle-token"]',
+  copyTokenButton: '[data-testid="fleet-copy-token"]',
 };
 
 export default FleetManager;

--- a/apps/web/src/pages/Settings/CollectionForm.tsx
+++ b/apps/web/src/pages/Settings/CollectionForm.tsx
@@ -33,6 +33,29 @@ export default function CollectionForm({
 }: Props) {
   const [confirmDelete, setConfirmDelete] = React.useState(false);
   const [confirmSave, setConfirmSave] = React.useState(false);
+  const isTokenField = !renderValueField && valueLabel === "Token";
+  const [showToken, setShowToken] = React.useState(false);
+  const [copied, setCopied] = React.useState(false);
+  const canCopy = React.useMemo(
+    () => typeof navigator !== "undefined" && Boolean(navigator.clipboard),
+    [],
+  );
+
+  React.useEffect(() => {
+    if (!isTokenField) return;
+    setCopied(false);
+  }, [form.value, isTokenField]);
+
+  const handleCopy = async () => {
+    if (!isTokenField || !canCopy || !form.value) return;
+    try {
+      await navigator.clipboard.writeText(form.value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
+  };
 
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -54,6 +77,36 @@ export default function CollectionForm({
         <label className="block text-sm font-medium">{valueLabel}</label>
         {renderValueField ? (
           renderValueField(form, onChange)
+        ) : isTokenField ? (
+          <>
+            <div className="flex gap-2">
+              <input
+                className="h-10 w-full rounded border px-3"
+                type={showToken ? "text" : "password"}
+                value={form.value}
+                onChange={(e) => onChange({ ...form, value: e.target.value })}
+                required
+              />
+              <button
+                type="button"
+                className="h-10 rounded border px-3"
+                onClick={() => setShowToken((prev) => !prev)}
+              >
+                {showToken ? "Скрыть" : "Показать"}
+              </button>
+              <button
+                type="button"
+                className="h-10 rounded border px-3"
+                onClick={handleCopy}
+                disabled={!canCopy || !form.value}
+              >
+                Копировать
+              </button>
+            </div>
+            {copied && (
+              <span className="text-xs text-green-600">Токен скопирован</span>
+            )}
+          </>
         ) : (
           <input
             className="h-10 w-full rounded border px-3"

--- a/apps/web/src/pages/Settings/CollectionsPage.tsx
+++ b/apps/web/src/pages/Settings/CollectionsPage.tsx
@@ -433,7 +433,9 @@ export default function CollectionsPage() {
                 ? "Департамент"
                 : t.key === "positions"
                   ? "Отдел"
-                  : undefined;
+                  : t.key === "fleets"
+                    ? "Token"
+                    : undefined;
           const valueFieldRenderer =
             t.key === "departments"
               ? renderDepartmentValueField

--- a/packages/shared/collection-lib/index.ts
+++ b/packages/shared/collection-lib/index.ts
@@ -48,7 +48,7 @@ export function validateBaseItem(item: BaseItem): boolean {
 }
 
 export function validateFleet(fleet: Fleet): boolean {
-  return validateBaseItem(fleet);
+  return validateBaseItem(fleet) && Boolean(fleet.token);
 }
 
 export function validateDepartment(dept: Department): boolean {

--- a/packages/shared/collection-lib/types.ts
+++ b/packages/shared/collection-lib/types.ts
@@ -8,7 +8,9 @@ export interface BaseItem {
   name: string;
 }
 
-export interface Fleet extends BaseItem {}
+export interface Fleet extends BaseItem {
+  token: string;
+}
 
 export interface Department extends BaseItem {
   fleetId: string;

--- a/tests/api/collections.spec.ts
+++ b/tests/api/collections.spec.ts
@@ -45,10 +45,14 @@ app.delete('/employees/:id', (req, res) => {
 
 describe('API коллекций', () => {
   it('создаёт и читает флот', async () => {
-    const create = await request(app).post('/fleets').send({ id: 'f1', name: 'Флот' });
+    const create = await request(app)
+      .post('/fleets')
+      .send({ id: 'f1', name: 'Флот', token: 'секрет' });
     assert.equal(create.status, 201);
+    assert.equal(create.body.token, 'секрет');
     const read = await request(app).get('/fleets/f1');
     assert.equal(read.body.name, 'Флот');
+    assert.equal(read.body.token, 'секрет');
   });
 
   it('обновляет отдел', async () => {

--- a/tests/collection.spec.ts
+++ b/tests/collection.spec.ts
@@ -12,7 +12,7 @@ import {
 describe('Collection', () => {
   test('создаёт и читает элемент', () => {
     const fleets = new Collection<Fleet>();
-    const fleet = fleets.create({ id: '1', name: 'Флот-1' });
+    const fleet = fleets.create({ id: '1', name: 'Флот-1', token: 'секрет-1' });
     expect(fleets.read('1')).toEqual(fleet);
   });
 
@@ -32,8 +32,8 @@ describe('Collection', () => {
 
   test('выводит список элементов', () => {
     const fleets = new Collection<Fleet>();
-    fleets.create({ id: 'f1', name: 'Флот-1' });
-    fleets.create({ id: 'f2', name: 'Флот-2' });
+    fleets.create({ id: 'f1', name: 'Флот-1', token: 'секрет-1' });
+    fleets.create({ id: 'f2', name: 'Флот-2', token: 'секрет-2' });
     const list = fleets.list();
     expect(list).toHaveLength(2);
   });

--- a/tests/e2e/employees.spec.ts
+++ b/tests/e2e/employees.spec.ts
@@ -33,7 +33,7 @@ test.beforeAll(async () => {
     res.json(employees);
   });
 
-  const fleet = await Fleet.create({ name: 'Флот' });
+  const fleet = await Fleet.create({ name: 'Флот', token: 'секрет-флота' });
   const department = await Department.create({
     fleetId: fleet._id,
     name: 'Отдел',


### PR DESCRIPTION
## Summary
- require fleet documents to include a token and validate it throughout shared types and DTOs
- add masked token input with copy controls to the fleet settings form and component
- adjust web/API/e2e tests to cover the new fleet token contract

## Testing
- pnpm lint
- pnpm test:unit
- pnpm test:api
- pnpm test:e2e

------
https://chatgpt.com/codex/tasks/task_b_68caadcf6c8c8320bd8543761cc99728