### PR TITLE
fix: remove static loader markup and rebalance vendor chunks

### DIFF
--- a/apps/api/public/index.html
+++ b/apps/api/public/index.html
@@ -27,9 +27,7 @@
     <link rel="stylesheet" crossorigin="anonymous" href="/assets/index-CxZVReFj.css" integrity="sha384-tL0tGQI53KrxF+CbuFAhHCVwDCPxJ/oC3Qz9nCnrlnjvZZeFEulqtF1D2887+PA2">
   </head>
   <body class="min-h-screen bg-white font-sans">
-    <div id="root">
-      <div role="status">Загрузка интерфейса…</div>
-    </div>
+    <div id="root"></div>
   
 
 </body></html>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -20,9 +20,7 @@
     <script type="module" src="/src/themeInit.ts"></script>
   </head>
   <body class="min-h-screen bg-white font-sans">
-    <div id="root">
-      <div role="status">Загрузка интерфейса…</div>
-    </div>
+    <div id="root"></div>
     <script nonce="__CSP_NONCE__" data-webpack-nonce>
       window.__webpack_nonce__ = document.currentScript?.nonce;
     </script>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -205,14 +205,14 @@ export default defineConfig(() => {
             if (!pkg) {
               return undefined;
             }
-            if (pkg.startsWith("@ckeditor/") || pkg.startsWith("ckeditor5")) {
-              return "ckeditor";
-            }
             if (pkg === "jspdf" || pkg === "jspdf-autotable") {
               return "jspdf";
             }
             if (pkg.startsWith("@radix-ui/")) {
               return "vendor-ui";
+            }
+            if (pkg.startsWith("@ckeditor/") || pkg.startsWith("ckeditor5")) {
+              return "vendor-richtext";
             }
             const mapped = vendorChunkLookup.get(pkg);
             if (mapped) {


### PR DESCRIPTION
## Что сделано
- убрал статический прелоадер из index.html веб-клиента и API
- перенастроил manualChunks: перенёс пакеты CKEditor в vendor-richtext, чтобы избежать циклической зависимости

## Зачем
- починить продакшен-сборку и пустой экран после добавления статического прелоадера

## Чек-лист
- [x] pnpm lint
- [x] pnpm test
- [x] pnpm build

## Логи
- pnpm lint
- pnpm test
- pnpm build (через pnpm test:e2e)

## Самопроверка
- проверил предпросмотр (Playwright) — страница входа отображается
- убедился, что сборка проходит успешно
- повторно убедился, что в коммите нет артефактов


------
https://chatgpt.com/codex/tasks/task_b_68d037dfe4808320b60f0196ee50a6de