### PR TITLE
feat: mark invalid fleets and add normalization script

### DIFF
--- a/apps/api/src/db/models/CollectionItem.ts
+++ b/apps/api/src/db/models/CollectionItem.ts
@@ -2,10 +2,19 @@
 // Основные модули: mongoose
 import { Schema, model, Document, Types } from 'mongoose';
 
+export interface CollectionItemMeta {
+  invalid?: boolean;
+  invalidReason?: string;
+  invalidCode?: string;
+  invalidAt?: Date;
+  [key: string]: unknown;
+}
+
 export interface CollectionItemAttrs {
   type: string;
   name: string;
   value: string;
+  meta?: CollectionItemMeta;
 }
 
 export interface CollectionItemDocument
@@ -20,6 +29,7 @@ const collectionItemSchema = new Schema<CollectionItemDocument>({
   type: { type: String, required: true },
   name: { type: String, required: true },
   value: { type: String, required: true },
+  meta: { type: Schema.Types.Mixed, default: undefined },
 });
 
 collectionItemSchema.index(

--- a/apps/api/src/db/repos/collectionRepo.ts
+++ b/apps/api/src/db/repos/collectionRepo.ts
@@ -22,6 +22,9 @@ export async function create(
     name: data.name,
     value: data.value,
   };
+  if (data.meta) {
+    payload.meta = data.meta;
+  }
   if (data._id) {
     payload._id =
       typeof data._id === 'string' ? new Types.ObjectId(data._id) : data._id;

--- a/apps/api/tests/fleetVehiclesRoute.test.ts
+++ b/apps/api/tests/fleetVehiclesRoute.test.ts
@@ -184,6 +184,10 @@ describe('GET /api/v1/fleets/:id/vehicles', () => {
     expect(res.body).toMatchObject({ error: 'Не удалось восстановить автопарк' });
     expect(res.body.detail).toContain('Некорректная ссылка Wialon');
     expect(res.body.detail).toContain('Обновите ссылку Wialon');
+
+    const item = await CollectionItem.findById(id);
+    expect(item?.meta?.invalid).toBe(true);
+    expect(item?.meta?.invalidReason).toContain('Некорректная ссылка');
   });
 
   it('восстанавливает флот из коллекции с устаревшим значением', async () => {

--- a/apps/web/src/services/collections.ts
+++ b/apps/web/src/services/collections.ts
@@ -7,6 +7,13 @@ export interface CollectionItem {
   type: string;
   name: string;
   value: string;
+  meta?: {
+    invalid?: boolean;
+    invalidReason?: string;
+    invalidCode?: string;
+    invalidAt?: string;
+    [key: string]: unknown;
+  };
 }
 
 const parseErrorMessage = (status: number, body: string) => {

--- a/scripts/db/normalizeFleetCollectionItem.ts
+++ b/scripts/db/normalizeFleetCollectionItem.ts
@@ -1,0 +1,121 @@
+// Назначение: нормализация ссылки автопарка в коллекции и перезапуск синхронизации
+// Основные модули: mongoose, модели CollectionItem и Fleet, утилиты Wialon
+import 'dotenv/config';
+import { Types } from 'mongoose';
+import connect from '../apps/api/src/db/connection';
+import {
+  CollectionItem,
+  type CollectionItemMeta,
+} from '../apps/api/src/db/models/CollectionItem';
+import {
+  Fleet,
+  ensureFleetFields,
+} from '../apps/api/src/db/models/fleet';
+import { parseLocatorLink } from '../apps/api/src/utils/wialonLocator';
+import { DEFAULT_BASE_URL } from '../apps/api/src/services/wialon';
+import { syncFleetVehicles } from '../apps/api/src/services/fleetVehicles';
+
+type NormalizedMeta = CollectionItemMeta | undefined;
+
+function usage(): never {
+  console.error('Использование: pnpm ts-node scripts/db/normalizeFleetCollectionItem.ts <itemId> <locatorUrl>');
+  return process.exit(1);
+}
+
+function sanitizeMeta(meta: NormalizedMeta): NormalizedMeta {
+  if (!meta) {
+    return undefined;
+  }
+  let changed = false;
+  const next: CollectionItemMeta = {};
+  for (const [key, value] of Object.entries(meta)) {
+    if (
+      key === 'invalid' ||
+      key === 'invalidReason' ||
+      key === 'invalidCode' ||
+      key === 'invalidAt'
+    ) {
+      changed = true;
+      continue;
+    }
+    next[key] = value;
+  }
+  if (!changed) {
+    return meta;
+  }
+  return Object.keys(next).length > 0 ? next : undefined;
+}
+
+async function normalizeFleetCollectionItem(id: string, rawValue: string): Promise<void> {
+  if (!Types.ObjectId.isValid(id)) {
+    throw new Error('Идентификатор коллекции должен быть ObjectId');
+  }
+  const connection = await connect();
+  try {
+    const item = await CollectionItem.findById(id);
+    if (!item) {
+      throw new Error('Элемент коллекции не найден');
+    }
+    if (item.type !== 'fleets') {
+      throw new Error('Указанный элемент не относится к автопаркам');
+    }
+    const locator = parseLocatorLink(rawValue, DEFAULT_BASE_URL);
+    const shouldUpdateValue = item.value !== locator.locatorUrl;
+    let metaChanged = false;
+    if (shouldUpdateValue) {
+      item.value = locator.locatorUrl;
+    }
+    const currentMeta = item.meta as CollectionItemMeta | undefined;
+    const nextMeta = sanitizeMeta(currentMeta);
+    if (nextMeta !== currentMeta) {
+      item.set('meta', nextMeta);
+      metaChanged = true;
+    }
+    if (shouldUpdateValue || metaChanged) {
+      if (metaChanged) {
+        item.markModified('meta');
+      }
+      await item.save();
+    }
+
+    let fleet = await Fleet.findById(item._id);
+    if (!fleet) {
+      fleet = await Fleet.create({
+        _id: item._id,
+        name: item.name,
+        token: locator.token,
+        locatorUrl: locator.locatorUrl,
+        baseUrl: locator.baseUrl,
+        locatorKey: locator.locatorKey,
+      });
+    } else {
+      fleet.token = locator.token;
+      fleet.locatorUrl = locator.locatorUrl;
+      fleet.baseUrl = locator.baseUrl;
+      fleet.locatorKey = locator.locatorKey;
+      await fleet.save();
+    }
+
+    const updatedFleet = await ensureFleetFields(fleet);
+    await syncFleetVehicles(updatedFleet);
+  } finally {
+    await connection.close();
+  }
+}
+
+if (require.main === module) {
+  const [, , id, locatorUrl] = process.argv;
+  if (!id || !locatorUrl) {
+    usage();
+  }
+  normalizeFleetCollectionItem(id, locatorUrl)
+    .then(() => {
+      console.log('Ссылка автопарка обновлена, синхронизация выполнена');
+      process.exit(0);
+    })
+    .catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error('Ошибка нормализации автопарка:', message);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary
- add metadata support for collection items and flag invalid fleet records when recovery fails
- reuse stored failure state to skip flagged fleets during migrations and align API/web types and tests
- add a database script that normalizes fleet locator values, clears the invalid flag and re-runs synchronization

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_b_68cd4025eed88320ae2e19e8641630d8