### PR TITLE
feat: restrict fleet collections access

### DIFF
--- a/apps/api/tests/collectionsFleetAccess.test.ts
+++ b/apps/api/tests/collectionsFleetAccess.test.ts
@@ -1,0 +1,95 @@
+// Назначение: проверка доступа к чтению автопарка в коллекциях
+// Основные модули: jest, supertest, express, router collections
+process.env.NODE_ENV = 'test';
+process.env.BOT_TOKEN = 't';
+process.env.CHAT_ID = '1';
+process.env.JWT_SECRET = 's';
+process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
+process.env.APP_URL = 'https://localhost';
+
+import express, { type Request } from 'express';
+import request from 'supertest';
+import { stopScheduler } from '../src/services/scheduler';
+import { stopQueue } from '../src/services/messageQueue';
+
+jest.mock('../src/utils/rateLimiter', () => () => (_req, _res, next) => next());
+const roleState: { current: 'user' | 'manager' | 'admin' } = { current: 'user' };
+jest.mock('../src/middleware/auth', () => ({
+  __esModule: true,
+  default: () => (req, _res, next) => {
+    (req as Request & { user?: { id: number; role: string } }).user = {
+      id: 1,
+      role: roleState.current,
+    };
+    next();
+  },
+}));
+jest.mock('../src/middleware/requireRole', () => () => (_req, _res, next) => next());
+
+jest.mock('../src/db/repos/collectionRepo', () => ({
+  __esModule: true,
+  list: jest.fn(),
+}));
+
+const repo = require('../src/db/repos/collectionRepo') as {
+  list: jest.MockedFunction<typeof import('../src/db/repos/collectionRepo')['list']>;
+};
+const collectionsRouter = require('../src/routes/collections').default;
+
+describe('Доступ к автопарку в коллекциях', () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/collections', collectionsRouter);
+
+  afterAll(() => {
+    stopScheduler();
+    stopQueue();
+  });
+
+  beforeEach(() => {
+    roleState.current = 'user';
+    repo.list.mockReset();
+    repo.list.mockResolvedValue({
+      items: [
+        {
+          _id: 'fleet-1',
+          type: 'fleets',
+          name: 'Автопарк №1',
+          value: 'token-1',
+        },
+      ],
+      total: 1,
+    });
+  });
+
+  test('пользователь без прав получает 403 для списка автопарка', async () => {
+    const res = await request(app).get('/api/v1/collections?type=fleets');
+    expect(res.status).toBe(403);
+    expect(res.body.detail).toBe('Недостаточно прав для просмотра автопарка');
+    expect(repo.list).not.toHaveBeenCalled();
+  });
+
+  test('менеджер видит токены автопарка', async () => {
+    roleState.current = 'manager';
+    const res = await request(app).get('/api/v1/collections?type=fleets');
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].value).toBe('token-1');
+    expect(repo.list).toHaveBeenCalledTimes(1);
+    expect(repo.list.mock.calls[0][0]).toEqual({
+      type: 'fleets',
+      name: undefined,
+      value: undefined,
+      search: undefined,
+    });
+    expect(repo.list.mock.calls[0][1]).toBe(1);
+    expect(repo.list.mock.calls[0][2]).toBe(20);
+  });
+
+  test('администратор также получает полный ответ', async () => {
+    roleState.current = 'admin';
+    const res = await request(app).get('/api/v1/collections?type=fleets');
+    expect(res.status).toBe(200);
+    expect(res.body.items[0].value).toBe('token-1');
+  });
+});

--- a/apps/web/src/pages/Settings/CollectionsPage.test.tsx
+++ b/apps/web/src/pages/Settings/CollectionsPage.test.tsx
@@ -213,4 +213,28 @@ describe("CollectionsPage", () => {
     ) as HTMLInputElement;
     expect(activeSearch.value).toBe("");
   });
+
+  it("показывает сообщение об отсутствии доступа к автопарку", async () => {
+    mockedFetch.mockImplementation(async (type: string, search = "") => {
+      if (type === "fleets") {
+        throw new Error("Недостаточно прав для просмотра автопарка");
+      }
+      const byType = dataset[type] ?? {};
+      const key = search || "";
+      return byType[key] ?? byType[""] ?? { items: [], total: 0 };
+    });
+
+    render(<CollectionsPage />);
+
+    await screen.findByText("Главный департамент");
+
+    const fleetsTab = screen.getByRole("tab", { name: "Автопарк" });
+    fireEvent.click(fleetsTab);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Недостаточно прав для просмотра автопарка"),
+      ).not.toBeNull();
+    });
+  });
 });

--- a/apps/web/src/pages/Settings/CollectionsPage.tsx
+++ b/apps/web/src/pages/Settings/CollectionsPage.tsx
@@ -116,6 +116,8 @@ export default function CollectionsPage() {
         error instanceof Error
           ? error.message
           : "Не удалось загрузить элементы";
+      setItems([]);
+      setTotal(0);
       setHint(message);
     }
   }, [active, currentQuery, page]);

--- a/apps/web/src/services/collections.ts
+++ b/apps/web/src/services/collections.ts
@@ -27,7 +27,9 @@ const parseErrorMessage = (status: number, body: string) => {
     message =
       status === 429
         ? "Достигнут лимит запросов, попробуйте позже."
-        : "Не удалось загрузить элементы";
+        : status === 403
+          ? "Нет доступа к коллекции"
+          : "Не удалось загрузить элементы";
   }
   return message;
 };


### PR DESCRIPTION
## Что сделано
- ограничил выдачу коллекции `fleets` ролями admin/manager и вернул RFC-ответ 403 для остальных
- дополнил обработку 403 в web-сервисе и экранах настроек, очищая список элементов и показывая подсказку
- добавил unit-тест для React-экрана и API-тест, проверяющий доступ и видимость токенов

## Почему
- токены автопарка нельзя выдавать без расширенных прав, иначе их увидят пользователи без доступа

## Чек-лист
- [x] `pnpm lint`
- [ ] `pnpm test` (unit и api проходят; e2e падают без установленных браузеров — нужны `pnpm exec playwright install`)

## Логи
- `pnpm lint`
- `pnpm test`

## Самопроверка
- [x] Проверил, что новый 403 используется в обоих GET-маршрутах
- [x] Убедился, что фронтенд очищает список при ошибке
- [x] Убедился, что новые тесты падают без прав и проходят с admin/manager
- [ ] E2E не запускались повторно после фейла без браузеров

------
https://chatgpt.com/codex/tasks/task_b_68cac377551083209715767b79bd17c9