### PR TITLE
feat: harden theme tokens merge

### DIFF
--- a/apps/web/src/context/ThemeProvider.test.tsx
+++ b/apps/web/src/context/ThemeProvider.test.tsx
@@ -1,0 +1,91 @@
+/** @jest-environment jsdom */
+// Тесты ThemeProvider: проверка токенов и cookie
+// Модули: React Testing Library, ThemeProvider
+import { cleanup, render, waitFor, act } from "@testing-library/react";
+import type { ReactNode } from "react";
+import presets from "../theme/presets.json";
+import { ThemeProvider } from "./ThemeProvider";
+import { useTheme } from "./useTheme";
+
+jest.mock("next-themes", () => ({
+  ThemeProvider: ({ children }: { children?: unknown }) => <>{children}</>,
+}));
+
+type ThemeValue = ReturnType<typeof useTheme>;
+
+describe("ThemeProvider", () => {
+  beforeEach(() => {
+    cleanup();
+    document.cookie = "theme=;path=/;max-age=0";
+    document.cookie = "theme-tokens=;path=/;max-age=0";
+    document.documentElement.className = "";
+    document.documentElement.style.cssText = "";
+  });
+
+  function readCookie(name: string) {
+    const match = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`));
+    return match ? decodeURIComponent(match[1]) : null;
+  }
+
+  it("сбрасывает повреждённый cookie токенов к пресету", async () => {
+    document.cookie = "theme=dark;path=/";
+    document.cookie = "theme-tokens=not-json;path=/";
+
+    render(
+      <ThemeProvider>
+        <div />
+      </ThemeProvider>,
+    );
+
+    await waitFor(() =>
+      expect(
+        document.documentElement.style.getPropertyValue("--background"),
+      ).toBe(presets.dark.background),
+    );
+
+    const saved = readCookie("theme-tokens");
+    expect(saved).not.toBe("not-json");
+    expect(saved).not.toBeNull();
+    const parsed = JSON.parse(saved!);
+    expect(parsed.theme).toBe("dark");
+    expect(parsed.tokens).toMatchObject(presets.dark);
+  });
+
+  it("меняет тему, обновляя CSS и cookie", async () => {
+    let captured: ThemeValue | null = null;
+    function Capture({ children }: { children?: ReactNode }) {
+      captured = useTheme();
+      return <>{children}</>;
+    }
+
+    render(
+      <ThemeProvider>
+        <Capture />
+      </ThemeProvider>,
+    );
+
+    await waitFor(() =>
+      expect(
+        document.documentElement.style.getPropertyValue("--background"),
+      ).toBe(presets.light.background),
+    );
+
+    await act(async () => {
+      captured?.setTheme("dark");
+    });
+
+    await waitFor(() =>
+      expect(document.documentElement.classList.contains("dark")).toBe(true),
+    );
+    expect(
+      document.documentElement.style.getPropertyValue("--background"),
+    ).toBe(presets.dark.background);
+
+    expect(readCookie("theme")).toBe("dark");
+    const saved = readCookie("theme-tokens");
+    expect(saved).not.toBeNull();
+    const parsed = JSON.parse(saved!);
+    expect(parsed.theme).toBe("dark");
+    expect(parsed.tokens).toMatchObject(presets.dark);
+  });
+});

--- a/apps/web/src/themeInit.ts
+++ b/apps/web/src/themeInit.ts
@@ -6,12 +6,41 @@
   const tokens = document.cookie.match(/theme-tokens=([^;]+)/);
   if (tokens) {
     try {
-      const obj: Record<string, string> = JSON.parse(
-        decodeURIComponent(tokens[1]),
-      );
-      for (const k in obj) {
-        if (Object.prototype.hasOwnProperty.call(obj, k)) {
-          document.documentElement.style.setProperty(`--${k}`, obj[k]);
+      const parsed = JSON.parse(decodeURIComponent(tokens[1])) as unknown;
+      let map: Record<string, string> | null = null;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        if ("theme" in parsed || "tokens" in parsed) {
+          const cookieTheme = (parsed as { theme?: unknown }).theme;
+          const rawTokens = (parsed as { tokens?: unknown }).tokens;
+          if (
+            (typeof cookieTheme !== "string" || cookieTheme === t) &&
+            rawTokens &&
+            typeof rawTokens === "object" &&
+            !Array.isArray(rawTokens)
+          ) {
+            map = {};
+            for (const [key, value] of Object.entries(
+              rawTokens as Record<string, unknown>,
+            )) {
+              if (typeof value === "string") {
+                map[key] = value;
+              }
+            }
+          }
+        } else {
+          map = {};
+          for (const [key, value] of Object.entries(
+            parsed as Record<string, unknown>,
+          )) {
+            if (typeof value === "string") {
+              map[key] = value;
+            }
+          }
+        }
+      }
+      if (map) {
+        for (const [key, value] of Object.entries(map)) {
+          document.documentElement.style.setProperty(`--${key}`, value);
         }
       }
     } catch {


### PR DESCRIPTION
## Summary
- normalise theme cookie parsing and ensure preset tokens always override stale values
- validate and reset `theme-tokens` cookie when the stored theme mismatches or JSON is malformed
- add regression tests for ThemeProvider covering cookie reset and theme switching side effects

## Testing
- pnpm lint
- pnpm test:unit
- manual: attempted ts-node script to toggle ThemeProvider (blocked by next-themes runtime in this sandbox)

## Checklist
- [x] Tests
- [x] Lint
- [ ] Build
- [ ] Docs
- [ ] Backward compatibility checked

## Risk Notes
- manual theme validation in this environment requires next-themes DOM APIs; repeat manual verification in a full browser if needed.


------
https://chatgpt.com/codex/tasks/task_b_68d0f97ff7dc8320a09737f238431609