### PR TITLE
fix: корректная сериализация вложений при отправке формы задачи

### DIFF
--- a/apps/web/src/services/buildTaskFormData.test.ts
+++ b/apps/web/src/services/buildTaskFormData.test.ts
@@ -1,0 +1,28 @@
+// Назначение файла: тесты функции buildTaskFormData.
+// Основные модули: buildTaskFormData, FormData, Jest.
+import { buildTaskFormData } from "./buildTaskFormData";
+
+describe("buildTaskFormData", () => {
+  it("корректно сериализует массив вложений в JSON", () => {
+    const attachments = [
+      {
+        name: "Отчёт",
+        url: "/api/v1/files/abc123",
+        thumbnailUrl: "/uploads/thumb.png",
+        uploadedBy: 10,
+        uploadedAt: "2024-01-01T00:00:00.000Z",
+        type: "application/pdf",
+        size: 1024,
+      },
+    ];
+    const formData = buildTaskFormData({
+      attachments,
+      assignees: [1, 2],
+      metadata: { flag: true },
+    });
+    expect(formData.get("formVersion")).toBe("1");
+    expect(formData.getAll("assignees")).toEqual(["1", "2"]);
+    expect(formData.get("attachments")).toBe(JSON.stringify(attachments));
+    expect(formData.get("metadata")).toBe(JSON.stringify({ flag: true }));
+  });
+});

--- a/apps/web/src/services/buildTaskFormData.ts
+++ b/apps/web/src/services/buildTaskFormData.ts
@@ -15,12 +15,21 @@ export const buildTaskFormData = (
     if (v === undefined || v === null) return;
     if (Array.isArray(v)) {
       if (v.length === 0) return;
+      const hasObjects = v.some(
+        (item) => typeof item === "object" && item !== null,
+      );
+      if (hasObjects) {
+        body.append(k, JSON.stringify(v));
+        return;
+      }
       v.forEach((val) => body.append(k, String(val)));
-    } else if (typeof v === "object") {
-      body.append(k, JSON.stringify(v));
-    } else {
-      body.append(k, String(v));
+      return;
     }
+    if (typeof v === "object") {
+      body.append(k, JSON.stringify(v));
+      return;
+    }
+    body.append(k, String(v));
   });
   if (files) Array.from(files).forEach((f) => body.append("files", f));
   return body;


### PR DESCRIPTION
## Что сделано
- Исправлена сборка FormData для массивов объектов, чтобы вложения передавались на сервер как JSON.
- Добавлен модульный тест, подтверждающий корректную сериализацию вложений и массивов примитивов.

## Почему
- Без изменения API получало `attachments` как строки `[object Object]`, из-за чего валидация ожидала поле `files` и отвечала ошибкой 400.

## Чек-лист
- [x] `pnpm lint`
- [x] `pnpm test:unit`

## Логи
- `pnpm lint`
- `pnpm test:unit`

## Самопроверка
- [x] Формирование FormData учитывает вложения и не ломает отправку примитивных массивов.
- [x] Автотест воспроизводит и покрывает исправленную логику.


------
https://chatgpt.com/codex/tasks/task_b_68d057481d6c8320baba89a13c4b7ab2