### PR TITLE
chore: ensure firefox is installed before e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pretest": "pnpm --filter shared build",
     "pretest:unit": "pnpm --filter shared build",
     "pretest:api": "pnpm --filter shared build",
-    "pretest:e2e": "./scripts/build_with_tmp.sh",
+    "pretest:e2e": "./scripts/ensure_playwright_browsers.sh && ./scripts/build_with_tmp.sh",
     "build": "pnpm --filter shared build && pnpm -r --filter '!shared' build && npx tsc scripts/db/ensureDefaults.ts --module commonjs --target ES2020 --outDir dist --rootDir . --types node && node dist/scripts/db/ensureDefaults.js",
     "dev": "PNPM_SCRIPT_TIMEOUT=0 pnpm -r dev",
     "lint": "pnpm -r lint",

--- a/scripts/ensure_playwright_browsers.sh
+++ b/scripts/ensure_playwright_browsers.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Назначение скрипта: установка браузеров Playwright, необходимых для e2e-тестов.
+# Основные модули: pnpm, Playwright.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "pnpm не найден. Установите pnpm перед запуском тестов." >&2
+  exit 1
+fi
+
+INSTALL_ARGS=("firefox")
+if [[ "${CI:-}" == "true" ]] || [[ "$(uname -s)" == "Linux" ]]; then
+  INSTALL_ARGS=("--with-deps" "firefox")
+fi
+
+pnpm exec playwright install "${INSTALL_ARGS[@]}"


### PR DESCRIPTION
## Summary
- добавить скрипт, который гарантирует установку браузеров Playwright перед запуском e2e-тестов
- подключить новый скрипт в pretest:e2e, чтобы стабилизировать тесты в CI

## Testing
- `pnpm run test:e2e --project=firefox`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68d149586b588320a1fcd23332b339ae