### PR TITLE
feat: support JSON Wialon locator tokens

### DIFF
--- a/apps/api/tests/services/wialon.test.ts
+++ b/apps/api/tests/services/wialon.test.ts
@@ -91,6 +91,26 @@ describe('wialon service', () => {
     expect(parsed.locatorKey).toBe(rawKey);
   });
 
+  it('извлекает токен из JSON в hash', () => {
+    const rawKey = 'json-token';
+    const payload = encodeURIComponent(JSON.stringify({ token: rawKey, map: 1 }));
+    const link = `https://hosting.wialon.com/locator/index.html#${payload}`;
+    const parsed = parseLocatorLink(link);
+    expect(parsed.token).toBe(rawKey);
+    expect(parsed.locatorKey).toBe(rawKey);
+  });
+
+  it('находит токен во вложенном JSON', () => {
+    const rawKey = 'nested-token';
+    const payload = encodeURIComponent(
+      JSON.stringify({ options: { params: { token: rawKey } } }),
+    );
+    const link = `https://hosting.wialon.com/locator/index.html#${payload}`;
+    const parsed = parseLocatorLink(link);
+    expect(parsed.token).toBe(rawKey);
+    expect(parsed.locatorKey).toBe(rawKey);
+  });
+
   it('использует сырой ключ если декодированный токен содержит непечатные символы', () => {
     const rawKey = 'fb4bcbccf4815a386eface22e0afc0b0524DE7B5134AB9B26EAAA61C328F1558C5AB5967';
     const link = `https://wialon.gps-garant.com.ua/locator/index.html?t=${rawKey}`;


### PR DESCRIPTION
## Что сделано
- Добавил обход JSON-структур в утилиту `wialonLocator`, чтобы находить токен Wialon в ссылках `locator/index.html#{...}`.
- Дополнил unit-тесты сервиса Wialon сценариями с JSON-якорями и вложенными объектами.

## Почему
- Пользователи вставляют ссылки Wialon с токеном в JSON-якоре, из-за чего синхронизация автопарков не выполнялась.

## Проверки
- [x] `./scripts/setup_and_test.sh`
- [x] `pnpm lint`
- [x] `pnpm build`
- [ ] `pnpm run dev` (API падает без MongoDB; запуск возможен в рабочей среде)

## Логи
- `./scripts/setup_and_test.sh` → Test Suites: 70 passed, coverage собрана (Locust отсутствует в окружении).
- `pnpm lint` → команда прошла без ошибок.
- `pnpm build` → сборка выполнена, инициализация БД пропущена из-за недоступной MongoDB.
- `pnpm run dev` → `ts-node src/server.ts` завершился с кодом 1 (нужна MongoDB для API).

## Самопроверка
- Новые кейсы в тестах воспроизводят проблему и падают на старой версии.
- Обход JSON ограничен глубиной, чтобы избежать рекурсии.
- Обработка ссылок без токена не изменилась.
- Поведение парсера при некорректных символах осталось прежним.

------
https://chatgpt.com/codex/tasks/task_b_68ce78a5dfb88320b4fa38700b6f70c3