### PR TITLE
feat: handle raw wialon locator tokens

### DIFF
--- a/apps/api/src/utils/wialonLocator.ts
+++ b/apps/api/src/utils/wialonLocator.ts
@@ -74,6 +74,9 @@ function decodeLocatorKeyDetailed(locatorKey: string): DecodeLocatorKeyResult {
     const decoded = buffer.toString('utf8');
     const normalizedToken = decoded.trim();
     if (!normalizedToken || hasControlCharacters(normalizedToken)) {
+      if (isRawCandidate && !hasControlCharacters(trimmed)) {
+        return { token: trimmed, fallback: true };
+      }
       throw new Error('Расшифрованный ключ содержит недопустимые символы');
     }
     return { token: normalizedToken, fallback: false };

--- a/apps/api/tests/services/wialon.test.ts
+++ b/apps/api/tests/services/wialon.test.ts
@@ -59,6 +59,14 @@ describe('wialon service', () => {
     expect(parsed.locatorKey).toBe(rawKey);
   });
 
+  it('использует сырой ключ если декодированный токен содержит непечатные символы', () => {
+    const rawKey = 'fb4bcbccf4815a386eface22e0afc0b0524DE7B5134AB9B26EAAA61C328F1558C5AB5967';
+    const link = `https://wialon.gps-garant.com.ua/locator/index.html?t=${rawKey}`;
+    const parsed = parseLocatorLink(link);
+    expect(parsed.token).toBe(rawKey);
+    expect(parsed.locatorKey).toBe(rawKey);
+  });
+
   it('отклоняет ключ с непечатными символами', () => {
     const url = new URL('https://hosting.wialon.com/locator');
     const invalidKey = `raw-${String.fromCharCode(7)}`;


### PR DESCRIPTION
## What
- fallback to raw Wialon locator keys when base64 decoding produces control characters
- cover the regression with a dedicated unit test for the gps-garant locator link

## Why
- shared Wialon locator links from gps-garant return hexadecimal keys that are misdetected as base64 and rejected; we now accept them as raw tokens

## Checklist
- [x] Tests are passing
- [x] Lint is clean
- [x] Build succeeds via test workflow
- [x] Backward compatibility preserved

## Logs
- `pnpm lint`
- `pnpm test`

## Self-check
- [x] Added automated coverage for the regression
- [x] Verified no extra build artefacts remain tracked
- [x] Ensured error handling still rejects keys with control characters


------
https://chatgpt.com/codex/tasks/task_b_68cd9a9587b883208d9c1de0cbca2432