### PR TITLE
feat(web): filter heavy modulepreload chunks

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -57,6 +57,37 @@ function cspNonceDevPlugin() {
   };
 }
 
+function escapeRegex(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+const modulePreloadChunks = [
+  "ckeditor",
+  "jspdf",
+  "fast-png",
+  "pako",
+  "fflate",
+];
+
+const modulePreloadPattern = new RegExp(
+  `<link\\s[^>]*rel=["']modulepreload["'][^>]*href=["'][^"']*(?:${modulePreloadChunks
+    .map(escapeRegex)
+    .join("|")})[^"']*["'][^>]*>`,
+  "gi",
+);
+
+function filterModulePreloadLinks() {
+  return {
+    name: "filter-modulepreload-links",
+    transformIndexHtml(html: string, ctx: IndexHtmlTransformContext | undefined) {
+      if (ctx?.server) {
+        return html;
+      }
+      return html.replace(modulePreloadPattern, "");
+    },
+  };
+}
+
 const vendorChunkGroups: Record<string, string[]> = {
   "vendor-core": [
     "react",
@@ -136,6 +167,7 @@ export default defineConfig(() => {
           })
         : undefined,
       preserveIndexHtml(),
+      filterModulePreloadLinks(),
       cspNonceDevPlugin(),
     ].filter(Boolean),
     resolve: {


### PR DESCRIPTION
## Что и почему
- добавил плагин `filter-modulepreload-links`, который в продакшн-сборке вырезает `<link rel="modulepreload">` для чанков ckeditor, jspdf, fast-png, pako и fflate, чтобы прекратить раннюю загрузку тяжёлых бандлов
- оставил dev-сервер без изменений, фильтрация выполняется только при сборке

## Логи
- `pnpm --filter web build`
- `rg "modulepreload" apps/api/public/index.html`

## Чек-лист
- [x] pnpm --filter web build
- [ ] pnpm lint (не требовалось по задаче)
- [ ] pnpm test (не требовалось по задаче)

## Самопроверка
- проверил, что Vite-сборка завершается успешно
- убедился, что в index.html больше нет modulepreload для запрещённых чанков
- конфигурация dev-сервера не затронута


------
https://chatgpt.com/codex/tasks/task_b_68d0179d1a608320a2b526b96188793e