### PR TITLE
feat: корректный URL коллекции департаментов

### DIFF
--- a/apps/web/src/components/TaskDialog.test.tsx
+++ b/apps/web/src/components/TaskDialog.test.tsx
@@ -43,7 +43,7 @@ const taskData = {
 };
 
 const authFetchMock = jest.fn((url: string) => {
-  if (url === "/api/collections/departments") {
+  if (url === "/api/v1/collections/departments") {
     return Promise.resolve({ ok: true, json: async () => [] });
   }
   if (url === "/api/v1/users") {

--- a/apps/web/src/components/TaskDialog.tsx
+++ b/apps/web/src/components/TaskDialog.tsx
@@ -306,7 +306,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
   };
 
   React.useEffect(() => {
-    authFetch("/api/collections/departments")
+    authFetch("/api/v1/collections/departments")
       .then((r) => (r.ok ? r.json() : []))
       .then((d) => setDepartments(d));
   }, []);


### PR DESCRIPTION
## Что сделано
- Исправил обращение TaskDialog к `/api/v1/collections/departments`, чтобы фронтенд использовал актуальный API-префикс.
- Обновил unit-тест TaskDialog для нового URL и убедился, что моки покрывают корректный путь.

## Почему
- Интерфейс загружал департаменты по устаревшему адресу `/api/collections/departments`, из-за чего получал 404 и показывал ошибки на страницах задач и маршрутов.

## Чек-лист
- [x] `./scripts/setup_and_test.sh`
- [x] Линтер/типизация (в рамках скрипта)

## Логи
- `./scripts/setup_and_test.sh`
  - Warning: Locust не установлен, стресс-тест пропущен.

## Самопроверка
1. Все обращения к списку департаментов используют единый API-префикс `v1`.
2. Тесты TaskDialog воспроизводят тот же URL, что и реальный код.
3. Скрипт предварительной проверки проходит до конца (за исключением пропуска Locust).


------
https://chatgpt.com/codex/tasks/task_b_68cbd9b52618832086122a292173964c