### PR TITLE
fix: стабилизировать тесты вложений задач

### DIFF
--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -125,7 +125,10 @@ class TasksService {
     this.applyCargoMetrics(payload);
     await this.applyRouteInfo(payload);
     try {
-      const task = await this.repo.createTask(payload, userId);
+      const task =
+        userId === undefined
+          ? await this.repo.createTask(payload)
+          : await this.repo.createTask(payload, userId);
       await clearRouteCache();
       await this.logAttachmentSync(
         'create',

--- a/apps/api/tests/taskAttachments.test.ts
+++ b/apps/api/tests/taskAttachments.test.ts
@@ -8,7 +8,8 @@ import { Types } from 'mongoose';
 import type { RequestHandler } from 'express';
 
 const createdTaskId = new Types.ObjectId();
-const existingTaskId = new Types.ObjectId();
+const mockExistingTaskId = new Types.ObjectId();
+const existingTaskId = mockExistingTaskId;
 const fileId = new Types.ObjectId();
 
 const mockTaskCreate = jest.fn(async (data: any) => ({
@@ -58,7 +59,7 @@ jest.mock('../src/services/wgLogEngine', () => ({
 
 jest.mock('../src/services/tasks', () => ({
   getById: jest.fn(async () => ({
-    _id: existingTaskId,
+    _id: mockExistingTaskId,
     created_by: 1,
     assignees: [],
     controllers: [],


### PR DESCRIPTION
## Что сделано
- убрал обращение мока к переменной без префикса mock, чтобы jest не блокировал тест `taskAttachments`
- скорректировал `TasksService.create`, исключив передачу `undefined` вторым аргументом

## Почему
- docker-сборка падала на jest из-за запрета out-of-scope переменных
- сервис передавал `undefined`, что ломало ожидаемое поведение теста

## Чек-лист
- [x] Локально прошёл `pnpm lint`
- [x] Локально прошёл `pnpm test`

## Логи
- `pnpm lint`
- `pnpm test`

## Самопроверка
- [x] Изменения атомарны
- [x] Названия коммитов и PR соответствуют сути
- [x] Нет закоммиченных артефактов сборки
- [x] Проверил, что тесты падают до правок и проходят после (по логу CI)
- [x] Проверил, что изменения не затрагивают prod-настройки

------
https://chatgpt.com/codex/tasks/task_b_68d2b192912c8320bc8da80bd40f09e2