### PR TITLE
feat: обработка некорректных датчиков автопарка

### DIFF
--- a/apps/web/src/pages/Settings/FleetVehiclesGrid.test.tsx
+++ b/apps/web/src/pages/Settings/FleetVehiclesGrid.test.tsx
@@ -1,0 +1,42 @@
+/** @jest-environment jsdom */
+// Назначение: проверяет устойчивость FleetVehiclesGrid к некорректным датчикам.
+// Основные модули: React, @testing-library/react, FleetVehiclesGrid.
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import FleetVehiclesGrid from "./FleetVehiclesGrid";
+import type { VehicleDto } from "shared";
+
+describe("FleetVehiclesGrid", () => {
+  const baseVehicle: VehicleDto = {
+    id: "veh-1",
+    unitId: 101,
+    name: "Тестовая машина",
+    sensors: [],
+  };
+
+  it("корректно обрабатывает customSensors со значением null", () => {
+    render(
+      <FleetVehiclesGrid
+        vehicles={[
+          {
+            ...baseVehicle,
+            customSensors: [
+              null as unknown as VehicleDto["sensors"][number],
+              { name: undefined, value: null } as unknown as VehicleDto["sensors"][number],
+            ],
+          },
+        ]}
+        loading={false}
+        error={undefined}
+        onRefresh={() => {}}
+        onEdit={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Дополнительные датчики")).toBeInTheDocument();
+    const listItems = screen.getAllByRole("listitem");
+    expect(listItems).toHaveLength(1);
+    expect(listItems[0]).toHaveTextContent(/—\s*:\s*—/);
+  });
+});

--- a/apps/web/src/pages/Settings/FleetVehiclesGrid.tsx
+++ b/apps/web/src/pages/Settings/FleetVehiclesGrid.tsx
@@ -12,14 +12,20 @@ interface Props {
 }
 
 function formatSensors(list: VehicleDto["sensors"] | undefined) {
-  if (!list?.length) return null;
+  const sensors = (list ?? []).filter(
+    (sensor): sensor is VehicleDto["sensors"][number] => Boolean(sensor),
+  );
+  if (!sensors.length) return null;
   return (
     <ul className="mt-1 space-y-1 text-sm text-gray-700">
-      {list.map((sensor, index) => (
-        <li key={`${sensor.name}-${index}`}>
-          <span className="font-medium">{sensor.name}</span>: {String(sensor.value ?? "—")}
-        </li>
-      ))}
+      {sensors.map((sensor, index) => {
+        const name = sensor?.name ?? "—";
+        return (
+          <li key={`${name}-${index}`}>
+            <span className="font-medium">{name}</span>: {String(sensor?.value ?? "—")}
+          </li>
+        );
+      })}
     </ul>
   );
 }


### PR DESCRIPTION
## Что сделано
- фильтрация некорректных элементов датчиков и безопасный вывод названия сенсора в FleetVehiclesGrid
- добавлен модульный тест, подтверждающий устойчивость к customSensors, содержащим null

## Почему
- прежняя реализация падала на данных вида customSensors: [null], что ломало вкладку «Автопарк»

## Чек-лист
- [x] `pnpm test`
- [x] `pnpm test:api`
- [x] `pnpm test:e2e`
- [ ] Ручная проверка вкладки «Автопарк» (нет возможности в контейнере)

## Логи ключевых команд
- `pnpm test`

## Самопроверка
- [x] Обновлённый код покрыт тестом
- [x] Команда сборки прошла в рамках `pnpm test`
- [x] Нет лишних артефактов сборки в репозитории
- [ ] Ручные проверки недоступны


------
https://chatgpt.com/codex/tasks/task_b_68ccec01b88883209bc5b7633469018a