### PR TITLE
feat: show creator column and harden attachment parsing

### DIFF
--- a/apps/api/src/utils/attachments.ts
+++ b/apps/api/src/utils/attachments.ts
@@ -1,7 +1,124 @@
 // Утилиты для работы со вложениями задач
-// Основные модули: mongoose, db/model
+// Основные модули: json5, mongoose, db/model
+import JSON5 from 'json5';
 import { Types } from 'mongoose';
 import type { Attachment } from '../db/model';
+
+const jsonParsers = [
+  JSON.parse,
+  JSON5.parse,
+];
+
+const isPlainObject = (
+  value: unknown,
+): value is Record<string, unknown> =>
+  Boolean(value && typeof value === 'object' && !Array.isArray(value));
+
+const toNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return undefined;
+    const parsed = Number(trimmed);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+};
+
+const toDate = (value: unknown): Date | undefined => {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value;
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+  return undefined;
+};
+
+const normalizeAttachmentRecord = (
+  input: Record<string, unknown>,
+): Attachment | null => {
+  const urlRaw = typeof input.url === 'string' ? input.url.trim() : '';
+  if (!urlRaw) {
+    return null;
+  }
+  const nameRaw = input.name;
+  const name =
+    typeof nameRaw === 'string' && nameRaw.trim()
+      ? nameRaw.trim()
+      : urlRaw.split('/').pop() || urlRaw;
+  const thumbnailUrl =
+    typeof input.thumbnailUrl === 'string' && input.thumbnailUrl.trim()
+      ? input.thumbnailUrl
+      : undefined;
+  const uploadedBy = toNumber(input.uploadedBy);
+  const uploadedAt = toDate(input.uploadedAt);
+  const type =
+    typeof input.type === 'string' && input.type.trim()
+      ? input.type
+      : 'application/octet-stream';
+  const size = toNumber(input.size);
+
+  const normalized: Attachment = {
+    name,
+    url: urlRaw,
+    thumbnailUrl,
+    uploadedBy,
+    uploadedAt,
+    type,
+    size,
+  } as Attachment;
+
+  return normalized;
+};
+
+function parseAttachmentLike(value: unknown): Attachment[] | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return [];
+    }
+    for (const parse of jsonParsers) {
+      try {
+        const parsed = parse(trimmed);
+        const result = parseAttachmentLike(parsed);
+        if (result) {
+          return result;
+        }
+      } catch {
+        // пробуем следующий парсер
+      }
+    }
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value
+      .filter(isPlainObject)
+      .map((item) => normalizeAttachmentRecord(item))
+      .filter((item): item is Attachment => item !== null);
+  }
+  if (isPlainObject(value)) {
+    const single = normalizeAttachmentRecord(value);
+    return single ? [single] : [];
+  }
+  return [];
+}
+
+export function coerceAttachments(
+  value: unknown,
+): Attachment[] | undefined {
+  return parseAttachmentLike(value);
+}
 
 /**
  * Извлекает ObjectId файлов из массива вложений задачи.

--- a/apps/web/src/columns/taskColumns.tsx
+++ b/apps/web/src/columns/taskColumns.tsx
@@ -33,7 +33,10 @@ const numberBadgeClass =
   `${pillBadgeBaseClass} justify-center font-mono uppercase tracking-[0.18em] text-[0.68rem] text-slate-900 ring-1 ring-slate-500/30 bg-slate-500/10 dark:bg-slate-500/20 dark:text-slate-100 dark:ring-slate-400/30`;
 
 const titleBadgeClass =
-  `${pillBadgeBaseClass} max-w-full justify-start normal-case text-slate-900 ring-1 ring-indigo-500/35 bg-indigo-500/12 dark:bg-indigo-400/15 dark:text-slate-100 dark:ring-indigo-400/30`;
+  `${pillBadgeBaseClass} max-w-full w-full justify-start normal-case text-slate-900 ring-1 ring-indigo-500/35 bg-indigo-500/12 dark:bg-indigo-400/15 dark:text-slate-100 dark:ring-indigo-400/30`;
+
+const creatorBadgeClass =
+  `${pillBadgeBaseClass} max-w-full w-full justify-start normal-case text-indigo-900 ring-1 ring-indigo-500/35 bg-indigo-500/12 dark:bg-indigo-400/15 dark:text-slate-100 dark:ring-indigo-400/30`;
 
 const fallbackBadgeClass = buildBadgeClass(
   "bg-muted/60 ring-1 ring-muted-foreground/30 dark:bg-slate-700/60 dark:ring-slate-500/35",
@@ -352,15 +355,47 @@ export default function taskColumns(
       },
     },
     {
-      header: "Дата создания",
+      header: "Задачу создал",
       accessorKey: "createdAt",
       meta: {
-        width: "clamp(6.75rem, 11vw, 8.75rem)",
-        minWidth: "6.5rem",
-        maxWidth: "9rem",
-        cellClassName: "whitespace-nowrap text-xs sm:text-sm",
+        width: "clamp(9rem, 18vw, 14rem)",
+        minWidth: "8.5rem",
+        maxWidth: "16rem",
+        cellClassName: "whitespace-nowrap",
       },
-      cell: (p) => renderDateCell(p.getValue<string>()),
+      cell: ({ row }) => {
+        const rawCreator =
+          (row.original.created_by as unknown) ??
+          (row.original.createdBy as unknown) ??
+          (row.original.creator as unknown);
+        const creatorId =
+          typeof rawCreator === "number"
+            ? rawCreator
+            : typeof rawCreator === "string" && rawCreator.trim()
+            ? Number(rawCreator)
+            : NaN;
+        if (!Number.isFinite(creatorId)) {
+          return <span className="text-muted-foreground">—</span>;
+        }
+        const id = creatorId as number;
+        const user = users[id];
+        const label =
+          (user?.name as string | undefined) ||
+          (user?.telegram_username as string | undefined) ||
+          (user?.username as string | undefined) ||
+          String(id);
+        const title = label.trim() || String(id);
+        return (
+          <EmployeeLink
+            employeeId={id}
+            stopPropagation
+            title={title}
+            className={`${creatorBadgeClass} ${focusableBadgeClass} no-underline`}
+          >
+            <span className="truncate">{compactText(label, 32)}</span>
+          </EmployeeLink>
+        );
+      },
     },
     {
       header: "Название",
@@ -375,7 +410,7 @@ export default function taskColumns(
         const v = p.getValue<string>() || "";
         const compact = compactText(v, 72);
         return (
-          <span title={v} className={`${titleBadgeClass} max-w-full`}>
+          <span title={v} className={titleBadgeClass}>
             <span className="truncate">{compact}</span>
           </span>
         );


### PR DESCRIPTION
## Summary
- replace the "Дата создания" column with a creator badge and make the title pill width deterministic
- normalize attachment payloads in task create/update flows and reuse the parser in the routes
- extend attachment unit tests to cover JSON/string payloads

## Testing
- pnpm lint
- pnpm test:unit


------
https://chatgpt.com/codex/tasks/task_b_68d2df8bc9008320870bb39c844ebb3f