### PR TITLE
fix: поддержка Unicode в Wialon locator

### DIFF
--- a/apps/api/src/utils/wialonLocator.ts
+++ b/apps/api/src/utils/wialonLocator.ts
@@ -10,8 +10,14 @@ export interface LocatorLinkData {
 
 const DEFAULT_BASE_FALLBACK = 'https://hst-api.wialon.com';
 
-function isPrintableAscii(value: string): boolean {
-  return /^[\x20-\x7E]+$/.test(value);
+function hasControlCharacters(value: string): boolean {
+  for (const char of value) {
+    const code = char.codePointAt(0);
+    if (code !== undefined && ((code >= 0 && code <= 0x1f) || code === 0x7f)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function normalizeBase64(value: string): string {
@@ -50,10 +56,11 @@ export function decodeLocatorKey(locatorKey: string): string {
     throw new Error('Не удалось расшифровать ключ локатора');
   }
   const decoded = buffer.toString('utf8');
-  if (!decoded.trim() || !isPrintableAscii(decoded)) {
+  const normalizedToken = decoded.trim();
+  if (!normalizedToken || hasControlCharacters(normalizedToken)) {
     throw new Error('Расшифрованный ключ содержит недопустимые символы');
   }
-  return decoded;
+  return normalizedToken;
 }
 
 export function parseLocatorLink(link: string, defaultBaseUrl?: string): LocatorLinkData {

--- a/apps/api/tests/fleetVehicles.test.ts
+++ b/apps/api/tests/fleetVehicles.test.ts
@@ -3,25 +3,17 @@
 import mongoose from 'mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 
-jest.mock('../src/services/wialon', () => ({
-  __esModule: true,
-  DEFAULT_BASE_URL: 'https://hst-api.wialon.com',
-  decodeLocatorKey: (value: string) => {
-    const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
-    const padding = (4 - (normalized.length % 4)) % 4;
-    const buffer = Buffer.from(normalized.padEnd(normalized.length + padding, '='), 'base64');
-    if (!buffer.length) {
-      throw new Error('Не удалось расшифровать ключ локатора');
-    }
-    const decoded = buffer.toString('utf8');
-    if (!decoded.trim() || !/^[\x20-\x7E]+$/.test(decoded)) {
-      throw new Error('Расшифрованный ключ содержит недопустимые символы');
-    }
-    return decoded;
-  },
-  login: jest.fn(),
-  loadUnits: jest.fn(),
-}));
+jest.mock('../src/services/wialon', () => {
+  const actual = jest.requireActual('../src/services/wialon');
+  return {
+    __esModule: true,
+    DEFAULT_BASE_URL: actual.DEFAULT_BASE_URL,
+    decodeLocatorKey: actual.decodeLocatorKey,
+    parseLocatorLink: actual.parseLocatorLink,
+    login: jest.fn(),
+    loadUnits: jest.fn(),
+  };
+});
 
 import { Fleet } from '../src/db/models/fleet';
 import { Vehicle } from '../src/db/models/vehicle';

--- a/apps/api/tests/fleetVehiclesRoute.test.ts
+++ b/apps/api/tests/fleetVehiclesRoute.test.ts
@@ -23,41 +23,17 @@ jest.mock('../src/auth/roles.decorator', () => ({
     next(),
 }));
 
-jest.mock('../src/services/wialon', () => ({
-  __esModule: true,
-  DEFAULT_BASE_URL: 'https://hst-api.wialon.com',
-  decodeLocatorKey: (value: string) => {
-    const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
-    const padding = (4 - (normalized.length % 4)) % 4;
-    const buffer = Buffer.from(normalized.padEnd(normalized.length + padding, '='), 'base64');
-    if (!buffer.length) {
-      throw new Error('Не удалось расшифровать ключ локатора');
-    }
-    const decoded = buffer.toString('utf8');
-    if (!decoded.trim() || !/^[\x20-\x7E]+$/.test(decoded)) {
-      throw new Error('Расшифрованный ключ содержит недопустимые символы');
-    }
-    return decoded;
-  },
-  parseLocatorLink: (link: string) => {
-    const url = new URL(link);
-    const key = url.searchParams.get('t');
-    if (!key) {
-      throw new Error('Нет ключа локатора');
-    }
-    const normalized = key.replace(/-/g, '+').replace(/_/g, '/');
-    const padding = (4 - (normalized.length % 4)) % 4;
-    const token = Buffer.from(normalized.padEnd(normalized.length + padding, '='), 'base64').toString('utf8');
-    return {
-      locatorUrl: url.toString(),
-      baseUrl: 'https://hst-api.wialon.com',
-      locatorKey: key,
-      token,
-    };
-  },
-  login: jest.fn(),
-  loadTrack: jest.fn(),
-}));
+jest.mock('../src/services/wialon', () => {
+  const actual = jest.requireActual('../src/services/wialon');
+  return {
+    __esModule: true,
+    DEFAULT_BASE_URL: actual.DEFAULT_BASE_URL,
+    decodeLocatorKey: actual.decodeLocatorKey,
+    parseLocatorLink: actual.parseLocatorLink,
+    login: jest.fn(),
+    loadTrack: jest.fn(),
+  };
+});
 
 jest.mock('../src/services/fleetVehicles', () => ({
   __esModule: true,

--- a/apps/api/tests/services/wialon.test.ts
+++ b/apps/api/tests/services/wialon.test.ts
@@ -43,6 +43,14 @@ describe('wialon service', () => {
     expect(parsed.locatorUrl).toBe(link);
   });
 
+  it('поддерживает кириллические символы в токене', () => {
+    const originalToken = 'пароль123';
+    const locatorKey = Buffer.from(originalToken, 'utf8').toString('base64');
+    const link = `https://hosting.wialon.com/locator?t=${locatorKey}`;
+    const parsed = parseLocatorLink(link);
+    expect(parsed.token).toBe(originalToken);
+  });
+
   it('отклоняет ссылку без валидного t', () => {
     expect(() => parseLocatorLink('https://hosting.wialon.com/locator?t=???')).toThrow(
       'Ключ локатора содержит недопустимые символы',


### PR DESCRIPTION
## Что сделано и зачем
- ослабил проверку `decodeLocatorKey`, чтобы принимать токены с кириллическими символами и другими печатными Unicode-значениями
- обновил jest-заглушки Wialon, чтобы они использовали фактическую реализацию, и добавил юнит-тест на кириллический токен

## Чек-лист
- [x] pnpm lint
- [x] CI=true pnpm test:unit
- [ ] pnpm test:api (не запускал: задача не затрагивает API-эндпоинты напрямую)
- [ ] pnpm test:e2e (не запускал: не требуется для фикса утилиты)

## Логи
- `pnpm lint`
- `CI=true pnpm test:unit`

## Самопроверка
1. Токены с кириллицей проходят `decodeLocatorKey` и возвращаются без скрытых символов.
2. Заглушки в тестах не расходятся с реальной реализацией сервиса.
3. Покрытие unit-тестами сохранено, добавлен кейс для Unicode-токена.


------
https://chatgpt.com/codex/tasks/task_b_68cc4c6f5bfc8320b8c77a7e5318e5e7