### PR TITLE
feat: allow task update with empty cargo metrics

### DIFF
--- a/apps/api/src/dto/tasks.dto.ts
+++ b/apps/api/src/dto/tasks.dto.ts
@@ -2,6 +2,17 @@
 // Основные модули: routes, middleware
 import { body } from 'express-validator';
 import { taskFields } from 'shared';
+
+const normalizeEmptyNumeric = (value: unknown) => {
+  if (typeof value === 'string' && value.trim() === '') return null;
+  return value;
+};
+
+const optionalFloatField = (field: string) =>
+  body(field)
+    .customSanitizer(normalizeEmptyNumeric)
+    .optional({ nullable: true })
+    .isFloat({ min: 0 });
 const statusField = taskFields.find((f) => f.name === 'status');
 const statusList: readonly string[] = statusField?.options ?? [
   'Новая',
@@ -18,11 +29,11 @@ export class CreateTaskDto {
       body('status').optional().isString().isIn(statusList),
       body('start_date').optional().isISO8601(),
       body('assignees').optional().isArray(),
-      body('cargo_length_m').optional().isFloat({ min: 0 }),
-      body('cargo_width_m').optional().isFloat({ min: 0 }),
-      body('cargo_height_m').optional().isFloat({ min: 0 }),
-      body('cargo_volume_m3').optional().isFloat({ min: 0 }),
-      body('cargo_weight_kg').optional().isFloat({ min: 0 }),
+      optionalFloatField('cargo_length_m'),
+      optionalFloatField('cargo_width_m'),
+      optionalFloatField('cargo_height_m'),
+      optionalFloatField('cargo_volume_m3'),
+      optionalFloatField('cargo_weight_kg'),
     ];
   }
 }
@@ -33,11 +44,11 @@ export class UpdateTaskDto {
       body('title').optional().isString(),
       body('task_description').optional().isString().isLength({ max: 4096 }),
       body('status').optional().isString().isIn(statusList),
-      body('cargo_length_m').optional().isFloat({ min: 0 }),
-      body('cargo_width_m').optional().isFloat({ min: 0 }),
-      body('cargo_height_m').optional().isFloat({ min: 0 }),
-      body('cargo_volume_m3').optional().isFloat({ min: 0 }),
-      body('cargo_weight_kg').optional().isFloat({ min: 0 }),
+      optionalFloatField('cargo_length_m'),
+      optionalFloatField('cargo_width_m'),
+      optionalFloatField('cargo_height_m'),
+      optionalFloatField('cargo_volume_m3'),
+      optionalFloatField('cargo_weight_kg'),
     ];
   }
 }

--- a/apps/api/tests/tasks.test.ts
+++ b/apps/api/tests/tasks.test.ts
@@ -144,6 +144,16 @@ test('обновление задачи', async () => {
   expect(res.body.status).toBe('Выполнена');
 });
 
+test('обновление с очисткой габаритов проходит валидацию', async () => {
+  const res = await request(app)
+    .patch(`/api/v1/tasks/${id}`)
+    .send({ cargo_length_m: '', cargo_weight_kg: '   ' });
+  expect(res.status).toBe(200);
+  const [, update] = Task.findByIdAndUpdate.mock.calls.at(-1);
+  expect(update.$set).not.toHaveProperty('cargo_length_m', '');
+  expect(update.$set).not.toHaveProperty('cargo_weight_kg', '   ');
+});
+
 test('добавление времени', async () => {
   await request(app).patch(`/api/v1/tasks/${id}/time`).send({ minutes: 15 });
   expect(Task.findById).toHaveBeenCalled();


### PR DESCRIPTION
## Что сделано
- добавил санитайзер числовых полей формы задач, допускающий очистку значений при обновлении
- расширил интеграционный тест задач кейсом с пустыми габаритами, убеждаясь в отсутствии строковых значений в update

## Зачем
- без санитайзера PATCH /api/v1/tasks возвращал 400 при попытке сохранить задачу с пустыми полями габаритов
- тест фиксирует регрессию и показывает, что БД больше не получает значения с пробелами

## Логи
- `./scripts/setup_and_test.sh`

## Чек-лист
- [x] Тесты зелёные
- [x] Линтер без ошибок
- [x] Сборка проходит (в составе скрипта)
- [x] Обратная совместимость сохранена

## Самопроверка
- [x] Изменения покрыты тестом
- [x] Учтены требования AGENTS.md
- [x] Пройдены предписанные скрипты


------
https://chatgpt.com/codex/tasks/task_b_68d2d3b305188320916e0479bde446c0