### PR TITLE
fix: allow unicode tokens in Wialon locator

### DIFF
--- a/apps/api/src/utils/wialonLocator.ts
+++ b/apps/api/src/utils/wialonLocator.ts
@@ -13,7 +13,7 @@ const DEFAULT_BASE_FALLBACK = 'https://hst-api.wialon.com';
 function hasControlCharacters(value: string): boolean {
   for (const char of value) {
     const code = char.codePointAt(0);
-    if (code !== undefined && (code < 0x20 || code > 0x7e)) {
+    if (code !== undefined && (code < 0x20 || (code >= 0x7f && code <= 0x9f))) {
       return true;
     }
   }


### PR DESCRIPTION
## Что сделано
- обновил проверку `hasControlCharacters`, чтобы отклонять только управляющие символы диапазонов C0/C1
- тем самым сохранил поддержку кириллических и прочих печатных символов в токенах Wialon

## Почему
- тест `wialon service › поддерживает кириллические символы в токене` падал из-за излишне строгой проверки, запрещавшей всё, что выходило за ASCII

## Логи
- `pnpm lint`
- `pnpm build`
- `pnpm test:unit`
- `pnpm test:api`
- `pnpm test:e2e`

## Чек-лист
- [x] Тесты зелёные
- [x] Линтер без ошибок
- [x] Сборка проходит
- [x] Обратная совместимость сохранена

## Самопроверка
- [x] Все артефакты сборки убраны из коммита
- [x] Изменения локально проверены командами из логов
- [x] Инструкции из AGENTS.md соблюдены

------
https://chatgpt.com/codex/tasks/task_b_68cd2dd8600c8320a41847d9421dec20