### PR TITLE
feat: adjust task date column layout

### DIFF
--- a/apps/web/src/columns/taskColumns.tsx
+++ b/apps/web/src/columns/taskColumns.tsx
@@ -32,9 +32,16 @@ const compactDateTimeFmt = new Intl.DateTimeFormat("ru-RU", {
 const formatDate = (value?: string) => {
   if (!value) return null;
   const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  const full = fullDateTimeFmt.format(date).replace(", ", " ");
+  const compact = compactDateTimeFmt.format(date).replace(", ", " ");
+  const [datePart, timePart] = compact.split(" ");
   return {
-    full: fullDateTimeFmt.format(date).replace(", ", " "),
-    compact: compactDateTimeFmt.format(date).replace(", ", " "),
+    full,
+    date: datePart || full,
+    time: timePart,
   };
 };
 
@@ -45,9 +52,12 @@ const renderDateCell = (value?: string) => {
     <time
       dateTime={value}
       title={formatted.full}
-      className="font-mono tabular-nums whitespace-nowrap"
+      className="inline-flex flex-col font-mono tabular-nums leading-tight"
     >
-      {formatted.compact}
+      <span>{formatted.date}</span>
+      {formatted.time ? (
+        <span className="text-muted-foreground">{formatted.time}</span>
+      ) : null}
     </time>
   );
 };
@@ -74,7 +84,11 @@ export default function taskColumns(
     {
       header: "Дата создания",
       accessorKey: "createdAt",
-      meta: { minWidth: "6.25rem", maxWidth: "7.5rem" },
+      meta: {
+        minWidth: "6.25rem",
+        maxWidth: "7.5rem",
+        cellClassName: "flex flex-col gap-0.5 text-xs sm:text-sm",
+      },
       cell: (p) => renderDateCell(p.getValue<string>()),
     },
     {
@@ -103,13 +117,21 @@ export default function taskColumns(
     {
       header: "Начало",
       accessorKey: "start_date",
-      meta: { minWidth: "6.25rem", maxWidth: "7.5rem" },
+      meta: {
+        minWidth: "6.25rem",
+        maxWidth: "7.5rem",
+        cellClassName: "flex flex-col gap-0.5 text-xs sm:text-sm",
+      },
       cell: (p) => renderDateCell(p.getValue<string>()),
     },
     {
       header: "Срок",
       accessorKey: "due_date",
-      meta: { minWidth: "6.25rem", maxWidth: "7.5rem" },
+      meta: {
+        minWidth: "6.25rem",
+        maxWidth: "7.5rem",
+        cellClassName: "flex flex-col gap-0.5 text-xs sm:text-sm",
+      },
       cell: (p) => renderDateCell(p.getValue<string>()),
     },
     {

--- a/apps/web/src/components/DataTable.tsx
+++ b/apps/web/src/components/DataTable.tsx
@@ -33,6 +33,7 @@ interface DataTableProps<T> {
 interface ColumnMeta {
   minWidth?: string;
   maxWidth?: string;
+  cellClassName?: string;
 }
 
 export default function DataTable<T>({
@@ -110,6 +111,12 @@ export default function DataTable<T>({
               {row.getVisibleCells().map((cell) => {
                 const meta =
                   (cell.column.columnDef.meta as ColumnMeta | undefined) || {};
+                const cellClassName = [
+                  "break-words whitespace-normal",
+                  meta.cellClassName,
+                ]
+                  .filter(Boolean)
+                  .join(" ");
                 return (
                   <TableCell
                     key={cell.id}
@@ -118,7 +125,7 @@ export default function DataTable<T>({
                       minWidth: meta.minWidth ?? "4rem",
                       maxWidth: meta.maxWidth ?? "16rem",
                     }}
-                    className="break-words whitespace-normal"
+                    className={cellClassName}
                     // фиксируем ширину ячейки данных
                   >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}


### PR DESCRIPTION
## Что сделано
- Перестроил ячейку даты задач на двухстрочный формат с подсветкой времени и безопасной обработкой некорректных значений.
- Добавил поддержку `meta.cellClassName` в `DataTable`, чтобы колонки могли управлять версткой и размером шрифта.
- Настроил дата-колонки задач на использование вертикального лэйаута и меньшего кегля для лучшей читаемости.

## Почему
- Нужно показать дату и время в одной ячейке без переноса строк и с возможностью гибкого форматирования через метаданные колонок.

## Логи
```bash
pnpm lint
pnpm test
pnpm run dev # API dev-сервер завершился с ошибкой (ts-node src/server.ts) из-за отсутствия подключения к MongoDB в среде
```

## Чек-лист
- [x] Линтер
- [x] Тесты
- [x] Сборка (`pnpm test` запускает build в pretest:e2e)
- [ ] Dev-сервер (см. лог выше)

## Самопроверка
- Дата в ячейке отображается двумя строками, тултип остался прежним.
- Табличный компонент принимает и применяет `meta.cellClassName`.
- Playwright-прогон задач прошёл для веб- и Telegram-клиента.
- В git-дереве только ожидаемые изменения.


------
https://chatgpt.com/codex/tasks/task_b_68cfe3d8c804832089d4f24e04938844