### PR TITLE
feat: link file attachments to tasks

### DIFF
--- a/apps/api/src/services/tasks.ts
+++ b/apps/api/src/services/tasks.ts
@@ -32,10 +32,13 @@ async function applyRouteInfo(data: TaskData = {}): Promise<void> {
   }
 }
 
-export const create = async (data: TaskData = {}): Promise<unknown> => {
+export const create = async (
+  data: TaskData = {},
+  userId?: number,
+): Promise<unknown> => {
   if (data.due_date && !data.remind_at) data.remind_at = data.due_date;
   await applyRouteInfo(data);
-  return q.createTask(data);
+  return q.createTask(data, userId);
 };
 
 export const get = (

--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -77,7 +77,10 @@ export default class TasksController {
   create = [
     handleValidation,
     async (req: RequestWithUser, res: Response) => {
-      const task = await this.service.create(req.body as Partial<TaskDocument>);
+      const task = await this.service.create(
+        req.body as Partial<TaskDocument>,
+        req.user!.id as number,
+      );
       await writeLog(
         `Создана задача ${task._id} пользователем ${req.user!.id}/${req.user!.username}`,
       );

--- a/apps/api/src/utils/attachments.ts
+++ b/apps/api/src/utils/attachments.ts
@@ -1,0 +1,31 @@
+// Утилиты для работы со вложениями задач
+// Основные модули: mongoose, db/model
+import { Types } from 'mongoose';
+import type { Attachment } from '../db/model';
+
+/**
+ * Извлекает ObjectId файлов из массива вложений задачи.
+ * Допускает URL вида `/api/v1/files/<id>` с дополнительными параметрами.
+ */
+export function extractAttachmentIds(
+  attachments: Attachment[] | undefined | null,
+): Types.ObjectId[] {
+  if (!Array.isArray(attachments) || attachments.length === 0) {
+    return [];
+  }
+  const result: Types.ObjectId[] = [];
+  const seen = new Set<string>();
+  attachments.forEach((attachment) => {
+    if (!attachment || typeof attachment.url !== 'string') return;
+    const [pathPart] = attachment.url.trim().split('?');
+    if (!pathPart) return;
+    const segments = pathPart.split('/').filter(Boolean);
+    const last = segments[segments.length - 1];
+    if (!last || !Types.ObjectId.isValid(last)) return;
+    const key = last.toLowerCase();
+    if (seen.has(key)) return;
+    seen.add(key);
+    result.push(new Types.ObjectId(last));
+  });
+  return result;
+}

--- a/apps/api/tests/taskAttachments.test.ts
+++ b/apps/api/tests/taskAttachments.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Назначение файла: тесты привязки вложений к задачам и проверки доступа.
+ * Основные модули: jest, supertest, express.
+ */
+import express = require('express');
+import request = require('supertest');
+import { Types } from 'mongoose';
+import type { RequestHandler } from 'express';
+
+const createdTaskId = new Types.ObjectId();
+const existingTaskId = new Types.ObjectId();
+const fileId = new Types.ObjectId();
+
+const taskCreateMock = jest.fn(async (data: any) => ({
+  ...data,
+  _id: createdTaskId,
+}));
+const taskFindByIdMock = jest.fn(async () => ({
+  _id: existingTaskId,
+  attachments: [
+    {
+      name: 'file.txt',
+      url: `/api/v1/files/${fileId}`,
+      uploadedBy: 1,
+      uploadedAt: new Date(),
+      type: 'text/plain',
+      size: 10,
+    },
+  ],
+}));
+const taskFindByIdAndUpdateMock = jest.fn(async () => ({
+  _id: existingTaskId,
+  attachments: [],
+}));
+const fileUpdateManyMock = jest.fn(async () => ({}));
+
+jest.mock('../src/db/model', () => ({
+  Task: {
+    create: taskCreateMock,
+    findById: taskFindByIdMock,
+    findByIdAndUpdate: taskFindByIdAndUpdateMock,
+  },
+  Archive: {},
+  User: {},
+  Role: {},
+  File: {
+    updateMany: fileUpdateManyMock,
+  },
+  RoleAttrs: {},
+  TaskTemplate: {},
+  TaskTemplateDocument: {},
+  HistoryEntry: {},
+}));
+
+jest.mock('../src/services/wgLogEngine', () => ({
+  writeLog: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../src/services/tasks', () => ({
+  getById: jest.fn(async () => ({
+    _id: existingTaskId,
+    created_by: 1,
+    assignees: [],
+    controllers: [],
+  })),
+}));
+
+const { createTask, updateTask } = require('../src/db/queries');
+const checkTaskAccess = require('../src/middleware/taskAccess').default as RequestHandler;
+const { ACCESS_USER } = require('../src/utils/accessMask');
+
+describe('Привязка вложений к задачам', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('устанавливает taskId после создания задачи', async () => {
+    const attachments = [
+      {
+        name: 'file.txt',
+        url: `/api/v1/files/${fileId}`,
+        uploadedBy: 7,
+        uploadedAt: new Date(),
+        type: 'text/plain',
+        size: 10,
+      },
+    ];
+    await createTask({ attachments }, 7);
+    expect(taskCreateMock).toHaveBeenCalled();
+    expect(fileUpdateManyMock).toHaveBeenNthCalledWith(
+      1,
+      {
+        _id: { $in: [fileId] },
+        $or: [{ userId: 7 }, { taskId: createdTaskId }],
+      },
+      { $set: { taskId: createdTaskId } },
+    );
+    expect(fileUpdateManyMock).toHaveBeenNthCalledWith(
+      2,
+      {
+        taskId: createdTaskId,
+        _id: { $nin: [fileId] },
+      },
+      { $unset: { taskId: '' } },
+    );
+  });
+
+  test('очищает привязку файлов при удалении вложения', async () => {
+    const result = await updateTask(
+      String(existingTaskId),
+      { attachments: [] },
+      1,
+    );
+    expect(result).not.toBeNull();
+    expect(fileUpdateManyMock).toHaveBeenCalledWith(
+      { taskId: existingTaskId },
+      { $unset: { taskId: '' } },
+    );
+  });
+});
+
+describe('Проверка доступа к задаче другим пользователем', () => {
+  test('возвращает 403 при попытке обновления без прав', async () => {
+    const app = express();
+    app.use((req, _res, next) => {
+      (req as any).user = { id: 99, access: ACCESS_USER };
+      next();
+    });
+    app.patch('/tasks/:id', checkTaskAccess, (_req, res) => {
+      res.json({ ok: true });
+    });
+    const response = await request(app).patch(`/tasks/${existingTaskId}`);
+    expect(response.status).toBe(403);
+  });
+});

--- a/apps/api/tests/tasksService.test.ts
+++ b/apps/api/tests/tasksService.test.ts
@@ -11,6 +11,10 @@ jest.mock('../src/services/route', () => ({
   clearRouteCache: jest.fn(),
 }));
 
+jest.mock('../src/services/wgLogEngine', () => ({
+  writeLog: jest.fn().mockResolvedValue(undefined),
+}));
+
 const route = require('../src/services/route');
 const { generateRouteLink } = require('shared');
 const TasksService = require('../src/tasks/tasks.service.ts').default;


### PR DESCRIPTION
## Summary
- update task creation and update flows to bind uploaded files through `File.updateMany`
- add attachment id parsing helper and log sync events in the task service
- cover attachment binding, unlinking, and unauthorized access with unit tests

## Testing
- pnpm test
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68d28b90fb108320ad4a3a0de1e27300