### PR TITLE
feat: sync fleet collections with fleet model

### DIFF
--- a/apps/api/src/db/repos/collectionRepo.ts
+++ b/apps/api/src/db/repos/collectionRepo.ts
@@ -1,5 +1,6 @@
 // Назначение файла: репозиторий элементов коллекции
 // Основные модули: mongoose, модели CollectionItem
+import { Types } from 'mongoose';
 import {
   CollectionItem,
   CollectionItemDocument,
@@ -14,9 +15,18 @@ export interface CollectionFilters {
 }
 
 export async function create(
-  data: CollectionItemAttrs,
+  data: CollectionItemAttrs & { _id?: Types.ObjectId | string },
 ): Promise<CollectionItemDocument> {
-  return CollectionItem.create(data);
+  const payload: Record<string, unknown> = {
+    type: data.type,
+    name: data.name,
+    value: data.value,
+  };
+  if (data._id) {
+    payload._id =
+      typeof data._id === 'string' ? new Types.ObjectId(data._id) : data._id;
+  }
+  return CollectionItem.create(payload);
 }
 
 export async function list(

--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -1,6 +1,7 @@
 // Роуты коллекций: CRUD операции
 // Модули: express, middleware/auth, middleware/requireRole, middleware/sendProblem, repos/collectionRepo, express-validator
 import { Router, RequestHandler } from 'express';
+import { Types } from 'mongoose';
 import { param } from 'express-validator';
 import createRateLimiter from '../utils/rateLimiter';
 import authMiddleware from '../middleware/auth';
@@ -9,11 +10,17 @@ import * as repo from '../db/repos/collectionRepo';
 import {
   CollectionItem,
   CollectionItemAttrs,
+  type CollectionItemDocument,
 } from '../db/models/CollectionItem';
 import { Employee } from '../db/models/employee';
 import { Task } from '../db/model';
 import type RequestWithUser from '../types/request';
 import { sendProblem } from '../utils/problem';
+import { Fleet } from '../db/models/fleet';
+import { Vehicle } from '../db/models/vehicle';
+import { parseLocatorLink } from '../utils/wialonLocator';
+import { DEFAULT_BASE_URL } from '../services/wialon';
+import { syncFleetVehicles } from '../services/fleetVehicles';
 
 const router: Router = Router();
 const limiter = createRateLimiter({
@@ -70,8 +77,94 @@ router.get('/:type', ...base, async (req, res) => {
   res.json(items);
 });
 
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+async function createFleetAndCollectionItem(
+  body: CollectionItemAttrs,
+  req: RequestWithUser,
+  res: Parameters<typeof sendProblem>[1],
+): Promise<void> {
+  if (!isNonEmptyString(body.name) || !isNonEmptyString(body.value)) {
+    sendProblem(req, res, {
+      type: 'about:blank',
+      title: 'Некорректные данные автопарка',
+      status: 400,
+      detail: 'Название и ссылка автопарка обязательны',
+    });
+    return;
+  }
+  let locator;
+  try {
+    locator = parseLocatorLink(body.value, DEFAULT_BASE_URL);
+  } catch (error) {
+    sendProblem(req, res, {
+      type: 'about:blank',
+      title: 'Некорректная ссылка Wialon',
+      status: 400,
+      detail:
+        error instanceof Error
+          ? error.message
+          : 'Не удалось разобрать ссылку автопарка',
+    });
+    return;
+  }
+  const id = new Types.ObjectId();
+  try {
+    const fleet = await Fleet.create({
+      _id: id,
+      name: body.name,
+      token: locator.token,
+      locatorUrl: locator.locatorUrl,
+      baseUrl: locator.baseUrl,
+      locatorKey: locator.locatorKey,
+    });
+    try {
+      await syncFleetVehicles(fleet);
+    } catch (error) {
+      console.error(
+        `Не удалось синхронизировать транспорт автопарка ${fleet._id}:`,
+        error,
+      );
+      await Vehicle.deleteMany({ fleetId: fleet._id });
+      await Fleet.findByIdAndDelete(fleet._id);
+      sendProblem(req, res, {
+        type: 'about:blank',
+        title: 'Синхронизация автопарка не выполнена',
+        status: 502,
+        detail: 'Не удалось синхронизировать транспорт автопарка',
+      });
+      return;
+    }
+    const item = await repo.create({
+      _id: id,
+      type: 'fleets',
+      name: body.name,
+      value: body.value,
+    });
+    res.status(201).json(item);
+  } catch (error) {
+    console.error('Ошибка создания автопарка из коллекции:', error);
+    await Fleet.findByIdAndDelete(id).catch(() => undefined);
+    await Vehicle.deleteMany({ fleetId: id }).catch(() => undefined);
+    sendProblem(req, res, {
+      type: 'about:blank',
+      title: 'Не удалось создать автопарк',
+      status: 500,
+      detail:
+        error instanceof Error ? error.message : 'Неизвестная ошибка сервера',
+    });
+  }
+}
+
 router.post('/', ...base, requireRole('admin'), async (req, res) => {
-  const item = await repo.create(req.body as CollectionItemAttrs);
+  const body = req.body as CollectionItemAttrs;
+  if (body.type === 'fleets') {
+    await createFleetAndCollectionItem(body, req as RequestWithUser, res);
+    return;
+  }
+  const item = await repo.create(body);
   res.status(201).json(item);
 });
 
@@ -81,15 +174,106 @@ router.put(
   requireRole('admin'),
   param('id').isMongoId(),
   async (req, res) => {
-    const item = await repo.update(
-      req.params.id,
-      req.body as Partial<CollectionItemAttrs>,
-    );
-    if (!item) {
+    const { id } = req.params;
+    const current = (await CollectionItem.findById(id)) as
+      | (CollectionItemDocument & { save: () => Promise<CollectionItemDocument> })
+      | null;
+    if (!current) {
       res.sendStatus(404);
       return;
     }
-    res.json(item);
+    if (current.type !== 'fleets') {
+      const item = await repo.update(
+        req.params.id,
+        req.body as Partial<CollectionItemAttrs>,
+      );
+      if (!item) {
+        res.sendStatus(404);
+        return;
+      }
+      res.json(item);
+      return;
+    }
+
+    const body = req.body as Partial<CollectionItemAttrs>;
+    const nextName = isNonEmptyString(body.name) ? body.name.trim() : current.name;
+    const hasValueUpdate = isNonEmptyString(body.value);
+    let locator;
+    if (hasValueUpdate) {
+      try {
+        locator = parseLocatorLink(body.value as string, DEFAULT_BASE_URL);
+      } catch (error) {
+        sendProblem(req as RequestWithUser, res, {
+          type: 'about:blank',
+          title: 'Некорректная ссылка Wialon',
+          status: 400,
+          detail:
+            error instanceof Error
+              ? error.message
+              : 'Не удалось разобрать ссылку автопарка',
+        });
+        return;
+      }
+    }
+
+    let fleet = await Fleet.findById(id);
+    if (!fleet) {
+      const valueForCreation = hasValueUpdate ? (body.value as string) : current.value;
+      try {
+        const data = locator ?? parseLocatorLink(valueForCreation, DEFAULT_BASE_URL);
+        fleet = await Fleet.create({
+          _id: current._id,
+          name: nextName,
+          token: data.token,
+          locatorUrl: data.locatorUrl,
+          baseUrl: data.baseUrl,
+          locatorKey: data.locatorKey,
+        });
+      } catch (error) {
+        sendProblem(req as RequestWithUser, res, {
+          type: 'about:blank',
+          title: 'Не удалось обновить автопарк',
+          status: 400,
+          detail:
+            error instanceof Error
+              ? error.message
+              : 'Ошибка при создании автопарка',
+        });
+        return;
+      }
+    } else {
+      fleet.name = nextName;
+      if (locator) {
+        fleet.token = locator.token;
+        fleet.locatorUrl = locator.locatorUrl;
+        fleet.baseUrl = locator.baseUrl;
+        fleet.locatorKey = locator.locatorKey;
+      }
+      await fleet.save();
+    }
+
+    try {
+      await syncFleetVehicles(fleet);
+    } catch (error) {
+      console.error(
+        `Не удалось синхронизировать транспорт автопарка ${fleet._id}:`,
+        error,
+      );
+      sendProblem(req as RequestWithUser, res, {
+        type: 'about:blank',
+        title: 'Синхронизация автопарка не выполнена',
+        status: 502,
+        detail: 'Не удалось синхронизировать транспорт автопарка',
+      });
+      return;
+    }
+
+    current.name = nextName;
+    if (hasValueUpdate && body.value) {
+      current.value = body.value;
+    }
+    const saved = await current.save();
+    res.json(saved);
   },
 );
 
@@ -102,6 +286,13 @@ router.delete(
     const item = await CollectionItem.findById(req.params.id);
     if (!item) {
       res.sendStatus(404);
+      return;
+    }
+    if (item.type === 'fleets') {
+      await Vehicle.deleteMany({ fleetId: item._id });
+      await Fleet.findByIdAndDelete(item._id);
+      await item.deleteOne();
+      res.json({ status: 'ok' });
       return;
     }
     if (item.type === 'departments') {

--- a/apps/api/tests/collectionsFleetFlow.test.ts
+++ b/apps/api/tests/collectionsFleetFlow.test.ts
@@ -1,0 +1,122 @@
+// Назначение: интеграционный сценарий create→sync→load для автопарка
+// Основные модули: express, supertest, mongodb-memory-server, mongoose
+process.env.NODE_ENV = 'test';
+process.env.BOT_TOKEN = 't';
+process.env.CHAT_ID = '1';
+process.env.JWT_SECRET = 's';
+process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
+process.env.APP_URL = 'https://localhost';
+
+import express from 'express';
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+
+jest.mock('../src/utils/rateLimiter', () => () => (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
+  next(),
+);
+jest.mock('../src/middleware/auth', () => ({
+  __esModule: true,
+  default: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}));
+jest.mock('../src/auth/roles.guard', () => ({
+  __esModule: true,
+  default: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}));
+jest.mock('../src/auth/roles.decorator', () => ({
+  __esModule: true,
+  Roles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}));
+
+jest.mock('../src/services/wialon', () => {
+  const actual = jest.requireActual('../src/services/wialon');
+  return {
+    __esModule: true,
+    DEFAULT_BASE_URL: 'https://hst-api.wialon.com',
+    decodeLocatorKey: actual.decodeLocatorKey,
+    login: jest.fn(),
+    loadUnits: jest.fn(),
+    loadTrack: jest.fn(),
+  };
+});
+
+const { login, loadUnits } = require('../src/services/wialon') as {
+  login: jest.MockedFunction<
+    (typeof import('../src/services/wialon'))['login']
+  >;
+  loadUnits: jest.MockedFunction<
+    (typeof import('../src/services/wialon'))['loadUnits']
+  >;
+};
+
+const { Fleet } = require('../src/db/models/fleet');
+const { Vehicle } = require('../src/db/models/vehicle');
+
+describe('Интеграция коллекций и флотов', () => {
+  let mongod: MongoMemoryServer;
+  let app: express.Express;
+
+  beforeAll(async () => {
+    mongod = await MongoMemoryServer.create();
+    await mongoose.connect(mongod.getUri());
+    app = express();
+    app.use(express.json());
+    const collectionsRouter = require('../src/routes/collections').default;
+    const fleetsRouter = require('../src/routes/fleets').default;
+    app.use('/api/v1/collections', collectionsRouter);
+    app.use('/api/v1/fleets', fleetsRouter);
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    if (mongod) {
+      await mongod.stop();
+    }
+  });
+
+  beforeEach(async () => {
+    await Fleet.deleteMany({});
+    await Vehicle.deleteMany({});
+    login.mockReset();
+    loadUnits.mockReset();
+  });
+
+  test('создаёт автопарк и позволяет получить транспорт', async () => {
+    const locatorKey = Buffer.from('test-token', 'utf8').toString('base64');
+    login.mockResolvedValue({ sid: 'sid', eid: 'eid', user: { id: 1 } });
+    loadUnits.mockResolvedValue([
+      {
+        id: 101,
+        name: 'Трактор',
+        sensors: [],
+        customSensors: [],
+        position: { lat: 55, lon: 37, speed: 10, course: 90, updatedAt: new Date() },
+      },
+    ]);
+
+    const createRes = await request(app)
+      .post('/api/v1/collections')
+      .send({
+        type: 'fleets',
+        name: 'Интеграционный автопарк',
+        value: `https://hosting.wialon.com/locator?t=${locatorKey}`,
+      })
+      .expect(201);
+
+    const id = createRes.body._id as string;
+    expect(id).toBeDefined();
+    const fleetDoc = await Fleet.findById(id);
+    expect(fleetDoc).not.toBeNull();
+    expect(login).toHaveBeenCalledWith('test-token', 'https://hst-api.wialon.com');
+    const vehicles = await Vehicle.find({ fleetId: fleetDoc!._id });
+    expect(vehicles).toHaveLength(1);
+    expect(vehicles[0].unitId).toBe(101);
+
+    const vehiclesRes = await request(app)
+      .get(`/api/v1/fleets/${id}/vehicles`)
+      .expect(200);
+
+    expect(vehiclesRes.body.vehicles).toHaveLength(1);
+    expect(vehiclesRes.body.vehicles[0]).toMatchObject({ unitId: 101, name: 'Трактор' });
+  });
+});

--- a/apps/api/tests/collectionsFleetsRoute.test.ts
+++ b/apps/api/tests/collectionsFleetsRoute.test.ts
@@ -1,0 +1,212 @@
+// Назначение: unit-тесты спецлогики автопарка в роуте коллекций
+// Основные модули: jest, supertest, express, router collections
+process.env.NODE_ENV = 'test';
+process.env.BOT_TOKEN = 't';
+process.env.CHAT_ID = '1';
+process.env.JWT_SECRET = 's';
+process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
+process.env.APP_URL = 'https://localhost';
+
+import express from 'express';
+import request from 'supertest';
+
+jest.mock('../src/utils/rateLimiter', () => () => (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
+  next(),
+);
+jest.mock('../src/middleware/auth', () => ({
+  __esModule: true,
+  default: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}));
+jest.mock('../src/middleware/requireRole', () => ({
+  __esModule: true,
+  default: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}));
+jest.mock('../src/db/repos/collectionRepo', () => ({
+  __esModule: true,
+  create: jest.fn(),
+  update: jest.fn(),
+}));
+jest.mock('../src/db/models/CollectionItem', () => ({
+  __esModule: true,
+  CollectionItem: {
+    findById: jest.fn(),
+  },
+}));
+jest.mock('../src/db/models/fleet', () => ({
+  __esModule: true,
+  Fleet: {
+    create: jest.fn(),
+    findById: jest.fn(),
+    findByIdAndDelete: jest.fn(),
+  },
+}));
+jest.mock('../src/db/models/vehicle', () => ({
+  __esModule: true,
+  Vehicle: {
+    deleteMany: jest.fn(),
+  },
+}));
+jest.mock('../src/utils/wialonLocator', () => ({
+  __esModule: true,
+  parseLocatorLink: jest.fn(),
+}));
+jest.mock('../src/services/fleetVehicles', () => ({
+  __esModule: true,
+  syncFleetVehicles: jest.fn(),
+}));
+
+const repo = require('../src/db/repos/collectionRepo') as {
+  create: jest.Mock;
+  update: jest.Mock;
+};
+const collectionModel = require('../src/db/models/CollectionItem') as {
+  CollectionItem: { findById: jest.Mock };
+};
+const fleetModel = require('../src/db/models/fleet') as {
+  Fleet: {
+    create: jest.Mock;
+    findById: jest.Mock;
+    findByIdAndDelete: jest.Mock;
+  };
+};
+const vehicleModel = require('../src/db/models/vehicle') as {
+  Vehicle: { deleteMany: jest.Mock };
+};
+const locatorUtil = require('../src/utils/wialonLocator') as {
+  parseLocatorLink: jest.Mock;
+};
+const syncService = require('../src/services/fleetVehicles') as {
+  syncFleetVehicles: jest.Mock;
+};
+
+describe('Маршруты коллекций для автопарка', () => {
+  const app = express();
+  app.use(express.json());
+
+  const collectionsRouter = require('../src/routes/collections').default;
+  app.use('/api/v1/collections', collectionsRouter);
+
+  beforeEach(() => {
+    repo.create.mockReset();
+    repo.update.mockReset();
+    collectionModel.CollectionItem.findById.mockReset();
+    fleetModel.Fleet.create.mockReset();
+    fleetModel.Fleet.findById.mockReset();
+    fleetModel.Fleet.findByIdAndDelete.mockReset();
+    vehicleModel.Vehicle.deleteMany.mockReset();
+    locatorUtil.parseLocatorLink.mockReset();
+    syncService.syncFleetVehicles.mockReset();
+  });
+
+  test('создаёт автопарк и элемент коллекции при POST', async () => {
+    locatorUtil.parseLocatorLink.mockReturnValue({
+      token: 'token',
+      locatorUrl: 'https://host/locator',
+      baseUrl: 'https://hst-api.wialon.com',
+      locatorKey: 'b64',
+    });
+    syncService.syncFleetVehicles.mockResolvedValue(undefined);
+    fleetModel.Fleet.create.mockImplementation(async (data: Record<string, unknown>) => ({
+      ...data,
+      _id: data._id,
+    }));
+    repo.create.mockImplementation(async (data: Record<string, unknown>) => ({
+      _id: String(data._id),
+      type: data.type,
+      name: data.name,
+      value: data.value,
+    }));
+
+    const res = await request(app)
+      .post('/api/v1/collections')
+      .send({ type: 'fleets', name: 'Автопарк', value: 'https://host/locator?t=abcd' });
+
+    expect(res.status).toBe(201);
+    expect(locatorUtil.parseLocatorLink).toHaveBeenCalledWith(
+      'https://host/locator?t=abcd',
+      expect.any(String),
+    );
+    expect(fleetModel.Fleet.create).toHaveBeenCalledTimes(1);
+    const createdId = fleetModel.Fleet.create.mock.calls[0][0]._id;
+    expect(repo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _id: createdId,
+        type: 'fleets',
+        name: 'Автопарк',
+        value: 'https://host/locator?t=abcd',
+      }),
+    );
+    expect(syncService.syncFleetVehicles).toHaveBeenCalledTimes(1);
+    expect(res.body).toMatchObject({ name: 'Автопарк', value: 'https://host/locator?t=abcd' });
+  });
+
+  test('обновляет существующий автопарк и синхронизирует транспорт', async () => {
+    collectionModel.CollectionItem.findById.mockResolvedValue({
+      _id: '507f1f77bcf86cd799439011',
+      type: 'fleets',
+      name: 'Старый',
+      value: 'https://host/locator?t=old',
+      save: jest.fn().mockResolvedValue({
+        _id: '507f1f77bcf86cd799439011',
+        type: 'fleets',
+        name: 'Новый',
+        value: 'https://host/locator?t=new',
+      }),
+    });
+    locatorUtil.parseLocatorLink.mockReturnValue({
+      token: 'new-token',
+      locatorUrl: 'https://host/locator?t=new',
+      baseUrl: 'https://hst-api.wialon.com',
+      locatorKey: 'bmV3',
+    });
+    const saveMock = jest.fn().mockResolvedValue(undefined);
+    fleetModel.Fleet.findById.mockResolvedValue({
+      _id: '507f1f77bcf86cd799439011',
+      name: 'Старый',
+      token: 'token',
+      locatorUrl: 'https://host/locator?t=old',
+      baseUrl: 'https://hst-api.wialon.com',
+      locatorKey: 'b2xk',
+      save: saveMock,
+    });
+    syncService.syncFleetVehicles.mockResolvedValue(undefined);
+
+    const res = await request(app)
+      .put('/api/v1/collections/507f1f77bcf86cd799439011')
+      .send({ name: 'Новый', value: 'https://host/locator?t=new' });
+
+    expect(res.status).toBe(200);
+    expect(locatorUtil.parseLocatorLink).toHaveBeenCalledWith(
+      'https://host/locator?t=new',
+      expect.any(String),
+    );
+    expect(saveMock).toHaveBeenCalledTimes(1);
+    expect(syncService.syncFleetVehicles).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Новый' }),
+    );
+    expect(repo.update).not.toHaveBeenCalled();
+    expect(res.body).toMatchObject({ name: 'Новый', value: 'https://host/locator?t=new' });
+  });
+
+  test('удаляет автопарк и связанные записи', async () => {
+    const deleteOne = jest.fn().mockResolvedValue({});
+    collectionModel.CollectionItem.findById.mockResolvedValue({
+      _id: '507f1f77bcf86cd799439011',
+      type: 'fleets',
+      deleteOne,
+    });
+    vehicleModel.Vehicle.deleteMany.mockResolvedValue({});
+    fleetModel.Fleet.findByIdAndDelete.mockResolvedValue({});
+
+    const res = await request(app).delete('/api/v1/collections/507f1f77bcf86cd799439011');
+
+    expect(res.status).toBe(200);
+    expect(vehicleModel.Vehicle.deleteMany).toHaveBeenCalledWith({
+      fleetId: '507f1f77bcf86cd799439011',
+    });
+    expect(fleetModel.Fleet.findByIdAndDelete).toHaveBeenCalledWith(
+      '507f1f77bcf86cd799439011',
+    );
+    expect(deleteOne).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/pages/Settings/CollectionsPage.tsx
+++ b/apps/web/src/pages/Settings/CollectionsPage.tsx
@@ -300,6 +300,9 @@ export default function CollectionsPage() {
       valueToSave = form.value.trim();
     }
     try {
+      if (active === "fleets") {
+        setHint("Синхронизация автопарка...");
+      }
       let saved: CollectionItem | null = null;
       if (form._id) {
         saved = await updateCollectionItem(form._id, {
@@ -312,15 +315,28 @@ export default function CollectionsPage() {
           value: valueToSave,
         });
       }
-      setHint("");
-      if (active === "fleets" && saved) {
+      if (!saved) {
+        throw new Error("Сервер не вернул сохранённый элемент");
+      }
+      if (active === "fleets") {
+        setItems((prev) => {
+          const index = prev.findIndex((item) => item._id === saved._id);
+          if (index >= 0) {
+            const updated = [...prev];
+            updated[index] = saved;
+            return updated;
+          }
+          return [saved, ...prev];
+        });
         setSelectedFleetId(saved._id);
         setForm({ _id: saved._id, name: saved.name, value: saved.value });
+        setHint("");
       } else {
         setForm({ name: "", value: "" });
+        setHint("");
       }
       await load();
-      if (active === "fleets" && saved) {
+      if (active === "fleets") {
         await loadFleetVehicles(saved._id);
       }
     } catch (error) {


### PR DESCRIPTION
## Что сделано
- синхронизировал POST/PUT/DELETE коллекции `fleets` с моделью Fleet и принудительной синхронизацией транспорта
- разрешил репозиторию коллекций создавать записи с заранее заданным идентификатором
- улучшил UI сохранения автопарка и обновил/расширил покрытие тестами

## Почему
- без зеркальной записи Fleet новые автопарки нельзя загрузить ни из UI, ни из фоновых джоб

## Проверки
- `pnpm lint`
- `pnpm test:unit`
- `pnpm test:api`
- `pnpm build`

## Самопроверка
- [x] Требования задачи выполнены
- [x] Локально проходят линтеры и тесты
- [x] Нет лишних артефактов сборки в коммите
- [x] UI уведомляет пользователя о долгих операциях сохранения


------
https://chatgpt.com/codex/tasks/task_b_68cba6901bf4832095c9d04cbcdf3db9