### PR TITLE
fix: handle wialon query tokens with question marks

### DIFF
--- a/apps/api/src/utils/wialonLocator.ts
+++ b/apps/api/src/utils/wialonLocator.ts
@@ -35,7 +35,10 @@ function extractLocatorKeyFromComponent(component: string, keys: string[]): stri
   }
   const queryIndex = normalized.indexOf('?');
   if (queryIndex >= 0) {
-    normalized = normalized.slice(queryIndex + 1);
+    const equalsIndex = normalized.indexOf('=');
+    if (equalsIndex === -1 || queryIndex < equalsIndex) {
+      normalized = normalized.slice(queryIndex + 1);
+    }
   }
   normalized = normalized.replace(/^\/+/, '');
   if (!normalized) {


### PR DESCRIPTION
## Что сделано
- скорректировал извлечение параметров локатора, чтобы `?` внутри значения не обрезал имя ключа
- сохранил существующую обработку поиска параметров `t` и `token`

## Почему
- ссылка `https://…?t=???` воспринималась как отсутствие параметра и сервис возвращал неверную ошибку

## Проверки
- [x] `pnpm lint`
- [x] `pnpm test:unit`
- [x] `pnpm build`
- [ ] `pnpm run dev` (не запускал: задача не затрагивает dev-сервер)

## Логи
- `pnpm lint`
- `pnpm test:unit`
- `pnpm build`

## Самопроверка
- ошибки линтера отсутствуют
- юнит-тесты проходят локально
- сборка завершается успешно
- функционал не требует миграций

## Риски
- минимальные: изменение затронуло только парсинг ссылок, при откате достаточно вернуть прежнюю функцию


------
https://chatgpt.com/codex/tasks/task_b_68ce6f1d04148320808c98bb773e15cc