### PR TITLE
feat: add tasks dashboard heading and adjust font loading

### DIFF
--- a/apps/api/public/index.html
+++ b/apps/api/public/index.html
@@ -6,8 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Управление задачами">
     <meta property="og:image" content="/hero/index.png">
-    <link rel="preload" href="/fonts/fonts.css" as="style" onload="this.onload=null;this.rel='stylesheet'" integrity="sha384-ANYe6kBj3YAwKw4e6vf9b57mQdtxRLl1bMsNEb+bbAOT4vceykEa8cURYlyy2zL8" crossorigin="anonymous">
-    <noscript><link rel="stylesheet" href="/fonts/fonts.css" integrity="sha384-ANYe6kBj3YAwKw4e6vf9b57mQdtxRLl1bMsNEb+bbAOT4vceykEa8cURYlyy2zL8" crossorigin="anonymous"></noscript>
+    <link rel="stylesheet" href="/fonts/fonts.css" integrity="sha384-ANYe6kBj3YAwKw4e6vf9b57mQdtxRLl1bMsNEb+bbAOT4vceykEa8cURYlyy2zL8" crossorigin="anonymous">
     <title>ERM Web App</title>
     <script type="module" crossorigin="anonymous" src="/assets/index-BIBFFpjG.js" integrity="sha384-o5GXsWTzEttKZqBvomYx3qaFMv1PRd8VlfssOS3LkYs4iAuBV2JMLJnVO1uq89uP"></script>
     <link rel="modulepreload" crossorigin="anonymous" href="/assets/react-DSrzR8JC.js" integrity="sha384-H2sC4wLvMuOhQRrkzTM7Oj+CRyDUag3gn3aiMVN2yZxMX7R861tsNdZF/eqkErN3">

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -9,13 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Управление задачами" />
     <meta property="og:image" content="/hero/index.png" />
-    <link
-      rel="preload"
-      href="/fonts/fonts.css"
-      as="style"
-      onload="this.onload=null;this.rel='stylesheet'"
-    />
-    <noscript><link rel="stylesheet" href="/fonts/fonts.css" /></noscript>
+    <link rel="stylesheet" href="/fonts/fonts.css" />
     <title>ERM Web App</title>
     <script type="module" src="/src/themeInit.ts"></script>
   </head>

--- a/apps/web/src/pages/TasksPage.tsx
+++ b/apps/web/src/pages/TasksPage.tsx
@@ -85,6 +85,9 @@ export default function TasksPage() {
     return <div className="p-4">У вас нет прав для просмотра задач</div>;
   return (
     <div className="space-y-6">
+      <h1 className="text-3xl font-semibold text-slate-900 dark:text-slate-100">
+        Панель управления задачами
+      </h1>
       {loading && <div>Загрузка...</div>}
       <TaskTable
         tasks={tasks}


### PR DESCRIPTION
## Что сделано
- добавлен заголовок «Панель управления задачами» на страницу списка задач
- заменена предзагрузка файла шрифтов на прямое подключение стилей, чтобы убрать предупреждения Chrome

## Зачем
- повысить понятность интерфейса и устранить ворнинги консоли о неиспользуемом preload

## Чек-лист
- [x] `pnpm --filter web lint`
- [x] `pnpm --filter web build`
- [x] обратная совместимость сохранена

## Логи команд
- `pnpm --filter web lint`
- `pnpm --filter web build`

## Самопроверка
1. Заголовок отображается и не ломает вёрстку
2. Предупреждения о preload больше не воспроизводятся в devtools
3. Локальная сборка проходит без ошибок

------
https://chatgpt.com/codex/tasks/task_b_68d313eedb488320b4fa1ebd0966ec0b