### PR TITLE
feat: регистронезависимый парсинг ключа Wialon

### DIFF
--- a/apps/api/src/utils/wialonLocator.ts
+++ b/apps/api/src/utils/wialonLocator.ts
@@ -116,7 +116,8 @@ function extractLocatorKeyFromComponent(component: string, keys: string[]): stri
         jsonCandidates.push(pair);
         continue;
       }
-      if (name !== key) {
+      const normalizedName = name.toLowerCase();
+      if (normalizedName !== key) {
         if (!rawValueParts.length) {
           jsonCandidates.push(pair);
         }
@@ -154,11 +155,12 @@ function extractLocatorKeyFromComponent(component: string, keys: string[]): stri
 
 function resolveLocatorKey(url: URL): string | null {
   const keys = ['t', 'token'];
-  const fromSearch = extractLocatorKeyFromComponent(url.search, keys);
+  const normalizedKeys = keys.map((key) => key.toLowerCase());
+  const fromSearch = extractLocatorKeyFromComponent(url.search, normalizedKeys);
   if (fromSearch) {
     return fromSearch;
   }
-  return extractLocatorKeyFromComponent(url.hash, keys);
+  return extractLocatorKeyFromComponent(url.hash, normalizedKeys);
 }
 
 // Обработка локатора поддерживает «сырые» токены, не прошедшие base64-декодирование;

--- a/apps/api/tests/services/wialon.test.ts
+++ b/apps/api/tests/services/wialon.test.ts
@@ -59,6 +59,14 @@ describe('wialon service', () => {
     expect(parsed.locatorKey).toBe(locatorKey);
   });
 
+  it('поддерживает параметр T в верхнем регистре', () => {
+    const locatorKey = Buffer.from('token-upper', 'utf8').toString('base64');
+    const link = `https://hosting.wialon.com/locator?T=${locatorKey}`;
+    const parsed = parseLocatorLink(link);
+    expect(parsed.token).toBe('token-upper');
+    expect(parsed.locatorKey).toBe(locatorKey);
+  });
+
   it('сохраняет сырой ключ при невозможности декодировать base64', () => {
     const rawKey = 'raw-token';
     const link = `https://hosting.wialon.com/locator?t=${rawKey}`;


### PR DESCRIPTION
## Что сделано
- нормализовал имена параметров при разборе компонентов Wialon-локатора
- передал в `resolveLocatorKey` приведённые к нижнему регистру ключи
- добавил юнит-тест на поддержку параметра `T` в верхнем регистре

## Почему
- ссылки Wialon могут содержать параметр `T` в любом регистре; без нормализации ключ не находился и токен не извлекался

## Чек-лист
- [x] `pnpm lint`
- [x] `pnpm test`

## Логи
- локально `pnpm lint`
- локально `pnpm test`

## Самопроверка
- требования задачи покрыты
- новые тесты подтверждают регистронезависимость
- локальные проверки прошли успешно

------
https://chatgpt.com/codex/tasks/task_b_68cedcb72d0c8320ad41a54f39cee7c7