### PR TITLE
fix: корректные типы документов флотов

### DIFF
--- a/apps/api/src/db/models/CollectionItem.ts
+++ b/apps/api/src/db/models/CollectionItem.ts
@@ -1,6 +1,6 @@
 // Назначение файла: модель универсальной коллекции
 // Основные модули: mongoose
-import { Schema, model, Document } from 'mongoose';
+import { Schema, model, Document, Types } from 'mongoose';
 
 export interface CollectionItemAttrs {
   type: string;
@@ -8,7 +8,13 @@ export interface CollectionItemAttrs {
   value: string;
 }
 
-export interface CollectionItemDocument extends CollectionItemAttrs, Document {}
+export interface CollectionItemDocument
+  extends Document<
+      Types.ObjectId,
+      Record<string, never>,
+      CollectionItemAttrs
+    >,
+    CollectionItemAttrs {}
 
 const collectionItemSchema = new Schema<CollectionItemDocument>({
   type: { type: String, required: true },

--- a/apps/api/src/db/models/fleet.ts
+++ b/apps/api/src/db/models/fleet.ts
@@ -1,11 +1,8 @@
 // Назначение файла: модель коллекции флотов
 // Основные модули: mongoose
-import { Schema, model, Document, Types } from 'mongoose';
-import {
-  DEFAULT_BASE_URL,
-  decodeLocatorKey,
-  parseLocatorLink,
-} from '../../services/wialon';
+import { Schema, model, Types, type HydratedDocument } from 'mongoose';
+import { DEFAULT_BASE_URL, decodeLocatorKey } from '../../services/wialon';
+import { parseLocatorLink } from '../../utils/wialonLocator';
 import {
   CollectionItem,
   type CollectionItemDocument,
@@ -19,9 +16,9 @@ export interface FleetAttrs {
   locatorKey: string;
 }
 
-export interface FleetDocument extends FleetAttrs, Document {}
+export type FleetDocument = HydratedDocument<FleetAttrs>;
 
-const fleetSchema = new Schema<FleetDocument>({
+const fleetSchema = new Schema<FleetAttrs>({
   name: { type: String, required: true },
   token: { type: String, required: true },
   locatorUrl: { type: String, required: true, default: '' },
@@ -29,13 +26,13 @@ const fleetSchema = new Schema<FleetDocument>({
   locatorKey: {
     type: String,
     required: true,
-    default(this: FleetDocument) {
+    default(this: { token: string }) {
       return this.token;
     },
   },
 });
 
-export const Fleet = model<FleetDocument>('Fleet', fleetSchema);
+export const Fleet = model<FleetAttrs>('Fleet', fleetSchema);
 
 interface LegacyFleetPayload {
   token?: string;


### PR DESCRIPTION
## Что сделано
- скорректированы типы mongoose-документов для коллекций Fleet и CollectionItem, чтобы `_id` имел корректный тип ObjectId
- обновлён импорт `parseLocatorLink`, чтобы использовать версию с поддержкой базового URL

## Почему
- сборка TypeScript падала из-за строгой проверки типов `_id` и несовместимости сигнатуры `parseLocatorLink`

## Чек-лист
- [x] `pnpm --filter telegram-task-bot build`
- [x] `./scripts/setup_and_test.sh`

## Логи ключевых команд
```
pnpm --filter telegram-task-bot build
./scripts/setup_and_test.sh
```

## Самопроверка
- [x] Типы документов соответствуют объектам, возвращаемым Mongoose
- [x] Используется утилита `parseLocatorLink` с нужной сигнатурой
- [x] Сборка и тесты проходят в строгом режиме TypeScript

------
https://chatgpt.com/codex/tasks/task_b_68cc4344cd988320a0aa48e7f4c2b9ea