### PR TITLE
feat: inject CSP nonces into inline scripts

### DIFF
--- a/apps/api/src/api/routes.ts
+++ b/apps/api/src/api/routes.ts
@@ -189,6 +189,7 @@ export default async function registerRoutes(
     express.static(path.join(__dirname, '../../public'), {
       maxAge: '1y',
       immutable: true,
+      index: false,
       // Для HTML отключаем кэш, чтобы браузер получал свежий index.html
       setHeaders(res, filePath) {
         if (filePath.endsWith('.html')) {

--- a/apps/api/src/api/security.ts
+++ b/apps/api/src/api/security.ts
@@ -50,10 +50,8 @@ export default function applySecurity(app: express.Express): void {
   type ResWithNonce = ServerResponse & { locals: { cspNonce: string } };
   const scriptSrc = [
     "'self'",
-    "'unsafe-inline'",
     (_req: IncomingMessage, res: ServerResponse) =>
       `'nonce-${(res as ResWithNonce).locals.cspNonce}'`,
-    "'sha256-2/O23rVGzYb9aZ8tq1s0n2ikD9CzHyqf5NS+VJWXcDI='",
     'https://telegram.org',
     ...parseList(process.env.CSP_SCRIPT_SRC_ALLOWLIST),
   ];
@@ -61,8 +59,6 @@ export default function applySecurity(app: express.Express): void {
   const styleSrc = [
     "'self'",
     "'unsafe-inline'",
-    (_req: IncomingMessage, res: ServerResponse) =>
-      `'nonce-${(res as ResWithNonce).locals.cspNonce}'`,
     ...parseList(process.env.CSP_STYLE_SRC_ALLOWLIST),
   ];
 

--- a/apps/web/plugins/inlineNonce.ts
+++ b/apps/web/plugins/inlineNonce.ts
@@ -1,0 +1,40 @@
+/* Назначение файла: плагин Vite, добавляющий placeholder nonce для встроенных скриптов и стилей. */
+import type { Plugin } from "vite";
+import { load } from "cheerio";
+import { resolve } from "node:path";
+import { writeFileSync } from "node:fs";
+
+const PLACEHOLDER = "__CSP_NONCE__";
+
+export default function inlineNonce(): Plugin {
+  return {
+    name: "inline-nonce-placeholder",
+    apply: "build",
+    enforce: "post",
+    writeBundle(options, bundle) {
+      Object.values(bundle)
+        .filter(
+          (item) => item.type === "asset" && item.fileName.endsWith(".html"),
+        )
+        .forEach((htmlAsset) => {
+          const asset = htmlAsset as { source: string };
+          const source = asset.source;
+          const $ = load(source);
+          $("script:not([src])").each((_, el) => {
+            if (!el.attribs.nonce) {
+              el.attribs.nonce = PLACEHOLDER;
+            }
+          });
+          $("style").each((_, el) => {
+            if (!el.attribs.nonce) {
+              el.attribs.nonce = PLACEHOLDER;
+            }
+          });
+          const html = $.html();
+          asset.source = html;
+          const filePath = resolve(options.dir ?? "", htmlAsset.fileName);
+          writeFileSync(filePath, html);
+        });
+    },
+  };
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -11,6 +11,7 @@ import legacy from "@vitejs/plugin-legacy";
 import { resolve } from "path";
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import sri from "./plugins/sri";
+import inlineNonce from "./plugins/inlineNonce";
 import { visualizer } from "rollup-plugin-visualizer";
 import { ViteImageOptimizer } from "vite-plugin-image-optimizer";
 
@@ -62,6 +63,7 @@ export default defineConfig(() => {
     plugins: [
       react(),
       legacy(),
+      inlineNonce(),
       sri(),
       ViteImageOptimizer(),
       process.env.ANALYZE


### PR DESCRIPTION
## Summary
- add a Vite post-build plugin that injects the `__CSP_NONCE__` placeholder into inline scripts and styles so the backend can replace it at runtime
- adjust the API security middleware to rely on nonces for scripts, keep inline styles allowed, and prevent the static middleware from short-circuiting the nonce injection
- register the new plugin in the Vite config so builds automatically receive CSP-compatible markup

## Testing
- `pnpm build`
- `pnpm lint`
- `pnpm test`

## Self-check
- [x] I verified the CSP warnings in the local browser console disappeared after the change
- [x] I confirmed that inline scripts receive a nonce in the rendered HTML
- [x] I kept build artefacts out of the commit

## Risks
- Cache might still hold the old HTML without nonce attributes; invalidate CDN caches or restart the web process during rollout. Revert by removing the new plugin import and reverting the CSP config.


------
https://chatgpt.com/codex/tasks/task_b_68ce9a5423188320aaddac0f4dbb7082