### PR TITLE
feat: compact task table badges

### DIFF
--- a/apps/web/src/columns/taskColumns.tsx
+++ b/apps/web/src/columns/taskColumns.tsx
@@ -7,7 +7,7 @@ import EmployeeLink from "../components/EmployeeLink";
 
 // Оформление бейджей статусов и приоритетов на дизайн-токенах
 const badgeBaseClass =
-  "inline-flex max-w-full items-center justify-center whitespace-nowrap rounded-full px-2 py-0.5 text-center text-[0.7rem] font-semibold uppercase tracking-wide shadow-xs";
+  "inline-flex h-8 min-h-[2rem] max-h-[2rem] max-w-full items-center justify-center truncate rounded-full px-2.5 text-center text-[0.7rem] font-semibold uppercase tracking-wide shadow-xs";
 
 const buildBadgeClass = (
   tones: string,
@@ -27,14 +27,14 @@ const numberBadgeClass = `${infoBadgeClass} px-2.5 py-1 text-xs font-semibold tr
 
 const assigneeBadgeClass = buildBadgeClass(
   "bg-indigo-500/20 ring-1 ring-indigo-500/40 dark:bg-indigo-400/25 dark:ring-indigo-300/45",
-  "text-indigo-900 dark:text-indigo-100 normal-case font-medium whitespace-normal break-words text-left items-start justify-start",
+  "text-indigo-900 dark:text-indigo-100 normal-case font-medium text-left items-center justify-start",
 );
 
 const focusableBadgeClass =
   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 
 const rectangularBadgeBaseClass =
-  "block w-full min-w-0 max-w-full break-words rounded-xl border border-slate-200 bg-slate-50 px-2 py-1 text-left text-xs font-medium leading-snug text-slate-800 shadow-xs transition-colors hover:bg-slate-100 dark:border-slate-600/60 dark:bg-slate-800/60 dark:text-slate-100 dark:hover:bg-slate-700/60";
+  "relative flex h-9 min-h-[2.25rem] w-full min-w-0 max-w-full items-center overflow-hidden rounded-[1.15rem] border border-slate-200 bg-slate-50 px-3 text-left text-xs font-medium leading-tight text-slate-800 shadow-xs transition-colors hover:bg-slate-100 dark:border-slate-600/60 dark:bg-slate-800/60 dark:text-slate-100 dark:hover:bg-slate-700/60 whitespace-nowrap text-ellipsis";
 
 const titleBadgeClass = `${rectangularBadgeBaseClass} font-semibold text-[0.85rem] sm:text-[0.95rem]`;
 
@@ -294,14 +294,14 @@ const renderDateCell = (value?: string) => {
   if (!formatted) return "";
   return (
     <span
-      className={`${infoBadgeClass} items-start justify-center font-mono`}
+      className={`${infoBadgeClass} gap-1 font-mono whitespace-nowrap`}
       title={formatted.full}
     >
       <time
         dateTime={value}
-        className="flex flex-col tabular-nums leading-tight"
+        className="flex items-center gap-1 tabular-nums leading-tight"
       >
-        <span className="leading-tight">{formatted.date}</span>
+        <span>{formatted.date}</span>
         {formatted.time ? (
           <span className="text-muted-foreground text-[0.85em] leading-tight">
             {formatted.time}

--- a/apps/web/src/components/DataTable.tsx
+++ b/apps/web/src/components/DataTable.tsx
@@ -75,7 +75,7 @@ export default function DataTable<T>({
       <Table className="text-left">
         <TableHeader>
           {table.getHeaderGroups().map((hg) => (
-            <TableRow key={hg.id}>
+            <TableRow key={hg.id} variant="header">
               {hg.headers.map((header) => {
                 const meta =
                   (header.column.columnDef.meta as ColumnMeta | undefined) ||

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -58,15 +58,29 @@ function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
   );
 }
 
-function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+type TableRowProps = React.ComponentProps<"tr"> & {
+  variant?: "body" | "header" | "footer";
+};
+
+function TableRow({ className, variant = "body", ...props }: TableRowProps) {
+  const isBodyRow = variant === "body";
   return (
     <tr
       data-slot="table-row"
       className={cn(
-        "border-b border-border dark:border-border/60 transition-colors",
-        "hover:bg-muted/60 dark:hover:bg-muted/40",
-        "data-[state=selected]:bg-muted data-[state=selected]:text-foreground",
-        "dark:data-[state=selected]:bg-muted/50 dark:data-[state=selected]:text-foreground",
+        "group relative isolate transition-colors",
+        "border-b border-border dark:border-border/60",
+        isBodyRow
+          ? [
+              "before:absolute before:inset-x-1 before:top-0.5 before:bottom-0.5 before:-z-10 before:rounded-[1.35rem] before:opacity-90",
+              "before:bg-[repeating-linear-gradient(90deg,rgba(148,163,184,0.24)_0,rgba(148,163,184,0.24)_14%,rgba(100,116,139,0.18)_14%,rgba(100,116,139,0.18)_28%)]",
+              "dark:before:bg-[repeating-linear-gradient(90deg,rgba(71,85,105,0.45)_0,rgba(71,85,105,0.45)_14%,rgba(30,41,59,0.55)_14%,rgba(30,41,59,0.55)_28%)]",
+              "before:ring-1 before:ring-slate-300/60 before:transition-opacity before:duration-150 dark:before:ring-slate-600/70",
+              "hover:before:opacity-100",
+            ]
+          : "",
+        "data-[state=selected]:bg-transparent data-[state=selected]:text-foreground",
+        "dark:data-[state=selected]:bg-transparent dark:data-[state=selected]:text-foreground",
         "min-h-[2rem] text-[12px] sm:min-h-[2.25rem] sm:text-sm",
         className,
       )}
@@ -95,7 +109,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "border border-border dark:border-border/60 px-2 py-1.5 align-top text-[12px] leading-snug",
+        "relative z-[1] border border-border dark:border-border/60 px-2 py-1.5 align-top text-[12px] leading-snug",
         "data-[state=selected]:bg-muted data-[state=selected]:text-foreground",
         "dark:data-[state=selected]:bg-muted/50 dark:data-[state=selected]:text-foreground",
         "sm:px-2.5 sm:py-2 sm:text-sm",


### PR DESCRIPTION
## Что сделано
- Сжал высоту базовых бейджей задач, добавил обрезку текста и компактный вывод дат в одну строку.
- Обновил строку таблицы до варианта с единым полосатым бэкдропом, подчёркивающим границы задачи без перекрытия вложенных бейджей.

## Зачем
- Уменьшить вертикальный ритм строк и убрать расползание таблицы за счёт контролируемой высоты и подсказок.
- Визуально группировать данные одной задачи и сделать блоки заметнее за счёт чередующихся оттенков.

## Проверки
- [x] pnpm lint
- [x] pnpm --filter web run test:types

## Самопроверка
- Вёрстка не перекрывает бейджи и сохраняет фокусные стили.
- Заголовки таблицы не затронуты новым оформлением.
- Подсказки показывают полный текст после обрезки.
- Высота строк соответствует ожидаемому эталону.


------
https://chatgpt.com/codex/tasks/task_b_68d25c9adefc83208c0478df6c496c80