### PR TITLE
feat(tasks): improve task list layout on mobile

### DIFF
--- a/apps/web/src/columns/taskColumns.tsx
+++ b/apps/web/src/columns/taskColumns.tsx
@@ -23,13 +23,22 @@ const infoBadgeClass = buildBadgeClass(
   "text-slate-900 dark:text-slate-100 normal-case font-medium",
 );
 
+const numberBadgeClass = `${infoBadgeClass} px-2.5 py-1 text-xs font-semibold tracking-wide sm:text-sm`;
+
 const assigneeBadgeClass = buildBadgeClass(
   "bg-indigo-500/20 ring-1 ring-indigo-500/40 dark:bg-indigo-400/25 dark:ring-indigo-300/45",
-  "text-indigo-900 dark:text-indigo-100 normal-case font-medium",
+  "text-indigo-900 dark:text-indigo-100 normal-case font-medium whitespace-normal break-words text-left items-start justify-start",
 );
 
 const focusableBadgeClass =
   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
+
+const rectangularBadgeBaseClass =
+  "block w-full min-w-0 max-w-full break-words rounded-xl border border-slate-200 bg-slate-50 px-2 py-1 text-left text-xs font-medium leading-snug text-slate-800 shadow-xs transition-colors hover:bg-slate-100 dark:border-slate-600/60 dark:bg-slate-800/60 dark:text-slate-100 dark:hover:bg-slate-700/60";
+
+const titleBadgeClass = `${rectangularBadgeBaseClass} font-semibold text-[0.85rem] sm:text-[0.95rem]`;
+
+const locationBadgeClass = `${rectangularBadgeBaseClass} text-[0.8rem] sm:text-[0.85rem]`;
 
 const statusBadgeClassMap: Record<Task["status"], string> = {
   Новая: buildBadgeClass(
@@ -192,10 +201,9 @@ const parseDistance = (value: unknown) => {
 const formatDistanceLabel = (value: unknown) => {
   const numeric = parseDistance(value);
   if (numeric !== null) {
-    const fractionDigits = Number.isInteger(numeric) ? 0 : 1;
     return numeric.toLocaleString("ru-RU", {
-      maximumFractionDigits: fractionDigits,
-      minimumFractionDigits: fractionDigits,
+      maximumFractionDigits: 2,
+      minimumFractionDigits: 2,
     });
   }
   if (typeof value === "string") {
@@ -243,9 +251,6 @@ const getDistanceBadgeClass = (value: unknown) => {
   }
   return extraLongDistanceBadgeClass;
 };
-
-const focusableLinkClass =
-  "text-primary underline decoration-2 underline-offset-2 transition-colors hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 
 const fullDateTimeFmt = new Intl.DateTimeFormat("ru-RU", {
   day: "2-digit",
@@ -339,10 +344,7 @@ export default function taskColumns(
         const numericMatch = value.match(/\d+/);
         const shortValue = numericMatch ? numericMatch[0] : value;
         return (
-          <span
-            className={`${infoBadgeClass} font-mono`}
-            title={value}
-          >
+          <span className={`${numberBadgeClass} font-mono`} title={value}>
             {shortValue}
           </span>
         );
@@ -369,9 +371,9 @@ export default function taskColumns(
       },
       cell: (p) => {
         const v = p.getValue<string>() || "";
-        const compact = compactText(v, 48);
+        const compact = compactText(v, 72);
         return (
-          <span title={v} className="block leading-tight">
+          <span title={v} className={titleBadgeClass}>
             {compact}
           </span>
         );
@@ -467,20 +469,20 @@ export default function taskColumns(
       },
       cell: ({ row }) => {
         const name = row.original.start_location || "";
-        const compact = compactText(name, 36);
+        const compact = compactText(name, 48);
         const link = row.original.start_location_link;
         return link ? (
           <a
             href={link}
             target="_blank"
             rel="noopener noreferrer"
-            className={focusableLinkClass}
+            className={`${locationBadgeClass} ${focusableBadgeClass} no-underline`}
             title={name}
           >
             {compact}
           </a>
         ) : (
-          <span title={name} className="block leading-tight">
+          <span title={name} className={locationBadgeClass}>
             {compact}
           </span>
         );
@@ -496,20 +498,20 @@ export default function taskColumns(
       },
       cell: ({ row }) => {
         const name = row.original.end_location || "";
-        const compact = compactText(name, 36);
+        const compact = compactText(name, 48);
         const link = row.original.end_location_link;
         return link ? (
           <a
             href={link}
             target="_blank"
             rel="noopener noreferrer"
-            className={focusableLinkClass}
+            className={`${locationBadgeClass} ${focusableBadgeClass} no-underline`}
             title={name}
           >
             {compact}
           </a>
         ) : (
-          <span title={name} className="block leading-tight">
+          <span title={name} className={locationBadgeClass}>
             {compact}
           </span>
         );
@@ -566,15 +568,13 @@ export default function taskColumns(
             users[id]?.username ||
             String(id),
         }));
-        const visible = labels.slice(0, 2);
-        const hiddenCount = labels.length - visible.length;
         const tooltip = labels.map((item) => item.label).join(", ");
         return (
           <div
-            className="flex flex-wrap items-center gap-x-1 gap-y-0.5 leading-tight"
+            className="flex w-full flex-wrap items-start gap-1 leading-tight"
             title={tooltip}
           >
-            {visible.map(({ id, label }) => (
+            {labels.map(({ id, label }) => (
               <EmployeeLink
                 key={id}
                 employeeId={id}
@@ -584,11 +584,6 @@ export default function taskColumns(
                 {compactText(label, 18)}
               </EmployeeLink>
             ))}
-            {hiddenCount > 0 ? (
-              <span className={`${infoBadgeClass} text-xs font-medium`}>
-                +{hiddenCount}
-              </span>
-            ) : null}
           </div>
         );
       },

--- a/apps/web/src/components/TableToolbar.tsx
+++ b/apps/web/src/components/TableToolbar.tsx
@@ -72,8 +72,8 @@ export default function TableToolbar<T>({ table, children }: Props<T>) {
         <GlobalSearch />
         {children}
       </div>
-      <div className="ml-auto flex w-full flex-wrap items-center gap-1 sm:w-auto sm:justify-end">
-        <details className="relative">
+      <div className="ml-auto flex w-full flex-wrap items-center justify-end gap-1 sm:w-auto">
+        <details className="relative flex-shrink-0">
           <summary className="cursor-pointer rounded border px-1.5 py-1 text-xs font-medium select-none sm:text-sm">
             {t("export")}
           </summary>
@@ -92,7 +92,7 @@ export default function TableToolbar<T>({ table, children }: Props<T>) {
             </button>
           </div>
         </details>
-        <details className="relative">
+        <details className="relative flex-shrink-0">
           <summary className="cursor-pointer rounded border px-1.5 py-1 text-xs font-medium select-none sm:text-sm">
             {t("settings")}
           </summary>

--- a/apps/web/src/components/TaskDialog.tsx
+++ b/apps/web/src/components/TaskDialog.tsx
@@ -898,7 +898,9 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
     <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/50 p-4">
       <div className="relative mx-auto w-full max-w-screen-md space-y-4 rounded-xl bg-white p-4 shadow-lg">
         <div className="pr-16">
-          <h3 className="text-lg font-semibold leading-tight text-gray-900 whitespace-nowrap overflow-hidden text-ellipsis">
+          <h3
+            className="text-lg font-semibold leading-snug text-gray-900 break-words sm:whitespace-nowrap sm:overflow-hidden sm:text-ellipsis"
+          >
             {headerLabel}
           </h3>
           {hasCreator ? (
@@ -956,7 +958,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               ref={handleTitleRef}
               rows={1}
               placeholder={t("title")}
-              className="focus:ring-brand-200 focus:border-accentPrimary w-full rounded-md border bg-gray-100 px-2.5 py-1.5 text-sm focus:outline-none focus:ring min-h-[44px] resize-none"
+              className="focus:ring-brand-200 focus:border-accentPrimary w-full rounded-md border bg-gray-100 px-2.5 py-1.5 text-[0.95rem] font-semibold focus:outline-none focus:ring min-h-[44px] resize-none sm:text-base"
               disabled={!editing}
               onKeyDown={(event) => {
                 if (event.key === "Enter") {

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -95,7 +95,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "border border-border dark:border-border/60 px-2 py-1.5 align-middle text-[12px] leading-snug",
+        "border border-border dark:border-border/60 px-2 py-1.5 align-top text-[12px] leading-snug",
         "data-[state=selected]:bg-muted data-[state=selected]:text-foreground",
         "dark:data-[state=selected]:bg-muted/50 dark:data-[state=selected]:text-foreground",
         "sm:px-2.5 sm:py-2 sm:text-sm",


### PR DESCRIPTION
## Что сделано
- Обновил заголовок карточки задачи и поле ввода названия: добавил перенос заголовка на мобильных устройствах и увеличил шрифт содержимого.
- Переработал отображение колонок «Название», «Старт», «Финиш», «Номер», «Км» и «Исполнители»: добавлены прямоугольные бейджи, формат расстояний 0,00 и показ всех исполнителей без наложений.
- Смещены меню «Экспорт» и «Настройки» к правому краю и выравнены ячейки таблицы по верхнему краю для адаптивной высоты строк.

## Почему
- Чтобы текст названия задачи корректно читался в мобильном интерфейсе и соответствовал пожеланиям по акценту.
- Чтобы поля таблицы смотрелись компактно, не перекрывались и соответствовали новому визуальному стилю.
- Чтобы выпадающие меню не уходили за границы экрана на мобильных устройствах.

## Проверки
- [x] `pnpm --filter web lint`

## Самопроверка
- [x] Изменения соответствуют требованиям задачи и инструкциям AGENTS.md.
- [x] UI остаётся адаптивным на разных разрешениях.
- [x] Нет регрессий в логике таблицы и диалога задач.


------
https://chatgpt.com/codex/tasks/task_b_68d24e90afd4832089a468c0cdc41049