### PR TITLE
fix: stabilize hero generation and widen priority column

### DIFF
--- a/apps/web/src/columns/taskColumns.tsx
+++ b/apps/web/src/columns/taskColumns.tsx
@@ -7,7 +7,7 @@ import type { Task } from "shared";
 
 // Оформление бейджей статусов и приоритетов на дизайн-токенах
 const badgeBaseClass =
-  "inline-flex items-center whitespace-nowrap rounded-full px-2 py-0.5 text-[0.7rem] font-semibold uppercase tracking-wide shadow-xs";
+  "inline-flex max-w-full items-center justify-center whitespace-nowrap rounded-full px-2 py-0.5 text-center text-[0.7rem] font-semibold uppercase tracking-wide shadow-xs";
 
 const buildBadgeClass = (tones: string) =>
   `${badgeBaseClass} text-primary transition-colors dark:text-primary ${tones}`;
@@ -226,9 +226,9 @@ export default function taskColumns(
       header: "Приоритет",
       accessorKey: "priority",
       meta: {
-        width: "clamp(4.5rem, 7vw, 6.5rem)",
-        minWidth: "4.5rem",
-        maxWidth: "6.5rem",
+        width: "clamp(8.5rem, 15vw, 12.5rem)",
+        minWidth: "8.5rem",
+        maxWidth: "12.5rem",
       },
       cell: (p) => {
         const value = p.getValue<string>() || "";

--- a/scripts/generate_hero_images.mjs
+++ b/scripts/generate_hero_images.mjs
@@ -1,37 +1,66 @@
 // Назначение файла: генерация hero-изображений для Open Graph.
 // Основные модули: fs/promises, path, sharp.
 
-import fs from 'fs/promises';
-import path from 'path';
+import fs from "fs/promises";
+import path from "path";
 
+// Подготовка sharp; при отсутствии двоичных модулей пропускаем генерацию
 let sharp;
+const loadErrors = [];
 try {
-  ({ default: sharp } = await import('sharp'));
-} catch {
-  ({ default: sharp } = await import(
-    '../apps/api/node_modules/sharp/lib/index.js'
-  ));
+  ({ default: sharp } = await import("sharp"));
+} catch (err) {
+  loadErrors.push(err);
+  try {
+    ({ default: sharp } = await import(
+      "../apps/api/node_modules/sharp/lib/index.js",
+    ));
+  } catch (fallbackErr) {
+    loadErrors.push(fallbackErr);
+  }
 }
 
-const outDir = path.resolve('apps/web/public/hero');
-await fs.mkdir(outDir, { recursive: true });
+if (!sharp) {
+  const reasons = loadErrors
+    .map((e) => (e && typeof e === "object" && "message" in e ? e.message : String(e)))
+    .filter(Boolean)
+    .join("; ");
+  console.warn(
+    "Пропускаем генерацию hero-изображений: sharp недоступен.",
+    reasons,
+  );
+} else {
+  const outDir = path.resolve("apps/web/public/hero");
+  await fs.mkdir(outDir, { recursive: true });
 
-const pages = [
-  { name: 'index', text: 'ERM Web App' },
-  { name: 'routes', text: 'Маршруты' },
-];
+  const pages = [
+    { name: "index", text: "ERM Web App" },
+    { name: "routes", text: "Маршруты" },
+  ];
 
-for (const p of pages) {
-  const svg = `<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
-    <linearGradient id="g" x1="0" x2="0" y1="0" y2="1">
-      <stop offset="0%" stop-color="#0ea5e9"/>
-      <stop offset="100%" stop-color="#0369a1"/>
-    </linearGradient>
-    <rect width="1200" height="630" fill="url(#g)"/>
-    <text x="50%" y="50%" font-size="64" fill="#fff" font-family="Arial, sans-serif" text-anchor="middle" dominant-baseline="middle">${p.text}</text>
-  </svg>`;
-  const buffer = Buffer.from(svg);
-  await sharp(buffer)
-    .png()
-    .toFile(path.join(outDir, `${p.name}.png`));
+  for (const p of pages) {
+    const svg =
+      `<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">` +
+      `    <linearGradient id="g" x1="0" x2="0" y1="0" y2="1">` +
+      `      <stop offset="0%" stop-color="#0ea5e9"/>` +
+      `      <stop offset="100%" stop-color="#0369a1"/>` +
+      `    </linearGradient>` +
+      `    <rect width="1200" height="630" fill="url(#g)"/>` +
+      `    <text x="50%" y="50%" font-size="64" fill="#fff" font-family="Arial, sans-serif" text-anchor="middle" dominant-baseline="middle">${p.text}</text>` +
+      `  </svg>`;
+    const buffer = Buffer.from(svg);
+    try {
+      await sharp(buffer)
+        .png()
+        .toFile(path.join(outDir, `${p.name}.png`));
+    } catch (err) {
+      const message =
+        err && typeof err === "object" && "message" in err ? err.message : String(err);
+      console.warn(
+        `Не удалось сгенерировать hero-изображение для ${p.name}:`,
+        message,
+      );
+      break;
+    }
+  }
 }


### PR DESCRIPTION
## Что сделано
- добавил обработку недоступности `sharp` в генерации hero-изображений, чтобы деплой не падал при отсутствующих бинарях
- расширил колонку "Приоритет" и ограничил ширину бейджей, чтобы текст не выходил за пределы таблицы

## Почему
- Railway-выкатка падала на `pnpm build`, если `sharp` не мог загрузить двоичные файлы
- пользователи жаловались, что значения приоритета визуально обрезаются

## Чек-лист
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Обратная совместимость сохранена

## Логи
- `pnpm lint`
- `pnpm test`
- `pnpm build`

## Самопроверка
1. Проверил отсутствие мусорных артефактов в репозитории
2. Убедился, что таблица задач использует обновлённые размеры
3. Убедился, что генерация hero не блокирует сборку при сбоях sharp

------
https://chatgpt.com/codex/tasks/task_b_68d1320a8c5c83209d56991c79ebb3a9