### PR TITLE
fix: isolate mongodb-memory-server downloads in tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -14,7 +14,10 @@ const config: Config = {
     '<rootDir>/tests/playwright/',
     '<rootDir>/apps/web/src/types/',
   ],
-  setupFiles: ['<rootDir>/tests/setupEnv.ts'],
+  setupFiles: [
+    '<rootDir>/tests/setupMongoMemoryServer.ts',
+    '<rootDir>/tests/setupEnv.ts',
+  ],
   coverageDirectory: 'coverage',
   transform: {
     '^.+\\.[jt]sx?$': ['ts-jest', { tsconfig: './tests/tsconfig.json' }],

--- a/tests/setupMongoMemoryServer.ts
+++ b/tests/setupMongoMemoryServer.ts
@@ -1,0 +1,19 @@
+/**
+ * Назначение файла: настройка каталога скачивания mongodb-memory-server для параллельных тестов.
+ * Основные модули: fs, os, path.
+ */
+
+import { mkdirSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+if (!process.env.MONGOMS_DOWNLOAD_DIR) {
+  const baseDir = path.join(os.tmpdir(), 'mongodb-memory-server');
+  const workerId = process.env.JEST_WORKER_ID ?? '0';
+  const downloadDir = path.join(baseDir, workerId);
+
+  mkdirSync(downloadDir, { recursive: true });
+  process.env.MONGOMS_DOWNLOAD_DIR = downloadDir;
+}
+
+process.env.MONGOMS_DISABLE_MD5_CHECK ||= '1';


### PR DESCRIPTION
## Что сделано
- добавлен набор настроек окружения, который направляет mongodb-memory-server в изолированную папку загрузки и выключает повторный md5-чек
- подключён новый setup-файл в конфигурации Jest, чтобы переменные применялись до старта любых тестов

## Почему
- параллельные jest-воркеры конфликтовали на общем lock-файле при скачивании бинарника MongoDB, из-за чего падали все тесты, связанные с MongoMemoryServer

## Чек-лист
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm test`
- [x] `pnpm run dev` (остановлен вручную после проверки старта)

## Логи
- `pnpm lint`
- `pnpm build`
- `pnpm test`
- `pnpm run dev`

## Самопроверка
- [x] новые файлы инициализируют окружение только при необходимости
- [x] инструкции AGENTS.md соблюдены
- [x] рабочее дерево чистое

## Риски и откат
- риск: увеличение времени скачивания бинарников, если воркеры используют независимые каталоги; смягчается редкими скачиваниями и кэшем runner
- откат: удалить `tests/setupMongoMemoryServer.ts` и вернуть `setupFiles` к исходному состоянию


------
https://chatgpt.com/codex/tasks/task_b_68cd8381c19c83209db88c778203ead7