### PR TITLE
feat: support raw wialon locator fallback

### DIFF
--- a/apps/api/src/db/models/fleet.ts
+++ b/apps/api/src/db/models/fleet.ts
@@ -373,6 +373,11 @@ export async function ensureFleetDocument(
     options?.onFailure?.(result.failure);
     return null;
   }
+  if (result.attrs.token === result.attrs.locatorKey) {
+    console.warn(
+      `Для автопарка ${item._id} используется исходный ключ локатора без декодирования`,
+    );
+  }
   return Fleet.create({
     _id: item._id,
     name: item.name,

--- a/apps/api/tests/services/wialon.test.ts
+++ b/apps/api/tests/services/wialon.test.ts
@@ -51,6 +51,23 @@ describe('wialon service', () => {
     expect(parsed.token).toBe(originalToken);
   });
 
+  it('сохраняет сырой ключ при невозможности декодировать base64', () => {
+    const rawKey = 'raw-token';
+    const link = `https://hosting.wialon.com/locator?t=${rawKey}`;
+    const parsed = parseLocatorLink(link);
+    expect(parsed.token).toBe(rawKey);
+    expect(parsed.locatorKey).toBe(rawKey);
+  });
+
+  it('отклоняет ключ с непечатными символами', () => {
+    const url = new URL('https://hosting.wialon.com/locator');
+    const invalidKey = `raw-${String.fromCharCode(7)}`;
+    url.searchParams.set('t', invalidKey);
+    expect(() => parseLocatorLink(url.toString())).toThrow(
+      'Ключ локатора содержит недопустимые символы',
+    );
+  });
+
   it('отклоняет ссылку без валидного t', () => {
     expect(() => parseLocatorLink('https://hosting.wialon.com/locator?t=???')).toThrow(
       'Ключ локатора содержит недопустимые символы',


### PR DESCRIPTION
## Описание
- добавил проверку ключей локатора Wialon с резервным режимом возврата исходного значения после валидации
- обновил восстановление автопарков для логирования предупреждения при использовании сырого ключа и расширил тесты
- уточнил ожидания в HTTP-тестах, покрыв путь с предупреждением и «сырыми» ключами

## Почему
- часть клиентов хранит токены без base64, нужно поддержать их без блокирующей ошибки и контролировать предупреждения

## Чек-лист
- [x] `pnpm lint`
- [x] `pnpm test` (включая сборку через `pretest:e2e`)
- [x] Обратная совместимость сохранена

## Логи
- `pnpm lint`
- `pnpm test`

## Самопроверка
- покрытие сценариев с сырьём и непечатными символами
- проверил предупреждение ensureFleetDocument в тесте
- убедился, что сборка проходит в рамках `pnpm test`
- рабочее дерево очищено перед коммитом


------
https://chatgpt.com/codex/tasks/task_b_68cd7a0d56d08320b604698a5256b75c