### PR TITLE
feat: auto-resize task title textarea

### DIFF
--- a/apps/web/src/components/TaskDialog.tsx
+++ b/apps/web/src/components/TaskDialog.tsx
@@ -288,7 +288,22 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
   // выбранная кнопка действия
   const [selectedAction, setSelectedAction] = React.useState("");
   const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const { ref: titleFieldRef, ...titleFieldRest } = register("title");
   const titleValue = watch("title");
+  const titleRef = React.useRef<HTMLTextAreaElement | null>(null);
+  const handleTitleRef = React.useCallback(
+    (node: HTMLTextAreaElement | null) => {
+      titleRef.current = node;
+      titleFieldRef(node);
+    },
+    [titleFieldRef],
+  );
+  React.useEffect(() => {
+    const node = titleRef.current;
+    if (!node) return;
+    node.style.height = "";
+    node.style.height = `${node.scrollHeight}px`;
+  }, [titleValue]);
   const resolveUserName = React.useCallback(
     (id: number) => {
       const person = users.find((u) => u.telegram_id === id);
@@ -844,11 +859,18 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
             <label className="block text-sm font-medium">
               {t("taskTitle")}
             </label>
-            <input
-              {...register("title")}
+            <textarea
+              {...titleFieldRest}
+              ref={handleTitleRef}
+              rows={1}
               placeholder={t("title")}
-              className="focus:ring-brand-200 focus:border-accentPrimary w-full rounded-md border bg-gray-100 px-2.5 py-1.5 text-sm focus:outline-none focus:ring"
+              className="focus:ring-brand-200 focus:border-accentPrimary w-full rounded-md border bg-gray-100 px-2.5 py-1.5 text-sm focus:outline-none focus:ring min-h-[44px] resize-none"
               disabled={!editing}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                }
+              }}
             />
             {errors.title && (
               <p className="text-sm text-red-600">{errors.title.message}</p>


### PR DESCRIPTION
## Что и почему
- Заменил поле заголовка задачи на textarea и добавил автоизменение высоты, чтобы длинные названия отображались без полос прокрутки.
- Заблокировал ввод перевода строки и синхронизировал ref-ы React Hook Form с локальным ref для корректного управления высотой.

## Чек-лист
- [x] Линт
- [x] Тесты
- [ ] Ручная проверка создания/редактирования задачи и загрузки файлов (недоступно в среде)

## Логи
- `pnpm lint`
- `pnpm test`

## Самопроверка
- Поле заголовка автоувеличивается и не даёт вводить перевод строки.
- Линтер и тесты проходят.
- Изменения ограничены компонентом TaskDialog.
- Реализована блокировка resize и задан минимальный размер для disabled-состояния.


------
https://chatgpt.com/codex/tasks/task_b_68d12377745c8320bddc7c2fe7dd6c1a