### PR TITLE
fix: apply CSP nonce to styles and ensure fonts

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "sideEffects": false,
   "scripts": {
+    "predev": "node ../../scripts/ensure-fonts.mjs",
+    "prebuild": "node ../../scripts/ensure-fonts.mjs",
     "dev": "vite",
     "build": "vite build",
     "lint": "node -r ./node_modules/ts-node/register ./node_modules/eslint/bin/eslint.js .",

--- a/apps/web/src/utils/ensureWebpackNonce.ts
+++ b/apps/web/src/utils/ensureWebpackNonce.ts
@@ -4,19 +4,56 @@
 declare global {
   interface Window {
     __webpack_nonce__?: string;
+    __styleNonceObserver__?: MutationObserver;
   }
 }
 
 const INLINE_SCRIPT_SELECTOR = 'script[data-webpack-nonce]';
+const STYLE_SELECTOR = 'style';
+
+function applyNonceToStyle(style: HTMLStyleElement, nonce: string): void {
+  if (!style.nonce) {
+    style.setAttribute('nonce', nonce);
+  }
+}
+
+function observeStyleNonce(nonce: string): void {
+  if (window.__styleNonceObserver__) return;
+  const observer = new MutationObserver((records) => {
+    for (const record of records) {
+      record.addedNodes.forEach((node) => {
+        if (node instanceof HTMLStyleElement) {
+          applyNonceToStyle(node, nonce);
+        } else if (node instanceof Element) {
+          node
+            .querySelectorAll<HTMLStyleElement>(STYLE_SELECTOR)
+            .forEach((style) => applyNonceToStyle(style, nonce));
+        }
+      });
+    }
+  });
+  observer.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+  window.__styleNonceObserver__ = observer;
+}
 
 export function ensureWebpackNonce(): void {
   if (typeof window === 'undefined') return;
-  if (window.__webpack_nonce__) return;
+  if (window.__webpack_nonce__) {
+    observeStyleNonce(window.__webpack_nonce__);
+    return;
+  }
   const script = document.querySelector<HTMLScriptElement>(
     INLINE_SCRIPT_SELECTOR,
   );
   const nonce = script?.nonce;
   if (nonce) {
     window.__webpack_nonce__ = nonce;
+    document
+      .querySelectorAll<HTMLStyleElement>(STYLE_SELECTOR)
+      .forEach((style) => applyNonceToStyle(style, nonce));
+    observeStyleNonce(nonce);
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "description": "Вспомогательные зависимости для запуска ESLint и тестов.",
   "scripts": {
-    "prebuild": "node scripts/generate_hero_images.mjs",
+    "predev": "node scripts/ensure-fonts.mjs",
+    "prebuild": "node scripts/ensure-fonts.mjs && node scripts/generate_hero_images.mjs",
     "pretest": "pnpm --filter shared build",
     "pretest:unit": "pnpm --filter shared build",
     "pretest:api": "pnpm --filter shared build",

--- a/scripts/ensure-fonts.mjs
+++ b/scripts/ensure-fonts.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// Назначение файла: проверяет наличие локальных шрифтов и скачивает недостающие.
+// Основные модули: fs/promises, path, url, fetch
+import { access, mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const fontsDir = path.join(__dirname, '../apps/web/public/fonts');
+
+const fonts = [
+  {
+    file: 'inter-400.ttf',
+    url: 'https://fonts.gstatic.com/s/inter/v19/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfMZg.ttf',
+  },
+  {
+    file: 'inter-700.ttf',
+    url: 'https://fonts.gstatic.com/s/inter/v19/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuFuYMZg.ttf',
+  },
+  {
+    file: 'poppins-400.ttf',
+    url: 'https://fonts.gstatic.com/s/poppins/v23/pxiEyp8kv8JHgFVrFJA.ttf',
+  },
+  {
+    file: 'poppins-700.ttf',
+    url: 'https://fonts.gstatic.com/s/poppins/v23/pxiByp8kv8JHgFVrLCz7V1s.ttf',
+  },
+  {
+    file: 'roboto-400.ttf',
+    url: 'https://fonts.gstatic.com/s/roboto/v48/KFOMCnqEu92Fr1ME7kSn66aGLdTylUAMQXC89YmC2DPNWubEbWmT.ttf',
+  },
+  {
+    file: 'roboto-700.ttf',
+    url: 'https://fonts.gstatic.com/s/roboto/v48/KFOMCnqEu92Fr1ME7kSn66aGLdTylUAMQXC89YmC2DPNWuYjammT.ttf',
+  },
+];
+
+async function fileExists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function downloadFont({ file, url }) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Не удалось скачать ${file}: ${response.status} ${response.statusText}`);
+  }
+  const buffer = Buffer.from(await response.arrayBuffer());
+  await writeFile(path.join(fontsDir, file), buffer);
+}
+
+async function ensureFonts() {
+  await mkdir(fontsDir, { recursive: true });
+  let downloaded = 0;
+  for (const font of fonts) {
+    const target = path.join(fontsDir, font.file);
+    if (await fileExists(target)) {
+      continue;
+    }
+    await downloadFont(font);
+    downloaded += 1;
+  }
+  if (downloaded > 0) {
+    console.log(`Скачано шрифтов: ${downloaded}`);
+  }
+}
+
+ensureFonts().catch((error) => {
+  console.error('Ошибка загрузки шрифтов:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Что сделано
- Добавил установку nonce для существующих и динамически создаваемых `<style>` через наблюдатель, чтобы CSP не блокировал CSS.
- Создал скрипт `scripts/ensure-fonts.mjs` и подключил его к `predev`/`prebuild` в корне и `apps/web`, чтобы перед сборкой автоматически подтягивать локальные шрифты.

## Почему
- CSP блокировал инлайновые стили без nonce, из-за чего ломалась работа CKEditor и других библиотек.
- На проде отсутствовали `.ttf`-файлы, поэтому запросы `/fonts/*.ttf` возвращали 404.

## Чек-лист
- [x] `pnpm lint`
- [x] `pnpm test:unit`
- [x] `pnpm test:api`
- [ ] `pnpm test:e2e` (в контейнере нет Playwright-браузеров)
- [x] `pnpm build`

## Логи ключевых команд
- `pnpm lint`
- `pnpm test` (unit+api пройдены, e2e упали из-за отсутствующих браузеров)

## Самопроверка
- Убедился, что наблюдатель за стилями создаётся один раз и не течёт в память.
- Проверил, что nonce назначается и уже существующим стилям.
- Скрипт подкачки шрифтов идемпотентен и запускается только при необходимости.
- При сборке шрифты появляются в `apps/web/public/fonts` до запуска Vite.
- Логика не ломает существующие `package.json`-скрипты.

------
https://chatgpt.com/codex/tasks/task_b_68cbedbd763c832091bc2afe3ea25299