### PR TITLE
fix: stabilize Playwright version detection in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,9 @@ jobs:
         run: pnpm install
       - name: Определение версии Playwright
         id: playwright-version
-        run: echo "version=$(node -p \"require('@playwright/test/package.json').version\")" >> "$GITHUB_OUTPUT"
+        run: |
+          VERSION=$(node -p "require('@playwright/test/package.json').version")
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
       - name: Кеш браузеров Playwright
         id: playwright-cache
         uses: actions/cache@v4
@@ -96,7 +98,9 @@ jobs:
         run: pnpm install
       - name: Определение версии Playwright
         id: playwright-version
-        run: echo "version=$(node -p \"require('@playwright/test/package.json').version\")" >> "$GITHUB_OUTPUT"
+        run: |
+          VERSION=$(node -p "require('@playwright/test/package.json').version")
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
       - name: Кеш браузеров Playwright
         id: playwright-cache
         uses: actions/cache@v4


### PR DESCRIPTION
## Что изменилось
- переписал шаг определения версии Playwright на многострочный скрипт с промежуточной переменной, чтобы избежать проблем с интерпретацией скобок в sh
- аналогично обновил job e2e-tests, чтобы кеш браузеров использовал ту же устойчивую конструкцию

## Почему это важно
- предыдущая однострочная команда ломалась в окружении CI (dash) из-за вложенных кавычек и приводила к падению линтер-джоба
- многострочное выполнение с временной переменной совместимо с sh и сохраняет значение версии в `$GITHUB_OUTPUT`

## Чек-лист
- [x] Линтеры (`pnpm lint`)
- [x] Юнит/интеграционные тесты (`pnpm test:unit`, `pnpm test:api`)
- [x] Сборка (`pnpm -r build`)
- [ ] E2E тесты (выполняются в CI)
- [x] Скрипт `./scripts/setup_and_test.sh`

## Логи ключевых команд
```
./scripts/setup_and_test.sh
```

## Самопроверка
- [x] Команда Playwright больше не содержит вложенных кавычек
- [x] Оба workflow-шага используют одинаковый подход
- [x] Скрипт перед коммитом отработал успешно
- [x] Рабочее дерево чистое


------
https://chatgpt.com/codex/tasks/task_b_68cd8f569edc8320b16b83605159aa0d