### PR TITLE
feat: guide fleet recovery failures

### DIFF
--- a/apps/api/src/metrics/index.ts
+++ b/apps/api/src/metrics/index.ts
@@ -40,3 +40,10 @@ export const osrmErrorsTotal = new client.Counter({
   labelNames: ['endpoint', 'reason'],
   registers: [register],
 });
+
+export const fleetRecoveryFailuresTotal = new client.Counter({
+  name: 'fleet_recovery_failures_total',
+  help: 'Неудачные попытки восстановления флота из коллекции',
+  labelNames: ['reason'],
+  registers: [register],
+});

--- a/apps/api/tests/fleetVehiclesRoute.test.ts
+++ b/apps/api/tests/fleetVehiclesRoute.test.ts
@@ -168,6 +168,24 @@ describe('GET /api/v1/fleets/:id/vehicles', () => {
     expect(mockedSyncFleetVehicles).toHaveBeenCalledTimes(1);
   });
 
+  it('возвращает 422 и подсказку, если флот нельзя восстановить', async () => {
+    const id = new mongoose.Types.ObjectId();
+    await CollectionItem.create({
+      _id: id,
+      type: 'fleets',
+      name: 'Проблемный флот',
+      value: 'not-a-link',
+    });
+
+    const res = await request(app)
+      .get(`/api/v1/fleets/${id.toString()}/vehicles`)
+      .expect(422);
+
+    expect(res.body).toMatchObject({ error: 'Не удалось восстановить автопарк' });
+    expect(res.body.detail).toContain('Некорректная ссылка Wialon');
+    expect(res.body.detail).toContain('Обновите ссылку Wialon');
+  });
+
   it('восстанавливает флот из коллекции с устаревшим значением', async () => {
     const id = new mongoose.Types.ObjectId();
     const legacyPayload = {


### PR DESCRIPTION
## Что сделано
- добавил метрику Prometheus для отслеживания сбоев восстановления флота и вернул причину наружу
- обновил восстановление флота, чтобы возвращать 422 с подсказкой при некорректной ссылке Wialon
- расширил тесты API сценарием отказа восстановления автопарка

## Зачем
- чтобы операторы сразу видели, что нужно обновить ссылку Wialon, а мы отслеживали подобные сбои

## Логи
- `pnpm test:unit`
- `pnpm lint`

## Чек-лист
- [x] Тесты зелёные
- [x] Линтер чист
- [ ] Сборка успешна
- [ ] Обратная совместимость задокументирована (не требуется)

## Самопроверка
- Ошибка 422 возвращается только при наличии записи коллекции
- Подсказка в ответе содержит причину из Wialon-парсера
- Метрика и предупреждение не раскрывают секреты
- Тесты покрывают новый сценарий отказа

------
https://chatgpt.com/codex/tasks/task_b_68ccf1cab76483208ef239012cc02c40