### PR TITLE
refactor: split login bootstrapping from authenticated shell

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,189 +1,22 @@
 // Корневой компонент мини‑приложения ERM
-import React, { Suspense, lazy } from "react";
+import React, { Suspense, lazy, useEffect } from "react";
 import { useTranslation, I18nextProvider } from "react-i18next";
 import i18n from "./i18n";
 import {
   BrowserRouter as Router,
-  Routes,
-  Route,
-  Navigate,
   useLocation,
+  useNavigate,
 } from "react-router-dom";
-const TasksPage = lazy(() => import("./pages/TasksPage"));
-const Reports = lazy(() => import("./pages/Reports"));
-const LogsPage = lazy(() => import("./pages/Logs"));
-const Profile = lazy(() => import("./pages/Profile"));
-const TaskKanban = lazy(() => import("./pages/TaskKanban"));
-const CodeLogin = lazy(() => import("./pages/CodeLogin"));
-const AttachmentMenu = lazy(() => import("./pages/AttachmentMenu"));
-const RoutesPage = lazy(() => import("./pages/Routes"));
-const SettingsPage = lazy(() => import("./pages/Settings"));
-const ThemeSettings = lazy(() => import("./pages/ThemeSettings"));
-const StoragePage = lazy(() => import("./pages/Storage"));
-const EmployeeCard = lazy(() => import("./pages/EmployeeCard"));
-import Sidebar from "./layouts/Sidebar";
-import Header from "./layouts/Header";
-import { SidebarProvider } from "./context/SidebarContext";
-import { useSidebar } from "./context/useSidebar";
-import { AuthProvider } from "./context/AuthProvider";
-import { useAuth } from "./context/useAuth";
-import { TasksProvider } from "./context/TasksContext";
-import ProtectedRoute from "./components/ProtectedRoute";
-import AdminRoute from "./components/AdminRoute";
-import ManagerRoute from "./components/ManagerRoute";
-import TaskDialogRoute from "./components/TaskDialogRoute";
 import ErrorBoundary from "./components/ErrorBoundary";
 import AlertDialog from "./components/AlertDialog";
+import { AuthProvider } from "./context/AuthProvider";
+import { useAuth } from "./context/useAuth";
+import { ToastProvider } from "./context/ToastProvider";
 
-const ThemeProviderLazy = lazy(async () => {
-  const mod = await import("./context/ThemeProvider");
-  return { default: mod.ThemeProvider };
-});
-
-const ToastProviderLazy = lazy(async () => {
-  const mod = await import("./context/ToastProvider");
-  return { default: mod.ToastProvider };
-});
-
+const AuthenticatedApp = lazy(() => import("./AuthenticatedApp"));
+const CodeLogin = lazy(() => import("./pages/CodeLogin"));
+const AttachmentMenu = lazy(() => import("./pages/AttachmentMenu"));
 const ToastsLazy = lazy(() => import("./components/Toasts"));
-
-function AppShell() {
-  const { user } = useAuth();
-  const { collapsed, open, toggle } = useSidebar();
-  const { t } = useTranslation();
-  return (
-    <>
-      {user && <Sidebar />}
-      {user && open && (
-        <div
-          className="fixed inset-0 z-40 bg-black/40"
-          tabIndex={-1}
-          ref={(el) => el?.focus()}
-          onClick={() => {
-            (document.activeElement as HTMLElement | null)?.blur();
-            toggle();
-          }}
-        />
-      )}
-      {user && <Header />}
-      <main
-        className={`mt-14 p-4 transition-all ${open ? (collapsed ? "md:ml-20" : "md:ml-60") : "md:ml-0"}`}
-      >
-        <Suspense fallback={<div>{t("loading")}</div>}>
-          <Routes>
-            <Route path="/menu" element={<AttachmentMenu />} />
-            <Route
-              path="/profile"
-              element={
-                <ProtectedRoute>
-                  <Profile />
-                </ProtectedRoute>
-              }
-            />
-            <Route
-              path="/employees/:id"
-              element={
-                <ProtectedRoute>
-                  <EmployeeCard />
-                </ProtectedRoute>
-              }
-            />
-            <Route
-              path="/tasks"
-              element={
-                <ProtectedRoute>
-                  <TasksPage />
-                </ProtectedRoute>
-              }
-            />
-            <Route
-              path="/mg/kanban"
-              element={
-                <ManagerRoute>
-                  <TaskKanban />
-                </ManagerRoute>
-              }
-            />
-            <Route
-              path="/mg/reports"
-              element={
-                <ManagerRoute>
-                  <Reports />
-                </ManagerRoute>
-              }
-            />
-            <Route
-              path="/mg/routes"
-              element={
-                <ManagerRoute>
-                  <RoutesPage />
-                </ManagerRoute>
-              }
-            />
-            <Route
-              path="/cp/kanban"
-              element={
-                <AdminRoute>
-                  <TaskKanban />
-                </AdminRoute>
-              }
-            />
-            <Route
-              path="/cp/reports"
-              element={
-                <AdminRoute>
-                  <Reports />
-                </AdminRoute>
-              }
-            />
-            <Route
-              path="/cp/routes"
-              element={
-                <AdminRoute>
-                  <RoutesPage />
-                </AdminRoute>
-              }
-            />
-            <Route
-              path="/cp/settings"
-              element={
-                <AdminRoute>
-                  <SettingsPage />
-                </AdminRoute>
-              }
-            />
-            <Route
-              path="/cp/logs"
-              element={
-                <AdminRoute>
-                  <LogsPage />
-                </AdminRoute>
-              }
-            />
-            <Route
-              path="/cp/storage"
-              element={
-                <AdminRoute>
-                  <StoragePage />
-                </AdminRoute>
-              }
-            />
-            <Route
-              path="/theme"
-              element={
-                <ProtectedRoute>
-                  <ThemeSettings />
-                </ProtectedRoute>
-              }
-            />
-            <Route path="*" element={<Navigate to="/tasks" />} />
-          </Routes>
-        </Suspense>
-      </main>
-      <TaskDialogRoute />
-    </>
-  );
-}
 
 function LoginLayout() {
   const { t } = useTranslation();
@@ -198,28 +31,10 @@ function LoginLayout() {
   );
 }
 
-function AuthenticatedArea({ alert }: { alert: React.ReactNode }) {
+function GlobalToasts() {
   return (
     <Suspense fallback={null}>
-      <ThemeProviderLazy>
-        <Suspense fallback={null}>
-          <ToastProviderLazy>
-            <ErrorBoundary fallback={<div>Произошла ошибка</div>}>
-              <Suspense fallback={null}>
-                <ToastsLazy />
-              </Suspense>
-              <AuthProvider>
-                <SidebarProvider>
-                  <TasksProvider>
-                    <AppShell />
-                  </TasksProvider>
-                </SidebarProvider>
-              </AuthProvider>
-              {alert}
-            </ErrorBoundary>
-          </ToastProviderLazy>
-        </Suspense>
-      </ThemeProviderLazy>
+      <ToastsLazy />
     </Suspense>
   );
 }
@@ -232,6 +47,19 @@ function AppContent({
   onCloseAlert: () => void;
 }) {
   const location = useLocation();
+  const navigate = useNavigate();
+  const { user, loading } = useAuth();
+  const { t } = useTranslation();
+  const isLogin = location.pathname.startsWith("/login");
+  const isAttachmentMenu = location.pathname.startsWith("/menu");
+  useEffect(() => {
+    if (loading || isAttachmentMenu) return;
+    if (!user && !isLogin) {
+      navigate("/login", { replace: true });
+    } else if (user && isLogin) {
+      navigate("/tasks", { replace: true });
+    }
+  }, [isAttachmentMenu, isLogin, loading, navigate, user]);
   const alert = (
     <AlertDialog
       open={!!initialAlert}
@@ -240,7 +68,29 @@ function AppContent({
       closeText={i18n.t("close")}
     />
   );
-  if (location.pathname.startsWith("/login")) {
+  if (isAttachmentMenu) {
+    return (
+      <>
+        <ErrorBoundary fallback={<div>Произошла ошибка</div>}>
+          <Suspense fallback={<div>{t("loading")}</div>}>
+            <AttachmentMenu />
+          </Suspense>
+        </ErrorBoundary>
+        {alert}
+      </>
+    );
+  }
+  if (loading) {
+    return (
+      <>
+        <main className="flex min-h-screen items-center justify-center bg-slate-50 p-4">
+          <div>{t("loading")}</div>
+        </main>
+        {alert}
+      </>
+    );
+  }
+  if (!user) {
     return (
       <>
         <ErrorBoundary fallback={<div>Произошла ошибка</div>}>
@@ -250,7 +100,11 @@ function AppContent({
       </>
     );
   }
-  return <AuthenticatedArea alert={alert} />;
+  return (
+    <Suspense fallback={<div>{t("loading")}</div>}>
+      <AuthenticatedApp alert={alert} />
+    </Suspense>
+  );
 }
 
 export default function App() {
@@ -261,12 +115,17 @@ export default function App() {
   );
   return (
     <I18nextProvider i18n={i18n}>
-      <Router>
-        <AppContent
-          initialAlert={initialAlert}
-          onCloseAlert={() => setInitialAlert(null)}
-        />
-      </Router>
+      <ToastProvider>
+        <AuthProvider>
+          <Router>
+            <GlobalToasts />
+            <AppContent
+              initialAlert={initialAlert}
+              onCloseAlert={() => setInitialAlert(null)}
+            />
+          </Router>
+        </AuthProvider>
+      </ToastProvider>
     </I18nextProvider>
   );
 }

--- a/apps/web/src/AuthenticatedApp.tsx
+++ b/apps/web/src/AuthenticatedApp.tsx
@@ -1,0 +1,192 @@
+// Назначение файла: оболочка авторизованной части приложения и маршрутизация после входа.
+// Основные модули: React, React Router, контексты приложения.
+import React, { Suspense, lazy } from "react";
+import { Routes, Route, Navigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import Sidebar from "./layouts/Sidebar";
+import Header from "./layouts/Header";
+import { SidebarProvider } from "./context/SidebarContext";
+import { useSidebar } from "./context/useSidebar";
+import { TasksProvider } from "./context/TasksContext";
+import { useAuth } from "./context/useAuth";
+import ProtectedRoute from "./components/ProtectedRoute";
+import AdminRoute from "./components/AdminRoute";
+import ManagerRoute from "./components/ManagerRoute";
+import TaskDialogRoute from "./components/TaskDialogRoute";
+import ErrorBoundary from "./components/ErrorBoundary";
+
+const TasksPage = lazy(() => import("./pages/TasksPage"));
+const Reports = lazy(() => import("./pages/Reports"));
+const LogsPage = lazy(() => import("./pages/Logs"));
+const Profile = lazy(() => import("./pages/Profile"));
+const TaskKanban = lazy(() => import("./pages/TaskKanban"));
+const RoutesPage = lazy(() => import("./pages/Routes"));
+const SettingsPage = lazy(() => import("./pages/Settings"));
+const ThemeSettings = lazy(() => import("./pages/ThemeSettings"));
+const StoragePage = lazy(() => import("./pages/Storage"));
+const EmployeeCard = lazy(() => import("./pages/EmployeeCard"));
+
+const ThemeProviderLazy = lazy(async () => {
+  const mod = await import("./context/ThemeProvider");
+  return { default: mod.ThemeProvider };
+});
+
+function AppShell() {
+  const { user } = useAuth();
+  const { collapsed, open, toggle } = useSidebar();
+  const { t } = useTranslation();
+  return (
+    <>
+      {user && <Sidebar />}
+      {user && open && (
+        <div
+          className="fixed inset-0 z-40 bg-black/40"
+          tabIndex={-1}
+          ref={(el) => el?.focus()}
+          onClick={() => {
+            (document.activeElement as HTMLElement | null)?.blur();
+            toggle();
+          }}
+        />
+      )}
+      {user && <Header />}
+      <main
+        className={`mt-14 p-4 transition-all ${open ? (collapsed ? "md:ml-20" : "md:ml-60") : "md:ml-0"}`}
+      >
+        <Suspense fallback={<div>{t("loading")}</div>}>
+          <Routes>
+            <Route
+              path="/profile"
+              element={
+                <ProtectedRoute>
+                  <Profile />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/employees/:id"
+              element={
+                <ProtectedRoute>
+                  <EmployeeCard />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/tasks"
+              element={
+                <ProtectedRoute>
+                  <TasksPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/mg/kanban"
+              element={
+                <ManagerRoute>
+                  <TaskKanban />
+                </ManagerRoute>
+              }
+            />
+            <Route
+              path="/mg/reports"
+              element={
+                <ManagerRoute>
+                  <Reports />
+                </ManagerRoute>
+              }
+            />
+            <Route
+              path="/mg/routes"
+              element={
+                <ManagerRoute>
+                  <RoutesPage />
+                </ManagerRoute>
+              }
+            />
+            <Route
+              path="/cp/kanban"
+              element={
+                <AdminRoute>
+                  <TaskKanban />
+                </AdminRoute>
+              }
+            />
+            <Route
+              path="/cp/reports"
+              element={
+                <AdminRoute>
+                  <Reports />
+                </AdminRoute>
+              }
+            />
+            <Route
+              path="/cp/routes"
+              element={
+                <AdminRoute>
+                  <RoutesPage />
+                </AdminRoute>
+              }
+            />
+            <Route
+              path="/cp/settings"
+              element={
+                <AdminRoute>
+                  <SettingsPage />
+                </AdminRoute>
+              }
+            />
+            <Route
+              path="/cp/logs"
+              element={
+                <AdminRoute>
+                  <LogsPage />
+                </AdminRoute>
+              }
+            />
+            <Route
+              path="/cp/storage"
+              element={
+                <AdminRoute>
+                  <StoragePage />
+                </AdminRoute>
+              }
+            />
+            <Route
+              path="/theme"
+              element={
+                <ProtectedRoute>
+                  <ThemeSettings />
+                </ProtectedRoute>
+              }
+            />
+            <Route path="*" element={<Navigate to="/tasks" />} />
+          </Routes>
+        </Suspense>
+      </main>
+      <TaskDialogRoute />
+    </>
+  );
+}
+
+export default function AuthenticatedApp({
+  alert,
+}: {
+  alert: React.ReactNode;
+}) {
+  return (
+    <Suspense fallback={null}>
+      <ThemeProviderLazy>
+        <Suspense fallback={null}>
+          <ErrorBoundary fallback={<div>Произошла ошибка</div>}>
+            <SidebarProvider>
+              <TasksProvider>
+                <AppShell />
+              </TasksProvider>
+            </SidebarProvider>
+            {alert}
+          </ErrorBoundary>
+        </Suspense>
+      </ThemeProviderLazy>
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## Summary
- move the authenticated layout into a dedicated `AuthenticatedApp` chunk so the login and attachment menu views no longer preload the full shell
- lift toast and auth providers to the root app component, add route-aware navigation guards, and supply a toast context for unauthenticated flows

## Testing
- `pnpm lint`
- `pnpm test`

## Checklist
- [x] Lint
- [x] Tests
- [x] Build
- [x] Backward compatibility retained

## Risk Notes
- If unexpected routes bypass the new guards, confirm redirects still land on `/tasks` for authenticated users and `/login` for guests; revert by restoring `App.tsx` and removing `AuthenticatedApp.tsx`.


------
https://chatgpt.com/codex/tasks/task_b_68cfdb6f09b48320b1bcd97bf76d11c5