### PR TITLE
feat: reorder assignees column badges

### DIFF
--- a/apps/web/src/columns/__tests__/taskColumns.test.tsx
+++ b/apps/web/src/columns/__tests__/taskColumns.test.tsx
@@ -1,0 +1,50 @@
+/** @jest-environment jsdom */
+// Назначение: проверяет колонку исполнителей таблицы задач.
+// Основные модули: React, Testing Library, taskColumns.
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MemoryRouter } from "react-router-dom";
+import taskColumns, { TaskRow } from "../taskColumns";
+
+describe("taskColumns", () => {
+  it("формирует тултип и переносы для нескольких исполнителей", () => {
+    const users = {
+      1: { name: "Александр Александров" },
+      2: { telegram_username: "ivanov" },
+    } as Record<number, any>;
+
+    const row = {
+      assignees: [1, 2],
+    } as TaskRow;
+
+    const columns = taskColumns(users);
+    const assigneesColumn = columns.find(
+      (col): col is typeof col & { accessorKey: string } =>
+        typeof (col as { accessorKey?: unknown }).accessorKey === "string" &&
+        (col as { accessorKey?: string }).accessorKey === "assignees",
+    );
+    expect(assigneesColumn).toBeDefined();
+
+    const cellRenderer = assigneesColumn?.cell as
+      | ((context: any) => React.ReactNode)
+      | undefined;
+    expect(cellRenderer).toBeDefined();
+    const cell = cellRenderer?.({
+      row: { original: row },
+    } as any);
+
+    const tooltip = "Александр Александров, ivanov";
+    render(<MemoryRouter>{cell as React.ReactElement}</MemoryRouter>);
+
+    const wrapper = screen.getByTitle(tooltip);
+    expect(wrapper).toHaveClass("flex-wrap");
+
+    const badges = screen.getAllByRole("button");
+    expect(badges).toHaveLength(2);
+    expect(badges[0]).toHaveClass("ring-indigo-500/35");
+    expect(within(badges[0]).getByText(/Александр/)).toHaveClass("truncate");
+    expect(badges[0].textContent).toMatch(/…$/);
+    expect(badges[1].textContent).toBe("ivanov");
+  });
+});

--- a/apps/web/src/columns/taskColumns.tsx
+++ b/apps/web/src/columns/taskColumns.tsx
@@ -14,9 +14,6 @@ const buildBadgeClass = (
   textClass = "text-primary dark:text-primary",
 ) => `${badgeBaseClass} transition-colors ${textClass} ${tones}`;
 
-const assigneeBadgeClass =
-  "inline-flex items-center gap-1 whitespace-nowrap rounded-full bg-indigo-500/15 px-2 py-0.5 text-left text-xs font-medium text-indigo-900 transition-colors hover:bg-indigo-500/25 dark:bg-indigo-400/20 dark:text-indigo-100 dark:hover:bg-indigo-400/30";
-
 const focusableBadgeClass =
   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 
@@ -99,7 +96,7 @@ const priorityBadgeClassMap: Record<string, string> = {
   ),
 };
 
-const hasOwn = <T extends Record<string, unknown>>(obj: T, key: string): key is keyof T =>
+const hasOwn = <T extends Record<PropertyKey, unknown>>(obj: T, key: PropertyKey): key is keyof T =>
   Object.prototype.hasOwnProperty.call(obj, key);
 
 const getStatusBadgeClass = (value: string) => {
@@ -417,6 +414,51 @@ export default function taskColumns(
       },
     },
     {
+      header: "Исполнители",
+      accessorKey: "assignees",
+      meta: {
+        width: "clamp(7rem, 20vw, 13rem)",
+        minWidth: "6rem",
+        maxWidth: "13rem",
+      },
+      cell: ({ row }) => {
+        const ids: number[] =
+          row.original.assignees ||
+          (row.original.assigned_user_id
+            ? [row.original.assigned_user_id]
+            : []);
+        if (!ids.length) {
+          return <span className="text-muted-foreground">—</span>;
+        }
+        const labels = ids.map((id) => ({
+          id,
+          label:
+            users[id]?.name ||
+            users[id]?.telegram_username ||
+            users[id]?.username ||
+            String(id),
+        }));
+        const tooltip = labels.map((item) => item.label).join(", ");
+        return (
+          <div
+            className="flex w-full flex-wrap items-start gap-1 leading-tight"
+            title={tooltip}
+          >
+            {labels.map(({ id, label }) => (
+              <EmployeeLink
+                key={id}
+                employeeId={id}
+                stopPropagation
+                className={`${creatorBadgeClass} ${focusableBadgeClass} no-underline`}
+              >
+                <span className="truncate">{compactText(label, 18)}</span>
+              </EmployeeLink>
+            ))}
+          </div>
+        );
+      },
+    },
+    {
       header: "Статус",
       accessorKey: "status",
       meta: {
@@ -596,51 +638,6 @@ export default function taskColumns(
           <span className={className} title={`${display} км`}>
             {display}
           </span>
-        );
-      },
-    },
-    {
-      header: "Исполнители",
-      accessorKey: "assignees",
-      meta: {
-        width: "clamp(7rem, 20vw, 13rem)",
-        minWidth: "6rem",
-        maxWidth: "13rem",
-      },
-      cell: ({ row }) => {
-        const ids: number[] =
-          row.original.assignees ||
-          (row.original.assigned_user_id
-            ? [row.original.assigned_user_id]
-            : []);
-        if (!ids.length) {
-          return <span className="text-muted-foreground">—</span>;
-        }
-        const labels = ids.map((id) => ({
-          id,
-          label:
-            users[id]?.name ||
-            users[id]?.telegram_username ||
-            users[id]?.username ||
-            String(id),
-        }));
-        const tooltip = labels.map((item) => item.label).join(", ");
-        return (
-          <div
-            className="flex w-full flex-wrap items-start gap-1 leading-tight"
-            title={tooltip}
-          >
-            {labels.map(({ id, label }) => (
-              <EmployeeLink
-                key={id}
-                employeeId={id}
-                stopPropagation
-                className={`${assigneeBadgeClass} ${focusableBadgeClass} no-underline`}
-              >
-                {compactText(label, 18)}
-              </EmployeeLink>
-            ))}
-          </div>
         );
       },
     },


### PR DESCRIPTION
## Что сделано и зачем
- переместил колонку исполнителей сразу за названием задачи, чтобы карточка легче читалась и группы исполнителей были заметнее
- переиспользовал стили бейджа автора для исполнителей, избавившись от дублирования
- добавил юнит-тест на рендер колонки с несколькими исполнителями, проверяющий тултип и переносы

## Чек-лист
- [x] `pnpm test:unit`
- [x] `pnpm lint`

## Логи
- `pnpm test:unit`
- `pnpm lint`

## Самопроверка
- UI-колонка рендерится с нужными классами и тултипом
- Структура колонок соответствует требованию (исполнители сразу после названия)
- Повторного определения классов для бейджей нет

## Risk notes
- При ошибке можно вернуть предыдущую версию `apps/web/src/columns/taskColumns.tsx`


------
https://chatgpt.com/codex/tasks/task_b_68d302194db48320b63fc4ee9d8f863d