### PR TITLE
feat: normalize Wialon locator JSON tokens

### DIFF
--- a/apps/api/src/db/models/fleet.ts
+++ b/apps/api/src/db/models/fleet.ts
@@ -404,9 +404,9 @@ export async function ensureFleetFields(
   }
   if (fleet.locatorKey) {
     try {
-      const decoded = decodeLocatorKey(fleet.locatorKey);
-      if (decoded !== fleet.token) {
-        fleet.token = decoded;
+      const decoded = decodeLocatorKeyDetailed(fleet.locatorKey);
+      if (decoded.token !== fleet.token) {
+        fleet.token = decoded.token;
         changed = true;
       }
     } catch (error) {

--- a/apps/api/src/services/wialon.ts
+++ b/apps/api/src/services/wialon.ts
@@ -195,7 +195,12 @@ function normalizeTrackPoint(point: WialonTrackPointRaw): TrackPoint {
 }
 
 export async function login(token: string, baseUrl?: string): Promise<WialonLoginResult> {
-  return request<WialonLoginResult>('token/login', { token }, { baseUrl });
+  const normalizedToken = decodeLocatorKey(token);
+  return request<WialonLoginResult>(
+    'token/login',
+    { token: normalizedToken },
+    { baseUrl },
+  );
 }
 
 export async function loadUnits(


### PR DESCRIPTION
## Что сделано
- добавил поиск поля token в JSON-полезной нагрузке после base64-декодирования локатора и переиспользовал существующие парсеры
- нормализовал использование токена в ensureFleetFields и login, чтобы в запросы Wialon уходила очищенная строка
- дополнил unit-тест wialon сервисов проверкой авторизации с base64-JSON локатором

## Зачем
- Wialon получает токен без обёртки JSON, даже если локатор хранит его в таком виде

## Чек-лист
- [x] ./scripts/setup_and_test.sh

## Логи ключевых команд
- `./scripts/setup_and_test.sh`

## Самопроверка
- [x] Новые тесты падают на старом коде
- [x] Поддержаны существующие кейсы локатора (query/hash)
- [x] Токен в login всегда проходит через decodeLocatorKey
- [x] В ensureFleetFields сохраняется нормализованный токен
- [x] Добавлены необходимые импорты и проверки

------
https://chatgpt.com/codex/tasks/task_b_68ceeddecdc4832086697809c5863346