### PR TITLE
feat: кеш браузеров Playwright в CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,19 @@ jobs:
         run: corepack enable
       - name: Установка зависимостей
         run: pnpm install
+      - name: Определение версии Playwright
+        id: playwright-version
+        run: echo "version=$(node -p \"require('@playwright/test/package.json').version\")" >> "$GITHUB_OUTPUT"
+      - name: Кеш браузеров Playwright
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
       - name: Проверка build-скриптов
         run: pnpm approve-builds
       - name: Установка браузеров Playwright
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: sudo env "PATH=$PATH" npx playwright install --with-deps
       - name: Линтеры
         run: pnpm lint
@@ -84,7 +94,17 @@ jobs:
         run: corepack enable
       - name: Установка зависимостей
         run: pnpm install
+      - name: Определение версии Playwright
+        id: playwright-version
+        run: echo "version=$(node -p \"require('@playwright/test/package.json').version\")" >> "$GITHUB_OUTPUT"
+      - name: Кеш браузеров Playwright
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
       - name: Установка браузеров Playwright
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: sudo env "PATH=$PATH" npx playwright install --with-deps
       - name: E2E тесты
         run: pnpm run test:e2e --project="${{ matrix.project }}"


### PR DESCRIPTION
## Описание
- добавил шаг кеширования браузеров Playwright в задания `lint-test-build` и `e2e-tests`
- определяю версию Playwright через package.json и использую её в ключе кеша вместе с `runner.os`
- запускаю `npx playwright install --with-deps` только при промахе кеша, сохранив выполнение под `sudo`

## Почему
- уменьшает время прогонов CI за счёт повторного использования скачанных браузеров
- избавляет от лишних установок Playwright в матричном e2e-прогоне

## Логи команд
- `./scripts/setup_and_test.sh`
- попытка `act pull_request -j lint-test-build -W .github/workflows/ci.yml -P ubuntu-latest=catthehacker/ubuntu:act-22.04` (ошибка из-за недоступного Docker daemon в окружении)

## Чек-лист
- [x] тесты зелёные
- [x] линтеры без ошибок
- [x] сборка проходит
- [ ] обратная совместимость проверена вручную (не требуется)

## Самопроверка
- [x] шаг кеширования стоит до установки браузеров
- [x] условие `cache-hit` не допускает лишней установки в e2e матрице
- [x] версия Playwright извлекается из зависимостей пакета

## Риски и откат
- риск: изменение структуры кэша при обновлении Playwright -> пересоздаётся ключ
- откат: удалить шаг `actions/cache` и условие `if: cache-hit` из `.github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_b_68cd7ff47fec832083e5ca251a27265c