### PR TITLE
test: стабилизировать моки roleCache в API тестах

### DIFF
--- a/apps/api/tests/auth.test.ts
+++ b/apps/api/tests/auth.test.ts
@@ -5,6 +5,17 @@ jest.mock('telegraf', () => ({
 }));
 jest.mock('jsonwebtoken');
 jest.mock('../src/services/telegramApi', () => ({ call: jest.fn() }));
+const { Types } = require('mongoose');
+const mockAdminRoleId = new Types.ObjectId('686591126cc86a6bd16c18af');
+const mockManagerRoleId = new Types.ObjectId('686633fdf6896f1ad3fa063e');
+jest.mock('../src/db/roleCache', () => ({
+  resolveRoleId: jest.fn(async (name: string) => {
+    if (name === 'admin') return mockAdminRoleId;
+    if (name === 'manager') return mockManagerRoleId;
+    return null;
+  }),
+  clearRoleCache: jest.fn(),
+}));
 jest.mock('../src/services/userInfoService', () => ({
   getMemberStatus: jest.fn(async () => 'member'),
 }));

--- a/apps/api/tests/authService.test.ts
+++ b/apps/api/tests/authService.test.ts
@@ -30,13 +30,13 @@ jest.mock('../src/utils/verifyInitData', () =>
 );
 
 const { Types } = require('mongoose');
-const adminRoleId = new Types.ObjectId('64b111111111111111111111');
-const managerRoleId = new Types.ObjectId('64b222222222222222222222');
+const mockAdminRoleId = new Types.ObjectId('64b111111111111111111111');
+const mockManagerRoleId = new Types.ObjectId('64b222222222222222222222');
 
 jest.mock('../src/db/roleCache', () => ({
   resolveRoleId: jest.fn(async (name: string) => {
-    if (name === 'admin') return adminRoleId;
-    if (name === 'manager') return managerRoleId;
+    if (name === 'admin') return mockAdminRoleId;
+    if (name === 'manager') return mockManagerRoleId;
     return new (require('mongoose').Types.ObjectId)('64b333333333333333333333');
   }),
   clearRoleCache: jest.fn(),
@@ -56,13 +56,13 @@ beforeEach(() => {
 });
 
 test('sendCode использует adminCodes для админа', async () => {
-  queries.getUser.mockResolvedValueOnce({ roleId: adminRoleId });
+  queries.getUser.mockResolvedValueOnce({ roleId: mockAdminRoleId });
   await service.sendCode('1');
   expect(otp.sendAdminCode).toHaveBeenCalledWith({ telegramId: 1 });
 });
 
 test('sendCode использует sendManagerCode для менеджера', async () => {
-  queries.getUser.mockResolvedValueOnce({ roleId: managerRoleId });
+  queries.getUser.mockResolvedValueOnce({ roleId: mockManagerRoleId });
   await service.sendCode('3');
   expect(otp.sendManagerCode).toHaveBeenCalledWith({ telegramId: 3 });
 });

--- a/apps/api/tests/createUser.test.ts
+++ b/apps/api/tests/createUser.test.ts
@@ -25,10 +25,10 @@ jest.mock('../src/db/model', () => ({
 }));
 
 const { Types } = require('mongoose');
-const defaultRoleId = new Types.ObjectId();
+const mockDefaultRoleId = new Types.ObjectId();
 
 jest.mock('../src/db/roleCache', () => ({
-  resolveRoleId: jest.fn(async () => defaultRoleId),
+  resolveRoleId: jest.fn(async () => mockDefaultRoleId),
   clearRoleCache: jest.fn(),
 }));
 
@@ -46,7 +46,7 @@ describe('createUser', () => {
     model.User.exists = jest.fn(async () => false);
     const u = await createUser(1, 'test');
     expect(u.name).toBe('test');
-    expect(u.roleId?.toString()).toBe(defaultRoleId.toString());
+    expect(u.roleId?.toString()).toBe(mockDefaultRoleId.toString());
   });
 
   test('генерирует id и username при пустом вводе', async () => {

--- a/apps/api/tests/loginFlow.test.ts
+++ b/apps/api/tests/loginFlow.test.ts
@@ -12,11 +12,23 @@ const session = require('express-session');
 const rateLimit = require('express-rate-limit');
 const lusca = require('lusca');
 const request = require('supertest');
+const { Types } = require('mongoose');
 jest.unmock('jsonwebtoken');
 
 jest.mock('../src/services/telegramApi', () => ({ call: jest.fn() }));
 jest.mock('../src/services/userInfoService', () => ({
   getMemberStatus: jest.fn(async () => 'member'),
+}));
+
+const mockAdminRoleId = new Types.ObjectId('64b111111111111111111111');
+const mockManagerRoleId = new Types.ObjectId('64b222222222222222222222');
+jest.mock('../src/db/roleCache', () => ({
+  resolveRoleId: jest.fn(async (name: string) => {
+    if (name === 'admin') return mockAdminRoleId;
+    if (name === 'manager') return mockManagerRoleId;
+    return null;
+  }),
+  clearRoleCache: jest.fn(),
 }));
 
 jest.mock('../src/db/queries', () => ({

--- a/apps/api/tests/loginRouteFlow.test.ts
+++ b/apps/api/tests/loginRouteFlow.test.ts
@@ -11,11 +11,23 @@ const cookieParser = require('cookie-parser');
 const session = require('express-session');
 const lusca = require('lusca');
 const request = require('supertest');
+const { Types } = require('mongoose');
 jest.unmock('jsonwebtoken');
 
 jest.mock('../src/services/telegramApi', () => ({ call: jest.fn() }));
 jest.mock('../src/services/userInfoService', () => ({
   getMemberStatus: jest.fn(async () => 'member'),
+}));
+
+const mockAdminRoleId = new Types.ObjectId('64b111111111111111111111');
+const mockManagerRoleId = new Types.ObjectId('64b222222222222222222222');
+jest.mock('../src/db/roleCache', () => ({
+  resolveRoleId: jest.fn(async (name: string) => {
+    if (name === 'admin') return mockAdminRoleId;
+    if (name === 'manager') return mockManagerRoleId;
+    return null;
+  }),
+  clearRoleCache: jest.fn(),
 }));
 
 jest.mock('../src/db/queries', () => ({

--- a/apps/api/tests/loginTasksFlow.test.ts
+++ b/apps/api/tests/loginTasksFlow.test.ts
@@ -9,13 +9,13 @@ process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
 process.env.APP_URL = 'https://localhost';
 
 const { Types } = require('mongoose');
-const adminRoleId = new Types.ObjectId('64b000000000000000000001');
-const managerRoleId = new Types.ObjectId('64b000000000000000000002');
+const mockAdminRoleId = new Types.ObjectId('64b000000000000000000001');
+const mockManagerRoleId = new Types.ObjectId('64b000000000000000000002');
 
 jest.mock('../src/db/roleCache', () => ({
   resolveRoleId: jest.fn(async (name: string) => {
-    if (name === 'admin') return adminRoleId;
-    if (name === 'manager') return managerRoleId;
+    if (name === 'admin') return mockAdminRoleId;
+    if (name === 'manager') return mockManagerRoleId;
     return new (require('mongoose').Types.ObjectId)('64b000000000000000000003');
   }),
   clearRoleCache: jest.fn(),
@@ -50,8 +50,8 @@ jest.mock('../src/services/tasks', () => ({
 jest.mock('../src/middleware/taskAccess', () => (_req, _res, next) => next());
 
 jest.mock('../src/db/queries', () => ({
-  getUser: jest.fn(async () => ({ roleId: managerRoleId })),
-  createUser: jest.fn(async () => ({ username: 'u', role: 'manager', roleId: managerRoleId })),
+  getUser: jest.fn(async () => ({ roleId: mockManagerRoleId })),
+  createUser: jest.fn(async () => ({ username: 'u', role: 'manager', roleId: mockManagerRoleId })),
   updateUser: jest.fn(async () => ({})),
   accessByRole: (r: string) => (r === 'admin' ? 6 : r === 'manager' ? 4 : 1),
 }));


### PR DESCRIPTION
## Что сделано
- добавил явные моки `roleCache` в тестах авторизации и потоков логина
- переименовал идентификаторы ролей в `mock*`, чтобы избежать ошибок hoisting в `jest.mock`

## Зачем
- прежние тесты обращались к реальной базе через `roleCache`, что вызывало таймауты и падения CI

## Проверки
- `pnpm lint`
- `pnpm test`
- `pnpm build`

## Логи
- вырезки команд приложены в отчёте агента

## Самопроверка
- [x] тесты покрывают изменения и проходят локально
- [x] линтер отрабатывает без ошибок
- [x] сборка проекта завершается успешно
- [x] рабочее дерево чистое


------
https://chatgpt.com/codex/tasks/task_b_68cd73d13c1483209ae8dba7047c4f63