### PR TITLE
fix: reject invalid fleet locator links during recovery

### DIFF
--- a/apps/api/src/db/models/fleet.ts
+++ b/apps/api/src/db/models/fleet.ts
@@ -2,7 +2,7 @@
 // Основные модули: mongoose
 import { Schema, model, Types, type HydratedDocument } from 'mongoose';
 import { DEFAULT_BASE_URL, decodeLocatorKey } from '../../services/wialon';
-import { parseLocatorLink } from '../../utils/wialonLocator';
+import { decodeLocatorKeyDetailed, parseLocatorLink } from '../../utils/wialonLocator';
 import { fleetRecoveryFailuresTotal } from '../../metrics';
 import {
   CollectionItem,
@@ -218,9 +218,9 @@ function parseLegacyValue(value: string): LegacyFleetPayload | null {
     const candidate = parts[0];
     if (candidate) {
       try {
-        const decoded = decodeLocatorKey(candidate);
-        if (isPrintableToken(decoded)) {
-          payload.token = decoded;
+        const decoded = decodeLocatorKeyDetailed(candidate);
+        if (!decoded.fallback && isPrintableToken(decoded.token)) {
+          payload.token = decoded.token;
           payload.locatorKey = candidate;
         }
       } catch {
@@ -228,6 +228,7 @@ function parseLegacyValue(value: string): LegacyFleetPayload | null {
       }
       if (!payload.token && looksLikeTokenCandidate(candidate)) {
         payload.token = candidate;
+        payload.locatorKey = candidate;
       }
     }
   }

--- a/apps/api/src/utils/wialonLocator.ts
+++ b/apps/api/src/utils/wialonLocator.ts
@@ -16,7 +16,7 @@ const REPLACEMENT_CHAR = '\uFFFD';
 // Обработка локатора поддерживает «сырые» токены, не прошедшие base64-декодирование;
 // fallback срабатывает, если декодирование возвращает управляющие символы,
 // символ подстановки U+FFFD или результат не совпадает с исходным ключом после повторного кодирования.
-interface DecodeLocatorKeyResult {
+export interface DecodeLocatorKeyResult {
   token: string;
   fallback: boolean;
 }
@@ -53,7 +53,9 @@ function resolveBaseUrlFromLocator(url: URL, defaultBaseUrl?: string): string {
   return port ? `${base}:${port}` : base;
 }
 
-function decodeLocatorKeyDetailed(locatorKey: string): DecodeLocatorKeyResult {
+export function decodeLocatorKeyDetailed(
+  locatorKey: string,
+): DecodeLocatorKeyResult {
   const trimmed = locatorKey.trim();
   if (!trimmed) {
     throw new Error('Ключ локатора не может быть пустым');


### PR DESCRIPTION
## Summary
- ensure fleet recovery skips invalid locator tokens by detecting decode fallbacks
- expose locator key decode metadata for callers that need to distinguish fallback values

## Testing
- pnpm test:unit
- pnpm test:api
- pnpm lint
- ./scripts/setup_and_test.sh

------
https://chatgpt.com/codex/tasks/task_b_68ce386418448320a2677e5ac8db464e