### PR TITLE
fix: handle hashbang tokens in wialon locator

### DIFF
--- a/apps/api/src/utils/wialonLocator.ts
+++ b/apps/api/src/utils/wialonLocator.ts
@@ -91,6 +91,10 @@ function extractLocatorKeyFromComponent(component: string, keys: string[]): stri
   if (!normalized) {
     return null;
   }
+  normalized = normalized.replace(/^!+/, '');
+  if (!normalized) {
+    return null;
+  }
   const queryIndex = normalized.indexOf('?');
   if (queryIndex >= 0) {
     const equalsIndex = normalized.indexOf('=');

--- a/apps/api/tests/services/wialon.test.ts
+++ b/apps/api/tests/services/wialon.test.ts
@@ -119,6 +119,23 @@ describe('wialon service', () => {
     expect(parsed.locatorKey).toBe(rawKey);
   });
 
+  it('поддерживает hashbang с параметром token', () => {
+    const rawKey = 'hashbang-token';
+    const link = `https://hosting.wialon.com/locator#!/token=${rawKey}`;
+    const parsed = parseLocatorLink(link);
+    expect(parsed.token).toBe(rawKey);
+    expect(parsed.locatorKey).toBe(rawKey);
+  });
+
+  it('поддерживает hashbang с параметром t', () => {
+    const token = 'hashbang-t';
+    const locatorKey = Buffer.from(token, 'utf8').toString('base64');
+    const link = `https://hosting.wialon.com/locator#!/?t=${locatorKey}`;
+    const parsed = parseLocatorLink(link);
+    expect(parsed.token).toBe(token);
+    expect(parsed.locatorKey).toBe(locatorKey);
+  });
+
   it('извлекает токен из JSON в hash', () => {
     const rawKey = 'json-token';
     const payload = encodeURIComponent(JSON.stringify({ token: rawKey, map: 1 }));


### PR DESCRIPTION
## Summary
- remove hashbang markers before parsing locator key pairs so hash fragments with `!` normalize correctly
- add regression tests covering `#!/token=` and `#!/?t=` combinations to ensure locator parsing stays stable

## Testing
- `pnpm lint`
- `pnpm test:unit`
- `pnpm test:api`
- `pnpm build`

## Checklist
- [x] Lint
- [x] Unit tests
- [x] API tests
- [x] Build
- [ ] E2E tests
- [x] Backwards compatible

## Self-check
- [x] Сохранены русские сообщения об ошибках
- [x] Нет лишних зависимостей
- [x] Новые тесты падают на старом коде
- [x] Чистая рабочая директория перед сдачей

------
https://chatgpt.com/codex/tasks/task_b_68cfa572cb0883209a161da7d4954b3e