### PR TITLE
feat: ленивый импорт TaskDialog

### DIFF
--- a/apps/web/src/components/TaskDialogRoute.tsx
+++ b/apps/web/src/components/TaskDialogRoute.tsx
@@ -1,10 +1,11 @@
 // Назначение файла: показ TaskDialog поверх текущей страницы
 // Отображает TaskDialog при наличии query-параметров
-import React from "react";
+import React, { Suspense } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
-import TaskDialog from "./TaskDialog";
 import useTasks from "../context/useTasks";
 import Modal from "./Modal";
+
+const TaskDialogLazy = React.lazy(() => import("./TaskDialog"));
 
 export default function TaskDialogRoute() {
   const [params] = useSearchParams();
@@ -20,13 +21,15 @@ export default function TaskDialogRoute() {
   };
   return (
     <Modal open onClose={close}>
-      <TaskDialog
-        id={id || undefined}
-        onClose={close}
-        onSave={() => {
-          refresh();
-        }}
-      />
+      <Suspense fallback={<div>Загрузка диалога...</div>}>
+        <TaskDialogLazy
+          id={id || undefined}
+          onClose={close}
+          onSave={() => {
+            refresh();
+          }}
+        />
+      </Suspense>
     </Modal>
   );
 }


### PR DESCRIPTION
## Что сделано
- перевёл `TaskDialogRoute` на ленивый импорт диалога через `React.lazy`
- обернул диалог в `Suspense` с fallback, чтобы исключить тяжёлые зависимости из стартового бандла

## Зачем
- `vendor-misc` больше не подгружается вместе со стартовым бандлом и загружается только при открытии диалога задачи

## Чек-лист
- [x] тесты/линт/сборка не запускались, так как не требовалось
- [x] `pnpm --filter web run bundle-report`
- [x] обратная совместимость сохранена

## Логи команд
- `pnpm --filter web run bundle-report`

## Самопроверка
- [x] ленивый импорт TaskDialog добавлен
- [x] компонент обёрнут в `Suspense`
- [x] стартовый бандл больше не тянет `vendor-misc`

## Риски и откат
- Риск: при падении динамического импорта диалог не загрузится; fallback подсказывает о загрузке.
- Откат: вернуть прямой импорт `TaskDialog` и убрать `Suspense`.

------
https://chatgpt.com/codex/tasks/task_b_68d014283d888320a7c86c257d2dae26