### PR TITLE
feat: densify tables and task dialog layout

### DIFF
--- a/apps/web/src/components/DataTable.tsx
+++ b/apps/web/src/components/DataTable.tsx
@@ -65,11 +65,11 @@ export default function DataTable<T>({
   });
 
   return (
-    <div className="space-y-1 font-ui text-[13px] sm:text-sm">
+    <div className="space-y-0.5 font-ui text-[13px] sm:text-sm">
       <TableToolbar table={table as TableType<T>}>
         {toolbarChildren}
       </TableToolbar>
-      <Table>
+      <Table className="text-left">
         <TableHeader>
           {table.getHeaderGroups().map((hg) => (
             <TableRow key={hg.id}>
@@ -129,7 +129,7 @@ export default function DataTable<T>({
           ))}
         </TableBody>
       </Table>
-      <div className="flex flex-col gap-1.5 text-xs sm:flex-row sm:items-center sm:justify-between sm:text-sm">
+      <div className="flex flex-col gap-1 text-xs sm:flex-row sm:items-center sm:justify-between sm:text-sm">
         <div className="flex flex-wrap items-center gap-1">
           <button
             onClick={() => onPageChange(Math.max(0, pageIndex - 1))}

--- a/apps/web/src/components/TaskDialog.tsx
+++ b/apps/web/src/components/TaskDialog.tsx
@@ -763,11 +763,11 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/50 p-4">
       <div
-        className={`w-full ${expanded ? "max-w-screen-xl" : "max-w-screen-md"} mx-auto space-y-2 rounded-xl bg-white p-4 shadow-lg`}
+        className={`w-full ${expanded ? "max-w-screen-xl" : "max-w-screen-md"} mx-auto space-y-1.5 rounded-xl bg-white p-4 shadow-lg`}
       >
         <div className="flex items-center justify-between">
           <h3 className="text-lg font-semibold">{t("task")}</h3>
-          <div className="flex space-x-2">
+          <div className="flex flex-wrap gap-2">
             {isEdit && !editing && (
               <button
                 onClick={() => setEditing(true)}
@@ -809,7 +809,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
           </div>
         </div>
         <>
-          <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+          <div className="grid grid-cols-1 gap-2 md:[grid-template-columns:repeat(auto-fit,minmax(220px,1fr))]">
             <div>
               <label className="block text-sm font-medium">
                 {t("taskNumber")}
@@ -817,7 +817,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               <input
                 value={requestId}
                 disabled
-                className="focus:ring-brand-200 focus:border-accentPrimary w-full rounded-lg border bg-gray-100 px-3 py-2 text-sm focus:ring focus:outline-none"
+                className="focus:ring-brand-200 focus:border-accentPrimary w-full rounded-md border bg-gray-100 px-2.5 py-1.5 text-sm focus:outline-none focus:ring"
               />
             </div>
             <div>
@@ -827,7 +827,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               <input
                 value={created}
                 disabled
-                className="focus:ring-brand-200 focus:border-accentPrimary w-full rounded-lg border bg-gray-100 px-3 py-2 text-sm focus:ring focus:outline-none"
+                className="focus:ring-brand-200 focus:border-accentPrimary w-full rounded-md border bg-gray-100 px-2.5 py-1.5 text-sm focus:outline-none focus:ring"
               />
             </div>
           </div>
@@ -847,14 +847,14 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
             <input
               {...register("title")}
               placeholder={t("title")}
-              className="focus:ring-brand-200 focus:border-accentPrimary w-full rounded-lg border bg-gray-100 px-3 py-2 text-sm focus:ring focus:outline-none"
+              className="focus:ring-brand-200 focus:border-accentPrimary w-full rounded-md border bg-gray-100 px-2.5 py-1.5 text-sm focus:outline-none focus:ring"
               disabled={!editing}
             />
             {errors.title && (
               <p className="text-sm text-red-600">{errors.title.message}</p>
             )}
           </div>
-          <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-3 md:[grid-template-columns:repeat(auto-fit,minmax(220px,1fr))]">
             <div>
               <label className="block text-sm font-medium">
                 {t("startDate")}
@@ -862,7 +862,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               <input
                 type="datetime-local"
                 {...register("startDate")}
-                className="w-full rounded border px-2 py-1"
+                className="w-full rounded-md border px-2.5 py-1.5 text-sm focus:outline-none focus:ring focus:ring-brand-200 focus:border-accentPrimary"
                 disabled={!editing}
               />
             </div>
@@ -873,18 +873,18 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               <input
                 type="datetime-local"
                 {...register("dueDate", { onChange: handleDueDateChange })}
-                className="w-full rounded border px-2 py-1"
+                className="w-full rounded-md border px-2.5 py-1.5 text-sm focus:outline-none focus:ring focus:ring-brand-200 focus:border-accentPrimary"
                 disabled={!editing}
               />
             </div>
           </div>
-          <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-3 md:[grid-template-columns:repeat(auto-fit,minmax(220px,1fr))]">
             <div>
               <label className="block text-sm font-medium">{t("status")}</label>
               <select
                 value={status}
                 onChange={(e) => setStatus(e.target.value)}
-                className="w-full rounded border px-2 py-1"
+                className="w-full rounded-md border px-2.5 py-1.5 text-sm focus:outline-none focus:ring focus:ring-brand-200 focus:border-accentPrimary"
                 disabled={!editing}
               >
                 {statuses.map((s) => (
@@ -901,7 +901,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               <select
                 value={priority}
                 onChange={(e) => setPriority(e.target.value)}
-                className="w-full rounded border px-2 py-1"
+                className="w-full rounded-md border px-2.5 py-1.5 text-sm focus:outline-none focus:ring focus:ring-brand-200 focus:border-accentPrimary"
                 disabled={!editing}
               >
                 {priorities.map((p) => (
@@ -912,7 +912,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               </select>
             </div>
           </div>
-          <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-3 md:[grid-template-columns:repeat(auto-fit,minmax(220px,1fr))]">
             <div>
               <label className="block text-sm font-medium">
                 {t("taskType")}
@@ -920,7 +920,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               <select
                 value={taskType}
                 onChange={(e) => setTaskType(e.target.value)}
-                className="w-full rounded border px-2 py-1"
+                className="w-full rounded-md border px-2.5 py-1.5 text-sm focus:outline-none focus:ring focus:ring-brand-200 focus:border-accentPrimary"
                 disabled={!editing}
               >
                 {types.map((t) => (
@@ -937,7 +937,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               <select
                 value={department}
                 onChange={(e) => setDepartment(e.target.value)}
-                className="w-full rounded border px-2 py-1"
+                className="w-full rounded-md border px-2.5 py-1.5 text-sm focus:outline-none focus:ring focus:ring-brand-200 focus:border-accentPrimary"
                 disabled={!editing}
               >
                 <option value="">{t("selectOption")}</option>
@@ -949,7 +949,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               </select>
             </div>
           </div>
-          <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-3 md:[grid-template-columns:repeat(auto-fit,minmax(220px,1fr))]">
             <div>
               <label className="block text-sm font-medium">
                 {t("creator")}
@@ -957,7 +957,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               <select
                 value={creator}
                 onChange={(e) => setCreator(e.target.value)}
-                className="w-full rounded border px-2 py-1"
+                className="w-full rounded-md border px-2.5 py-1.5 text-sm focus:outline-none focus:ring focus:ring-brand-200 focus:border-accentPrimary"
                 disabled={!editing}
               >
                 <option value="">{t("author")}</option>
@@ -982,13 +982,13 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               )}
             />
           </div>
-          <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-3 md:[grid-template-columns:repeat(auto-fit,minmax(220px,1fr))]">
             <div>
               <label className="block text-sm font-medium">
                 {t("startPoint")}
               </label>
               {startLink ? (
-                <div className="flex items-center space-x-2">
+                <div className="flex items-center gap-2">
                   <div className="flex flex-col">
                     <a
                       href={DOMPurify.sanitize(startLink)}
@@ -1015,14 +1015,14 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
                   )}
                 </div>
               ) : (
-                <div className="mt-1 flex space-x-2">
-                  <input
-                    value={startLink}
-                    onChange={(e) => handleStartLink(e.target.value)}
-                    placeholder={t("googleMapsLink")}
-                    className="flex-1 rounded border px-2 py-1"
-                    disabled={!editing}
-                  />
+                <div className="mt-1 flex gap-2">
+                    <input
+                      value={startLink}
+                      onChange={(e) => handleStartLink(e.target.value)}
+                      placeholder={t("googleMapsLink")}
+                      className="flex-1 rounded-md border px-2.5 py-1.5 text-sm focus:outline-none focus:ring focus:ring-brand-200 focus:border-accentPrimary"
+                      disabled={!editing}
+                    />
                   <a
                     href="https://maps.app.goo.gl/xsiC9fHdunCcifQF6"
                     target="_blank"
@@ -1039,7 +1039,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
                 {t("endPoint")}
               </label>
               {endLink ? (
-                <div className="flex items-center space-x-2">
+                <div className="flex items-center gap-2">
                   <div className="flex flex-col">
                     <a
                       href={DOMPurify.sanitize(endLink)}
@@ -1066,14 +1066,14 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
                   )}
                 </div>
               ) : (
-                <div className="mt-1 flex space-x-2">
-                  <input
-                    value={endLink}
-                    onChange={(e) => handleEndLink(e.target.value)}
-                    placeholder={t("googleMapsLink")}
-                    className="flex-1 rounded border px-2 py-1"
-                    disabled={!editing}
-                  />
+                <div className="mt-1 flex gap-2">
+                    <input
+                      value={endLink}
+                      onChange={(e) => handleEndLink(e.target.value)}
+                      placeholder={t("googleMapsLink")}
+                      className="flex-1 rounded-md border px-2.5 py-1.5 text-sm focus:outline-none focus:ring focus:ring-brand-200 focus:border-accentPrimary"
+                      disabled={!editing}
+                    />
                   <a
                     href="https://maps.app.goo.gl/xsiC9fHdunCcifQF6"
                     target="_blank"
@@ -1086,7 +1086,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               )}
             </div>
           </div>
-          <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-3 md:[grid-template-columns:repeat(auto-fit,minmax(220px,1fr))]">
             <div>
               <label className="block text-sm font-medium">
                 {t("transportType")}
@@ -1094,7 +1094,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               <select
                 value={transportType}
                 onChange={(e) => setTransportType(e.target.value)}
-                className="w-full rounded border px-2 py-1"
+                className="w-full rounded-md border px-2.5 py-1.5 text-sm focus:outline-none focus:ring focus:ring-brand-200 focus:border-accentPrimary"
                 disabled={!editing}
               >
                 {transports.map((t) => (
@@ -1111,7 +1111,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               <select
                 value={paymentMethod}
                 onChange={(e) => setPaymentMethod(e.target.value)}
-                className="w-full rounded border px-2 py-1"
+                className="w-full rounded-md border px-2.5 py-1.5 text-sm focus:outline-none focus:ring focus:ring-brand-200 focus:border-accentPrimary"
                 disabled={!editing}
               >
                 {payments.map((p) => (
@@ -1122,7 +1122,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               </select>
             </div>
           </div>
-          <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-3 md:[grid-template-columns:repeat(auto-fit,minmax(220px,1fr))]">
             {distanceKm !== null && (
               <div>
                 <label className="block text-sm font-medium">
@@ -1303,7 +1303,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
                         setShowDoneConfirm(true);
                       }
                     }}
-                    className="mt-1 mb-2 w-full rounded border px-2 py-1"
+                    className="mt-1 mb-2 w-full rounded-md border px-2.5 py-1.5 text-sm focus:outline-none focus:ring focus:ring-brand-200 focus:border-accentPrimary"
                   >
                     <option value="">{t("selectOption")}</option>
                     {doneOptions.map((o) => (

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -10,12 +10,12 @@ function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (
     <div
       data-slot="table-container"
-      className="relative w-full overflow-x-auto"
+      className="relative w-full overflow-x-auto rounded-xl border border-slate-200 shadow-sm"
     >
       <table
         data-slot="table"
         className={cn(
-          "w-full caption-bottom text-[12px] leading-tight text-gray-900 table-auto font-ui",
+          "w-full caption-bottom text-[12px] leading-tight text-gray-900 table-auto font-ui border-collapse",
           "sm:text-[13px] md:table-fixed",
           className,
         )}
@@ -29,7 +29,7 @@ function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
   return (
     <thead
       data-slot="table-header"
-      className={cn("[&_tr]:border-b", className)}
+      className={cn("bg-slate-50", className)}
       {...props}
     />
   );
@@ -63,7 +63,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
     <tr
       data-slot="table-row"
       className={cn(
-        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        "hover:bg-slate-100 data-[state=selected]:bg-slate-100 transition-colors",
         "min-h-[2rem] text-[12px] sm:min-h-[2.25rem] sm:text-sm",
         className,
       )}
@@ -77,7 +77,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "text-foreground px-1.5 py-1.5 text-left align-middle font-semibold",
+        "text-foreground border border-slate-200 px-2 py-2 text-left align-middle font-semibold",
         "text-[11px] leading-snug sm:px-2.5 sm:text-[13px]",
         "whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
@@ -92,7 +92,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "px-1.5 py-1.5 align-top text-[12px] leading-snug",
+        "border border-slate-200 px-2 py-1.5 align-top text-[12px] leading-snug",
         "sm:px-2.5 sm:py-2 sm:text-sm",
         "whitespace-normal [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,


### PR DESCRIPTION
## Summary
- add compact bordered styling to shared table components for denser data grids
- reorganize task dialog layout with auto-fit grids and slimmer controls to reduce unused space

## Testing
- pnpm lint
- pnpm test
- pnpm run dev *(fails: telegram-task-bot@1.0.0 dev requires backend services; see logs)*

## Checklist
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Dev server *(fails in local container without backend)*
- [x] Backward compatible

## Risk Notes
- visual density changes may require UX validation; revert by restoring table and dialog classes if users prefer previous spacing.


------
https://chatgpt.com/codex/tasks/task_b_68cf9dfa3e84832088d7e3d547e71d18