### PR TITLE
feat: сузить колонку названия задач

### DIFF
--- a/apps/web/src/columns/taskColumns.tsx
+++ b/apps/web/src/columns/taskColumns.tsx
@@ -33,7 +33,7 @@ const numberBadgeClass =
   `${pillBadgeBaseClass} justify-center font-mono uppercase tracking-[0.18em] text-[0.68rem] text-slate-900 ring-1 ring-slate-500/30 bg-slate-500/10 dark:bg-slate-500/20 dark:text-slate-100 dark:ring-slate-400/30`;
 
 const titleBadgeClass =
-  `${pillBadgeBaseClass} max-w-full w-full justify-start normal-case text-slate-900 ring-1 ring-indigo-500/35 bg-indigo-500/12 dark:bg-indigo-400/15 dark:text-slate-100 dark:ring-indigo-400/30`;
+  `${pillBadgeBaseClass} justify-start normal-case text-slate-900 ring-1 ring-indigo-500/35 bg-indigo-500/12 dark:bg-indigo-400/15 dark:text-slate-100 dark:ring-indigo-400/30`;
 
 const creatorBadgeClass =
   `${pillBadgeBaseClass} max-w-full w-full justify-start normal-case text-indigo-900 ring-1 ring-indigo-500/35 bg-indigo-500/12 dark:bg-indigo-400/15 dark:text-slate-100 dark:ring-indigo-400/30`;
@@ -401,9 +401,9 @@ export default function taskColumns(
       header: "Название",
       accessorKey: "title",
       meta: {
-        width: "clamp(12rem, 32vw, 26rem)",
-        minWidth: "10rem",
-        maxWidth: "26rem",
+        width: "clamp(6rem, 16vw, 13rem)",
+        minWidth: "5rem",
+        maxWidth: "13rem",
         cellClassName: "whitespace-nowrap",
       },
       cell: (p) => {

--- a/apps/web/src/pages/AttachmentMenu.tsx
+++ b/apps/web/src/pages/AttachmentMenu.tsx
@@ -26,9 +26,13 @@ export default function AttachmentMenu() {
   }, [addToast]);
 
   function select(id: string) {
-    if (window.Telegram?.WebApp?.sendData) {
-      window.Telegram.WebApp.sendData(`task_selected:${id}`);
-    }
+    type TelegramApi = {
+      WebApp?: {
+        sendData?: (data: string) => void;
+      };
+    };
+    const telegram = (globalThis as typeof globalThis & { Telegram?: TelegramApi }).Telegram;
+    telegram?.WebApp?.sendData?.(`task_selected:${id}`);
   }
 
   return (


### PR DESCRIPTION
## Summary
- уменьшить ширину колонки «Название» в таблице задач и убрать принудительную ширину бейджа
- смягчить обращение к Telegram WebApp в меню вложений, чтобы типы не падали в среде тестов

## Testing
- pnpm test
- pnpm lint

## Checklist
- [x] Тесты `pnpm test` пройдены
- [x] Линтер `pnpm lint` пройден
- [x] Сборка `pnpm build` пройдена
- [x] Обратная совместимость сохранена

## Risk Notes
- Более узкая колонка может сильнее обрезать длинные названия; откат — вернуть прежние размеры и классы ширины.
- При необходимости прямого обращения к window.Telegram может потребоваться доработка типизации.

------
https://chatgpt.com/codex/tasks/task_b_68d2f9eaa090832089a05a7e1112a8b1