### PR TITLE
fix: install webkit for e2e tests

### DIFF
--- a/scripts/ensure_playwright_browsers.sh
+++ b/scripts/ensure_playwright_browsers.sh
@@ -9,9 +9,9 @@ if ! command -v pnpm >/dev/null 2>&1; then
   exit 1
 fi
 
-INSTALL_ARGS=("firefox" "chromium")
+INSTALL_ARGS=("firefox" "chromium" "webkit")
 if [[ "${CI:-}" == "true" ]] || [[ "$(uname -s)" == "Linux" ]]; then
-  INSTALL_ARGS=("--with-deps" "firefox" "chromium")
+  INSTALL_ARGS=("--with-deps" "firefox" "chromium" "webkit")
 fi
 
 pnpm exec playwright install "${INSTALL_ARGS[@]}"


### PR DESCRIPTION
## Summary
- install the WebKit browser in the Playwright setup script alongside Chromium and Firefox
- include WebKit when requesting system dependencies in CI/Linux so webkit-based flows can run

## Testing
- pnpm run test:e2e --project=webkit

------
https://chatgpt.com/codex/tasks/task_b_68d15e39aa288320b36907c5c554f8de