### PR TITLE
feat: restyle tasks table rows

### DIFF
--- a/apps/web/src/columns/taskColumns.tsx
+++ b/apps/web/src/columns/taskColumns.tsx
@@ -7,7 +7,7 @@ import EmployeeLink from "../components/EmployeeLink";
 
 // Оформление бейджей статусов и приоритетов на дизайн-токенах
 const badgeBaseClass =
-  "inline-flex h-8 min-h-[2rem] max-h-[2rem] max-w-full items-center justify-center truncate rounded-full px-2.5 text-center text-[0.7rem] font-semibold uppercase tracking-wide shadow-xs";
+  "inline-flex min-w-0 items-center gap-1 rounded-full px-2 py-0.5 text-center text-[0.68rem] font-semibold uppercase tracking-wide shadow-xs";
 
 const buildBadgeClass = (
   tones: string,
@@ -18,27 +18,20 @@ const defaultBadgeClass = buildBadgeClass(
   "bg-accent/60 ring-1 ring-primary/30 dark:bg-accent/45 dark:ring-primary/30",
 );
 
-const infoBadgeClass = buildBadgeClass(
-  "bg-slate-500/20 ring-1 ring-slate-500/35 dark:bg-slate-400/25 dark:ring-slate-300/40",
-  "text-slate-900 dark:text-slate-100 normal-case font-medium",
-);
-
-const numberBadgeClass = `${infoBadgeClass} px-2.5 py-1 text-xs font-semibold tracking-wide sm:text-sm`;
-
-const assigneeBadgeClass = buildBadgeClass(
-  "bg-indigo-500/20 ring-1 ring-indigo-500/40 dark:bg-indigo-400/25 dark:ring-indigo-300/45",
-  "text-indigo-900 dark:text-indigo-100 normal-case font-medium text-left items-center justify-start",
-);
+const assigneeBadgeClass =
+  "inline-flex items-center gap-1 rounded-full bg-indigo-500/15 px-2 py-0.5 text-left text-xs font-medium text-indigo-900 transition-colors hover:bg-indigo-500/25 dark:bg-indigo-400/20 dark:text-indigo-100 dark:hover:bg-indigo-400/30";
 
 const focusableBadgeClass =
   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 
-const rectangularBadgeBaseClass =
-  "relative flex h-9 min-h-[2.25rem] w-full min-w-0 max-w-full items-center overflow-hidden rounded-[1.15rem] border border-slate-200 bg-slate-50 px-3 text-left text-xs font-medium leading-tight text-slate-800 shadow-xs transition-colors hover:bg-slate-100 dark:border-slate-600/60 dark:bg-slate-800/60 dark:text-slate-100 dark:hover:bg-slate-700/60 whitespace-nowrap text-ellipsis";
+const titleTextClass =
+  "block max-w-full truncate text-[0.85rem] font-semibold leading-tight text-slate-900 dark:text-slate-100 sm:text-[0.95rem]";
 
-const titleBadgeClass = `${rectangularBadgeBaseClass} font-semibold text-[0.85rem] sm:text-[0.95rem]`;
+const locationTextClass =
+  "block max-w-full truncate text-xs font-medium text-slate-700 dark:text-slate-200 sm:text-sm";
 
-const locationBadgeClass = `${rectangularBadgeBaseClass} text-[0.8rem] sm:text-[0.85rem]`;
+const locationLinkClass =
+  "block max-w-full truncate text-xs font-medium text-primary underline-offset-4 hover:underline sm:text-sm";
 
 const statusBadgeClassMap: Record<Task["status"], string> = {
   Новая: buildBadgeClass(
@@ -294,14 +287,14 @@ const renderDateCell = (value?: string) => {
   if (!formatted) return "";
   return (
     <span
-      className={`${infoBadgeClass} gap-1 font-mono whitespace-nowrap`}
+      className="flex items-center gap-1 font-mono text-xs text-slate-700 dark:text-slate-200 sm:text-sm"
       title={formatted.full}
     >
       <time
         dateTime={value}
-        className="flex items-center gap-1 tabular-nums leading-tight"
+        className="flex items-center gap-1 truncate tabular-nums leading-tight"
       >
-        <span>{formatted.date}</span>
+        <span className="truncate">{formatted.date}</span>
         {formatted.time ? (
           <span className="text-muted-foreground text-[0.85em] leading-tight">
             {formatted.time}
@@ -344,7 +337,10 @@ export default function taskColumns(
         const numericMatch = value.match(/\d+/);
         const shortValue = numericMatch ? numericMatch[0] : value;
         return (
-          <span className={`${numberBadgeClass} font-mono`} title={value}>
+          <span
+            className="block truncate font-mono text-xs text-slate-900 dark:text-slate-100 sm:text-sm"
+            title={value}
+          >
             {shortValue}
           </span>
         );
@@ -373,7 +369,7 @@ export default function taskColumns(
         const v = p.getValue<string>() || "";
         const compact = compactText(v, 72);
         return (
-          <span title={v} className={titleBadgeClass}>
+          <span title={v} className={titleTextClass}>
             {compact}
           </span>
         );
@@ -476,13 +472,13 @@ export default function taskColumns(
             href={link}
             target="_blank"
             rel="noopener noreferrer"
-            className={`${locationBadgeClass} ${focusableBadgeClass} no-underline`}
+            className={`${locationLinkClass} ${focusableBadgeClass}`}
             title={name}
           >
             {compact}
           </a>
         ) : (
-          <span title={name} className={locationBadgeClass}>
+          <span title={name} className={locationTextClass}>
             {compact}
           </span>
         );
@@ -505,13 +501,13 @@ export default function taskColumns(
             href={link}
             target="_blank"
             rel="noopener noreferrer"
-            className={`${locationBadgeClass} ${focusableBadgeClass} no-underline`}
+            className={`${locationLinkClass} ${focusableBadgeClass}`}
             title={name}
           >
             {compact}
           </a>
         ) : (
-          <span title={name} className={locationBadgeClass}>
+          <span title={name} className={locationTextClass}>
             {compact}
           </span>
         );

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -10,12 +10,12 @@ function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (
     <div
       data-slot="table-container"
-      className="relative w-full overflow-x-auto rounded-xl border border-border dark:border-border/60 shadow-sm lg:overflow-x-visible"
+      className="relative w-full overflow-x-auto scroll-smooth rounded-xl border border-border/70 bg-background shadow-sm dark:border-border/60 lg:overflow-x-auto"
     >
       <table
         data-slot="table"
         className={cn(
-          "w-full caption-bottom text-[12px] leading-tight text-foreground dark:text-foreground table-auto font-ui border-collapse",
+          "min-w-full table-auto caption-bottom font-ui text-[12px] leading-tight text-foreground dark:text-foreground",
           "sm:text-[13px]",
           className,
         )}
@@ -69,19 +69,16 @@ function TableRow({ className, variant = "body", ...props }: TableRowProps) {
       data-slot="table-row"
       className={cn(
         "group relative isolate transition-colors",
-        "border-b border-border dark:border-border/60",
         isBodyRow
           ? [
-              "before:absolute before:inset-x-1 before:top-0.5 before:bottom-0.5 before:-z-10 before:rounded-[1.35rem] before:opacity-90",
-              "before:bg-[repeating-linear-gradient(90deg,rgba(148,163,184,0.24)_0,rgba(148,163,184,0.24)_14%,rgba(100,116,139,0.18)_14%,rgba(100,116,139,0.18)_28%)]",
-              "dark:before:bg-[repeating-linear-gradient(90deg,rgba(71,85,105,0.45)_0,rgba(71,85,105,0.45)_14%,rgba(30,41,59,0.55)_14%,rgba(30,41,59,0.55)_28%)]",
-              "before:ring-1 before:ring-slate-300/60 before:transition-opacity before:duration-150 dark:before:ring-slate-600/70",
-              "hover:before:opacity-100",
+              "odd:bg-sky-50/70 even:bg-emerald-50/70 dark:odd:bg-slate-800/70 dark:even:bg-slate-700/70",
+              "odd:text-slate-900 even:text-slate-900 dark:odd:text-slate-100 dark:even:text-slate-100",
+              "hover:odd:bg-sky-100/80 hover:even:bg-emerald-100/80 dark:hover:odd:bg-slate-700 dark:hover:even:bg-slate-600",
             ]
-          : "",
+          : "bg-muted/80",
         "data-[state=selected]:bg-transparent data-[state=selected]:text-foreground",
         "dark:data-[state=selected]:bg-transparent dark:data-[state=selected]:text-foreground",
-        "min-h-[2rem] text-[12px] sm:min-h-[2.25rem] sm:text-sm",
+        "min-h-[2.5rem] text-[12px] sm:min-h-[2.75rem] sm:text-sm",
         className,
       )}
       {...props}
@@ -94,7 +91,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "text-foreground border border-border dark:border-border/60 px-2 py-2 text-left align-middle font-semibold",
+        "text-foreground border-b border-border/70 px-2 py-2 text-left align-middle font-semibold",
         "text-[11px] leading-snug sm:px-2.5 sm:text-[13px]",
         "whitespace-normal [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
@@ -109,10 +106,10 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "relative z-[1] border border-border dark:border-border/60 px-2 py-1.5 align-top text-[12px] leading-snug",
-        "data-[state=selected]:bg-muted data-[state=selected]:text-foreground",
+        "relative z-[1] px-2 py-2 align-middle text-[12px] leading-snug",
+        "data-[state=selected]:bg-muted/80 data-[state=selected]:text-foreground",
         "dark:data-[state=selected]:bg-muted/50 dark:data-[state=selected]:text-foreground",
-        "sm:px-2.5 sm:py-2 sm:text-sm",
+        "sm:px-2.5 sm:text-sm",
         "whitespace-normal [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
       )}


### PR DESCRIPTION
## Что сделано и зачем
- убрал общие прямоугольные бейджи и ограничил текст в ключевых колонках, чтобы высота строк стала стабильной и контент не расползался
- переработал TableRow/TableCell: убрал внутренние границы, добавил чередование цветовых оттенков и плавную горизонтальную прокрутку контейнера

## Чек-лист
- [x] `pnpm lint`
- [x] `pnpm --filter web lint`
- [x] `pnpm build`

## Логи
- `pnpm lint`
- `pnpm --filter web lint`
- `pnpm build`

## Самопроверка
- визуально проверил страницу `/tasks` через dev-server
- убедился, что строки таблицы ведут себя одинаково по высоте и прокрутка работает мягко
- статусы и приоритеты сохранили цветовую кодировку


------
https://chatgpt.com/codex/tasks/task_b_68d268277cc88320a50def2d3d72f9f5