### PR TITLE
fix: корректная загрузка CKEditor в веб-клиенте

### DIFF
--- a/apps/web/src/components/CKEditorPopup.tsx
+++ b/apps/web/src/components/CKEditorPopup.tsx
@@ -8,11 +8,9 @@ import { ensureWebpackNonce } from "../utils/ensureWebpackNonce";
 ensureWebpackNonce();
 
 const LazyCKEditor = React.lazy(async () => {
-  const reactEntry = "@ckeditor/ckeditor5-react";
-  const buildEntry = "@ckeditor/ckeditor5-build-classic";
   const [{ CKEditor }, { default: ClassicEditor }] = await Promise.all([
-    import(/* @vite-ignore */ reactEntry),
-    import(/* @vite-ignore */ buildEntry),
+    import("@ckeditor/ckeditor5-react"),
+    import("@ckeditor/ckeditor5-build-classic"),
   ]);
   type Props = React.ComponentProps<typeof CKEditor>;
   return {


### PR DESCRIPTION
## Что сделано
- убрана пометка `@vite-ignore` и прямые импорты CKEditor вынесены в ленивую загрузку, чтобы Vite мог переписать bare-импорт.

## Зачем
- без переписывания модуль не находился браузером, и при открытии редактора модальное окно ломалось.

## Чек-лист
- [x] `pnpm lint`
- [x] `pnpm test`

## Логи
- `pnpm lint`
- `pnpm test`

## Самопроверка
- [x] Ошибка воспроизводилась и больше не наблюдается.
- [x] Регрессий в сборке не появилось.
- [x] Динамический импорт остаётся ленивым.


------
https://chatgpt.com/codex/tasks/task_b_68d025cc0a9c8320baa4b4607278be2f