### PR TITLE
feat: handle invalid locator query parameter

### DIFF
--- a/apps/api/src/utils/wialonLocator.ts
+++ b/apps/api/src/utils/wialonLocator.ts
@@ -137,7 +137,7 @@ function extractLocatorKeyFromComponent(component: string, keys: string[]): stri
       try {
         value = decodeURIComponent(rawValue);
       } catch {
-        throw new Error('Ключ локатора содержит недопустимые символы');
+        continue;
       }
       const normalizedValue = normalizeLocatorKeyValue(value);
       if (!normalizedValue) {

--- a/tests/wialonLocator.spec.ts
+++ b/tests/wialonLocator.spec.ts
@@ -1,0 +1,25 @@
+/**
+ * Назначение файла: проверка разбора ссылок локатора с некорректными query-параметрами.
+ * Основные модули: utils/wialonLocator.
+ */
+import { parseLocatorLink } from '../apps/api/src/utils/wialonLocator';
+
+describe('Разбор ссылок локатора Wialon', () => {
+  test('использует hash, если query содержит некорректный параметр t', () => {
+    const link = 'https://example.com/?t=%ZZ#t=cmF3VG9rZW4xMjM=';
+
+    expect(() => parseLocatorLink(link)).not.toThrow();
+
+    const parsed = parseLocatorLink(link);
+    expect(parsed.locatorKey).toBe('cmF3VG9rZW4xMjM=');
+    expect(parsed.token).toBe('rawToken123');
+  });
+
+  test('использует token из hash при ошибке декодирования query-параметра t', () => {
+    const link = 'https://example.com/?t=%ZZ#token=cmF3VG9rZW4xMjM=';
+
+    const parsed = parseLocatorLink(link);
+    expect(parsed.locatorKey).toBe('cmF3VG9rZW4xMjM=');
+    expect(parsed.token).toBe('rawToken123');
+  });
+});


### PR DESCRIPTION
## Что сделано и почему
- обновлён разбор query-параметров локатора, чтобы некорректная percent-энкодинг последовательность не прерывала поиск ключа и позволяла перейти к hash
- добавлены модульные тесты, подтверждающие обработку ссылок с `t=%ZZ` в строке запроса и валидным токеном в hash

## Чек-лист
- [x] Локально пройдены тесты
- [x] Локально пройдён линтер
- [x] Локально собран проект
- [x] Обратная совместимость сохранена

## Логи ключевых команд
- `pnpm test:unit`
- `pnpm lint`
- `pnpm build`

## Самопроверка
- [x] Тесты воспроизводят кейс с некорректным query и валидным hash
- [x] Функция продолжает поиск после сбоя декодирования значения
- [x] Покрыт fallback на hash при отсутствии валидного ключа в query


------
https://chatgpt.com/codex/tasks/task_b_68cfaa06932483208935302b92f17089