### PR TITLE
feat: поддержка извлечения токена локатора из дополнительных источников

### DIFF
--- a/apps/api/tests/services/wialon.test.ts
+++ b/apps/api/tests/services/wialon.test.ts
@@ -51,6 +51,14 @@ describe('wialon service', () => {
     expect(parsed.token).toBe(originalToken);
   });
 
+  it('поддерживает параметр token', () => {
+    const locatorKey = Buffer.from('token-value-123', 'utf8').toString('base64');
+    const link = `https://hosting.wialon.com/locator?token=${locatorKey}`;
+    const parsed = parseLocatorLink(link);
+    expect(parsed.token).toBe('token-value-123');
+    expect(parsed.locatorKey).toBe(locatorKey);
+  });
+
   it('сохраняет сырой ключ при невозможности декодировать base64', () => {
     const rawKey = 'raw-token';
     const link = `https://hosting.wialon.com/locator?t=${rawKey}`;
@@ -73,6 +81,14 @@ describe('wialon service', () => {
     const parsed = parseLocatorLink(link);
     expect(parsed.token).toBe(rawKey);
     expect(parsed.locatorKey).toBe('-._~@:');
+  });
+
+  it('поддерживает токен в hash', () => {
+    const rawKey = 'raw-hash-token';
+    const link = `https://hosting.wialon.com/locator#token=${rawKey}`;
+    const parsed = parseLocatorLink(link);
+    expect(parsed.token).toBe(rawKey);
+    expect(parsed.locatorKey).toBe(rawKey);
   });
 
   it('использует сырой ключ если декодированный токен содержит непечатные символы', () => {


### PR DESCRIPTION
## Что сделано и зачем
- добавил нормализацию и поиск ключа локатора в параметрах `t`, `token` и фрагменте URL, чтобы парсинг охватывал все варианты ссылок
- расширил юнит-тесты сервиса Wialon, включая сценарии с `?token=` и `#token=`, для проверки fallback на сырые ключи
- убедился, что скрипт нормализации автопарков продолжает сохранять URL, ключ и токен из обновлённого парсера

## Чек-лист
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [ ] `pnpm run dev` (не запускается без доступной MongoDB, см. лог)

## Логи
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm run dev` → ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL (ts-node src/server.ts не может подключиться к БД)

## Самопроверка
- функции извлечения ключа возвращают нормализованное значение и не разрушают fallback для сырых токенов
- тесты покрывают базовые и сырые токены в query и hash
- скрипт нормализации автопарков по-прежнему переписывает токен, URL и ключ из результата парсера
- побочные артефакты сборки и тестов очищены перед коммитом

------
https://chatgpt.com/codex/tasks/task_b_68ce686548b083209693ed59636def90