### PR TITLE
feat(web): compact task table layout

### DIFF
--- a/apps/web/src/columns/taskColumns.tsx
+++ b/apps/web/src/columns/taskColumns.tsx
@@ -33,18 +33,18 @@ export default function taskColumns(
     {
       header: "Номер",
       accessorKey: "task_number",
-      meta: { minWidth: "3.5rem", maxWidth: "5.5rem" },
+      meta: { minWidth: "3rem", maxWidth: "4.5rem" },
     },
     {
       header: "Дата создания",
       accessorKey: "createdAt",
-      meta: { minWidth: "8rem", maxWidth: "11rem" },
+      meta: { minWidth: "7rem", maxWidth: "9.5rem" },
       cell: (p) => formatDate(p.getValue<string>()),
     },
     {
       header: "Название",
       accessorKey: "title",
-      meta: { minWidth: "9rem", maxWidth: "18rem" },
+      meta: { minWidth: "8rem", maxWidth: "16rem" },
       cell: (p) => {
         const v = p.getValue<string>() || "";
         return <span title={v}>{v}</span>;
@@ -53,7 +53,7 @@ export default function taskColumns(
     {
       header: "Статус",
       accessorKey: "status",
-      meta: { minWidth: "5.5rem", maxWidth: "7.5rem" },
+      meta: { minWidth: "4.5rem", maxWidth: "6.5rem" },
       cell: (p) => {
         const value = p.getValue<string>() || "";
         return <span className={statusColorMap[value] || ""}>{value}</span>;
@@ -62,29 +62,29 @@ export default function taskColumns(
     {
       header: "Приоритет",
       accessorKey: "priority",
-      meta: { minWidth: "5.5rem", maxWidth: "7.5rem" },
+      meta: { minWidth: "4.5rem", maxWidth: "6.5rem" },
     },
     {
       header: "Начало",
       accessorKey: "start_date",
-      meta: { minWidth: "8rem", maxWidth: "11rem" },
+      meta: { minWidth: "7rem", maxWidth: "9.5rem" },
       cell: (p) => formatDate(p.getValue<string>()),
     },
     {
       header: "Срок",
       accessorKey: "due_date",
-      meta: { minWidth: "8rem", maxWidth: "11rem" },
+      meta: { minWidth: "7rem", maxWidth: "9.5rem" },
       cell: (p) => formatDate(p.getValue<string>()),
     },
     {
       header: "Тип",
       accessorKey: "task_type",
-      meta: { minWidth: "5.5rem", maxWidth: "7.5rem" },
+      meta: { minWidth: "4.5rem", maxWidth: "6.5rem" },
     },
     {
       header: "Старт",
       accessorKey: "start_location",
-      meta: { minWidth: "8rem", maxWidth: "12rem" },
+      meta: { minWidth: "7rem", maxWidth: "10rem" },
       cell: ({ row }) => {
         const name = row.original.start_location || "";
         const link = row.original.start_location_link;
@@ -106,7 +106,7 @@ export default function taskColumns(
     {
       header: "Финиш",
       accessorKey: "end_location",
-      meta: { minWidth: "8rem", maxWidth: "12rem" },
+      meta: { minWidth: "7rem", maxWidth: "10rem" },
       cell: ({ row }) => {
         const name = row.original.end_location || "";
         const link = row.original.end_location_link;
@@ -128,12 +128,12 @@ export default function taskColumns(
     {
       header: "Км",
       accessorKey: "route_distance_km",
-      meta: { minWidth: "3.5rem", maxWidth: "5rem" },
+      meta: { minWidth: "3rem", maxWidth: "4.5rem" },
     },
     {
       header: "Исполнители",
       accessorKey: "assignees",
-      meta: { minWidth: "8rem", maxWidth: "14rem" },
+      meta: { minWidth: "7rem", maxWidth: "12rem" },
       cell: ({ row }) => {
         const ids: number[] =
           row.original.assignees ||

--- a/apps/web/src/components/DataTable.tsx
+++ b/apps/web/src/components/DataTable.tsx
@@ -65,7 +65,7 @@ export default function DataTable<T>({
   });
 
   return (
-    <div className="space-y-1.5 font-ui text-[13px] sm:text-sm">
+    <div className="space-y-1 font-ui text-[13px] sm:text-sm">
       <TableToolbar table={table as TableType<T>}>
         {toolbarChildren}
       </TableToolbar>
@@ -129,17 +129,17 @@ export default function DataTable<T>({
           ))}
         </TableBody>
       </Table>
-      <div className="flex flex-col gap-2 text-xs sm:flex-row sm:items-center sm:justify-between sm:text-sm">
-        <div className="flex flex-wrap items-center gap-1.5">
+      <div className="flex flex-col gap-1.5 text-xs sm:flex-row sm:items-center sm:justify-between sm:text-sm">
+        <div className="flex flex-wrap items-center gap-1">
           <button
             onClick={() => onPageChange(Math.max(0, pageIndex - 1))}
             disabled={pageIndex === 0}
-            className="rounded border px-2 py-1 font-medium disabled:opacity-50"
+            className="rounded border px-1.5 py-1 font-medium disabled:opacity-50"
           >
             Назад
           </button>
-          <span>
-            Страница {pageIndex + 1}
+          <span className="px-1">
+            Стр. {pageIndex + 1}
             {pageCount ? ` / ${pageCount}` : ""}
           </span>
           <button
@@ -151,7 +151,7 @@ export default function DataTable<T>({
               )
             }
             disabled={pageCount ? pageIndex + 1 >= pageCount : false}
-            className="rounded border px-2 py-1 font-medium disabled:opacity-50"
+            className="rounded border px-1.5 py-1 font-medium disabled:opacity-50"
           >
             Вперёд
           </button>
@@ -160,7 +160,7 @@ export default function DataTable<T>({
           <select
             value={pageSize}
             onChange={(e) => onPageSizeChange(Number(e.target.value))}
-            className="h-8 min-w-[4.5rem] rounded border px-2 text-xs sm:text-sm"
+            className="h-8 min-w-[4rem] rounded border px-1.5 text-xs sm:text-sm"
           >
             {[10, 25, 50].map((s) => (
               <option key={s} value={s}>

--- a/apps/web/src/components/GlobalSearch.tsx
+++ b/apps/web/src/components/GlobalSearch.tsx
@@ -35,7 +35,7 @@ export default function GlobalSearch() {
   };
 
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-1.5">
       <div className="relative">
         <MagnifyingGlassIcon className="pointer-events-none absolute top-1/2 left-2 size-4 -translate-y-1/2 text-gray-400" />
         <Input
@@ -45,7 +45,7 @@ export default function GlobalSearch() {
           onKeyDown={onKey}
           placeholder={t("search")}
           aria-label={t("search")}
-          className="h-8 w-52 pr-8 pl-8"
+          className="h-8 w-48 pr-8 pl-8"
         />
         {value && (
           <button
@@ -57,7 +57,7 @@ export default function GlobalSearch() {
           </button>
         )}
       </div>
-      <button onClick={search} className="rounded border px-2 py-1">
+      <button onClick={search} className="rounded border px-1.5 py-1">
         {t("find")}
       </button>
     </div>

--- a/apps/web/src/components/SearchFilters.tsx
+++ b/apps/web/src/components/SearchFilters.tsx
@@ -22,11 +22,13 @@ export default function SearchFilters({ inline = false }: Props) {
   };
 
   const content = (
-    <div className="flex w-56 flex-col gap-2">
+    <div className="flex w-52 flex-col gap-1.5 text-sm">
       <div>
-        <span className="block text-sm font-medium">Статус</span>
+        <span className="block text-xs font-semibold uppercase tracking-wide text-gray-600">
+          Статус
+        </span>
         {TASK_STATUSES.map((s) => (
-          <label key={s} className="flex items-center gap-1">
+          <label key={s} className="flex items-center gap-1 text-[13px]">
             <input
               type="checkbox"
               checked={local.status.includes(s)}
@@ -37,9 +39,11 @@ export default function SearchFilters({ inline = false }: Props) {
         ))}
       </div>
       <div>
-        <span className="block text-sm font-medium">Приоритет</span>
+        <span className="block text-xs font-semibold uppercase tracking-wide text-gray-600">
+          Приоритет
+        </span>
         {PRIORITIES.map((p) => (
-          <label key={p} className="flex items-center gap-1">
+          <label key={p} className="flex items-center gap-1 text-[13px]">
             <input
               type="checkbox"
               checked={local.priority.includes(p)}
@@ -49,23 +53,23 @@ export default function SearchFilters({ inline = false }: Props) {
           </label>
         ))}
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1.5">
         <input
           type="date"
-          className="rounded border p-1"
+          className="rounded border px-1.5 py-1 text-[13px]"
           value={local.from}
           onChange={(e) => setLocal({ ...local, from: e.target.value })}
         />
         <input
           type="date"
-          className="rounded border p-1"
+          className="rounded border px-1.5 py-1 text-[13px]"
           value={local.to}
           onChange={(e) => setLocal({ ...local, to: e.target.value })}
         />
       </div>
       <button
         onClick={() => setFilters(local)}
-        className="mt-2 rounded border px-2 py-1"
+        className="mt-1.5 rounded border px-1.5 py-1 text-[13px]"
       >
         Искать
       </button>
@@ -76,10 +80,10 @@ export default function SearchFilters({ inline = false }: Props) {
 
   return (
     <details className="relative">
-      <summary className="cursor-pointer rounded border px-2 py-1 select-none">
+      <summary className="cursor-pointer rounded border px-1.5 py-0.5 select-none text-sm">
         Фильтры
       </summary>
-      <div className="absolute z-10 mt-1 rounded border bg-white p-2 shadow">
+      <div className="absolute z-10 mt-1 rounded border bg-white p-1.5 shadow">
         {content}
       </div>
     </details>

--- a/apps/web/src/components/TableToolbar.tsx
+++ b/apps/web/src/components/TableToolbar.tsx
@@ -65,42 +65,42 @@ export default function TableToolbar<T>({ table, children }: Props<T>) {
   };
 
   return (
-    <div className="flex w-full flex-wrap items-center gap-1.5 text-xs sm:text-sm">
-      <div className="flex flex-1 flex-wrap items-center gap-1.5">
+    <div className="flex w-full flex-wrap items-center gap-1 text-xs sm:text-sm">
+      <div className="flex flex-1 flex-wrap items-center gap-1">
         <GlobalSearch />
         {children}
       </div>
-      <div className="ml-auto flex w-full flex-wrap items-center gap-1.5 sm:w-auto sm:justify-end">
+      <div className="ml-auto flex w-full flex-wrap items-center gap-1 sm:w-auto sm:justify-end">
         <details className="relative">
-          <summary className="cursor-pointer rounded border px-2 py-1 text-xs font-medium select-none sm:text-sm">
+          <summary className="cursor-pointer rounded border px-1.5 py-1 text-xs font-medium select-none sm:text-sm">
             {t("export")}
           </summary>
-          <div className="absolute right-0 z-10 mt-1 w-32 rounded border bg-white p-1.5 shadow">
+          <div className="absolute right-0 z-10 mt-1 w-32 rounded border bg-white p-1 shadow">
             <button
               onClick={exportCsv}
-              className="block w-full rounded px-2 py-1 text-left text-xs font-medium hover:bg-gray-100 sm:text-sm"
+              className="block w-full rounded px-1.5 py-1 text-left text-xs font-medium hover:bg-gray-100 sm:text-sm"
             >
               CSV
             </button>
             <button
               onClick={() => void exportPdf()}
-              className="mt-1 block w-full rounded px-2 py-1 text-left text-xs font-medium hover:bg-gray-100 sm:text-sm"
+              className="mt-1 block w-full rounded px-1.5 py-1 text-left text-xs font-medium hover:bg-gray-100 sm:text-sm"
             >
               PDF
             </button>
           </div>
         </details>
         <details className="relative">
-          <summary className="cursor-pointer rounded border px-2 py-1 text-xs font-medium select-none sm:text-sm">
+          <summary className="cursor-pointer rounded border px-1.5 py-1 text-xs font-medium select-none sm:text-sm">
             {t("settings")}
           </summary>
-          <div className="absolute right-0 z-10 mt-1 w-64 space-y-1.5 rounded border bg-white p-2 shadow">
+          <div className="absolute right-0 z-10 mt-1 w-64 space-y-1 rounded border bg-white p-1.5 shadow">
             <SearchFilters inline />
-            <div className="border-t pt-1.5">
+            <div className="border-t pt-1">
               {columns.map((col) => (
                 <div
                   key={col.id}
-                  className="flex items-center justify-between gap-1.5"
+                  className="flex items-center justify-between gap-1"
                 >
                   <label className="flex items-center gap-1 text-xs font-medium sm:text-sm">
                     <input
@@ -113,13 +113,13 @@ export default function TableToolbar<T>({ table, children }: Props<T>) {
                   <div className="flex gap-1">
                     <button
                       onClick={() => moveColumn(col.id, -1)}
-                      className="rounded border px-1 text-xs font-medium"
+                      className="rounded border px-1 text-xs font-medium leading-none"
                     >
                       ←
                     </button>
                     <button
                       onClick={() => moveColumn(col.id, 1)}
-                      className="rounded border px-1 text-xs font-medium"
+                      className="rounded border px-1 text-xs font-medium leading-none"
                     >
                       →
                     </button>

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -15,8 +15,8 @@ function Table({ className, ...props }: React.ComponentProps<"table">) {
       <table
         data-slot="table"
         className={cn(
-          "w-full caption-bottom text-[13px] leading-tight text-gray-900 table-auto font-ui",
-          "sm:text-sm md:table-fixed",
+          "w-full caption-bottom text-[12px] leading-tight text-gray-900 table-auto font-ui",
+          "sm:text-[13px] md:table-fixed",
           className,
         )}
         {...props}
@@ -64,7 +64,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
       data-slot="table-row"
       className={cn(
         "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
-        "min-h-[2.25rem] text-[13px] sm:min-h-[2.5rem] sm:text-sm",
+        "min-h-[2rem] text-[12px] sm:min-h-[2.25rem] sm:text-sm",
         className,
       )}
       {...props}
@@ -77,8 +77,8 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "text-foreground px-2 py-2 text-left align-middle font-semibold",
-        "text-[11px] leading-snug sm:px-3 sm:text-[13px]",
+        "text-foreground px-1.5 py-1.5 text-left align-middle font-semibold",
+        "text-[11px] leading-snug sm:px-2.5 sm:text-[13px]",
         "whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
       )}
@@ -92,8 +92,8 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "px-2 py-2 align-top text-[13px] leading-snug",
-        "sm:px-3 sm:py-2.5 sm:text-sm",
+        "px-1.5 py-1.5 align-top text-[12px] leading-snug",
+        "sm:px-2.5 sm:py-2 sm:text-sm",
         "whitespace-normal [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
       )}

--- a/apps/web/src/types/leaflet.d.ts
+++ b/apps/web/src/types/leaflet.d.ts
@@ -1,0 +1,66 @@
+// Назначение: заглушка типов для Leaflet в веб-приложении
+// Модули: Leaflet
+
+declare module "leaflet" {
+  namespace L {
+    type LatLngExpression =
+      | [number, number]
+      | [number, number, number]
+      | { lat: number; lng: number; alt?: number };
+
+    class Map {
+      constructor(element: string | HTMLElement, options?: any);
+      addLayer(layer: any): this;
+      removeLayer(layer: any): this;
+      remove(): void;
+      setView(center: LatLngExpression, zoom: number): this;
+      on(event: string, handler: (...args: any[]) => void): this;
+    }
+
+    class LayerGroup {
+      constructor(layers?: any[]);
+      addTo(map: Map): LayerGroup;
+      addLayer(layer: any): LayerGroup;
+      clearLayers(): void;
+      remove(): void;
+    }
+
+    class TileLayer {
+      constructor(urlTemplate: string, options?: any);
+      addTo(map: Map): TileLayer;
+    }
+
+    class Marker {
+      constructor(latlng: LatLngExpression, options?: any);
+      addTo(target: Map | LayerGroup): Marker;
+      bindPopup(html: string): Marker;
+      bindTooltip(content: string, options?: any): Marker;
+      on(event: string, handler: (...args: any[]) => void): Marker;
+    }
+
+    class Polyline {
+      constructor(latlngs: LatLngExpression[] | LatLngExpression[][], options?: any);
+      addTo(target: Map | LayerGroup): Polyline;
+    }
+
+    class Icon {
+      constructor(options?: any);
+    }
+
+    function map(element: string | HTMLElement, options?: any): Map;
+    function tileLayer(urlTemplate: string, options?: any): TileLayer;
+    function layerGroup(layers?: any[]): LayerGroup;
+    function marker(latlng: LatLngExpression, options?: any): Marker;
+    function polyline(
+      latlngs: LatLngExpression[] | LatLngExpression[][],
+      options?: any,
+    ): Polyline;
+    function divIcon(options?: any): Icon;
+
+    namespace control {
+      function layers(...args: any[]): any;
+    }
+  }
+
+  export = L;
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -25,7 +25,8 @@
       "shared/*": ["../../packages/shared/src/*"]
     },
     "composite": true,
-    "types": ["vite/client", "./src/types/telegram"]
+    "types": ["vite/client", "./src/types/telegram", "./src/types/leaflet"],
+    "typeRoots": ["./src/types", "../../node_modules/@types"]
   },
   "include": ["src"],
   "references": [{ "path": "../../packages/shared" }]

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -19,9 +19,14 @@
       "express",
       "multer",
       "../apps/web/src/types/telegram",
+      "../apps/web/src/types/leaflet",
       "mongodb-memory-server",
       "mongoose"
     ],
-    "typeRoots": ["../node_modules/@types", "../apps/api/src/types"]
+    "typeRoots": [
+      "../node_modules/@types",
+      "../apps/api/src/types",
+      "../apps/web/src/types"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- tighten table scaffolding, toolbar controls, and search widgets to reduce wasted space in task lists
- shrink task column widths for denser data presentation while keeping readability
- add Leaflet type declarations and wire them into tsconfig to keep tests building cleanly

## Testing
- pnpm lint
- pnpm test


------
https://chatgpt.com/codex/tasks/task_b_68cb0c5ac4548320b72d5448f30fa3a2