### PR TITLE
feat: highlight task deadlines

### DIFF
--- a/apps/web/src/columns/taskColumns.tsx
+++ b/apps/web/src/columns/taskColumns.tsx
@@ -1,9 +1,18 @@
 // Конфигурация колонок задач для React Table
-// Модули: React, @tanstack/react-table, EmployeeLink
+// Модули: React, @tanstack/react-table, heroicons, EmployeeLink
 import React from "react";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { Task } from "shared";
+import {
+  ClockIcon,
+  QuestionMarkCircleIcon,
+  StopCircleIcon,
+} from "@heroicons/react/20/solid";
 import EmployeeLink from "../components/EmployeeLink";
+import {
+  formatDurationShort,
+  getDeadlineState,
+} from "./taskDeadline";
 
 // Оформление бейджей статусов и приоритетов на дизайн-токенах
 const badgeBaseClass =
@@ -515,15 +524,128 @@ export default function taskColumns(
       cell: (p) => renderDateCell(p.getValue<string>()),
     },
     {
-      header: "Срок",
+      header: "Выполнить до",
       accessorKey: "due_date",
       meta: {
-        width: "clamp(6.75rem, 11vw, 8.75rem)",
-        minWidth: "6.5rem",
-        maxWidth: "9rem",
+        width: "clamp(7.75rem, 12.5vw, 10rem)",
+        minWidth: "7.5rem",
+        maxWidth: "10.5rem",
         cellClassName: "whitespace-nowrap text-xs sm:text-sm",
       },
-      cell: (p) => renderDateCell(p.getValue<string>()),
+      cell: (p) => {
+        const dueValue = p.getValue<string>();
+        const row = p.row.original;
+        const formatted = formatDate(dueValue);
+        const state = getDeadlineState(row.start_date, row.due_date);
+
+        if (state.kind === "invalid") {
+          return (
+            <span
+              className={`${dateBadgeClass} flex min-w-0 items-center gap-1`}
+              title={
+                state.reason === "missing"
+                  ? "Срок не назначен"
+                  : "Срок указан некорректно"
+              }
+            >
+              <QuestionMarkCircleIcon
+                className="size-4 flex-shrink-0 text-slate-400 dark:text-slate-500"
+                aria-hidden
+              />
+              <span className="truncate">Нет данных</span>
+            </span>
+          );
+        }
+
+        const isOverdue = state.kind === "overdue";
+        const iconClassName =
+          state.kind === "countdown"
+            ? state.level === "safe"
+              ? "text-emerald-600 dark:text-emerald-400"
+              : state.level === "warn"
+                ? "text-amber-500 dark:text-amber-300"
+                : "text-orange-500 dark:text-orange-300"
+            : isOverdue
+              ? "text-rose-600 dark:text-rose-400"
+              : "text-slate-400 dark:text-slate-500";
+
+        const remainingLabel =
+          state.remainingMs !== null
+            ? formatDurationShort(state.remainingMs)
+            : null;
+
+        const subtitle = (() => {
+          if (state.remainingMs === null) {
+            return null;
+          }
+          if (isOverdue) {
+            return `Просрочено на ${remainingLabel}`;
+          }
+          if (state.kind === "pending") {
+            return state.issue === "missing-start"
+              ? "Нет даты начала"
+              : "Диапазон дат некорректен";
+          }
+          return `Осталось ${remainingLabel}`;
+        })();
+
+        const percentLabel =
+          state.kind === "countdown"
+            ? `${Math.round(state.ratio * 100)}%`
+            : null;
+
+        const icon = isOverdue ? (
+          <StopCircleIcon
+            className={`size-4 flex-shrink-0 ${iconClassName}`}
+            aria-hidden
+          />
+        ) : (
+          <ClockIcon
+            className={`size-4 flex-shrink-0 ${iconClassName}`}
+            aria-hidden
+          />
+        );
+
+        return (
+          <span
+            className={`${dateBadgeClass} flex min-w-0 flex-col gap-0.5`}
+            title={
+              formatted
+                ? isOverdue
+                  ? `Просрочено с ${formatted.full}`
+                  : `Выполнить до ${formatted.full}`
+                : undefined
+            }
+          >
+            <span className="flex min-w-0 items-center gap-1">
+              {icon}
+              {formatted ? (
+                <time
+                  dateTime={dueValue}
+                  className="flex min-w-0 items-baseline gap-1 truncate tabular-nums"
+                >
+                  <span className="truncate">{formatted.date}</span>
+                  {formatted.time ? (
+                    <span className={dateBadgeTimeClass}>{formatted.time}</span>
+                  ) : null}
+                </time>
+              ) : (
+                <span className="truncate">{row.due_date}</span>
+              )}
+              {percentLabel ? (
+                <span className="ml-auto shrink-0 text-[0.62rem] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-200">
+                  {percentLabel}
+                </span>
+              ) : null}
+            </span>
+            {subtitle ? (
+              <span className="truncate text-[0.62rem] font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-300">
+                {subtitle}
+              </span>
+            ) : null}
+          </span>
+        );
+      },
     },
     {
       header: "Тип",

--- a/apps/web/src/columns/taskDeadline.test.ts
+++ b/apps/web/src/columns/taskDeadline.test.ts
@@ -1,0 +1,73 @@
+// Назначение файла: юнит-тесты утилит расчёта сроков задач.
+// Основные модули: Jest, taskDeadline.
+
+import { formatDurationShort, getDeadlineState } from "./taskDeadline";
+
+describe("getDeadlineState", () => {
+  const start = "2024-01-01T00:00:00.000Z";
+  const due = "2024-01-11T00:00:00.000Z";
+
+  it("возвращает зелёный уровень при запасе свыше 60%", () => {
+    const state = getDeadlineState(start, due, new Date("2024-01-02T00:00:00.000Z"));
+    expect(state.kind).toBe("countdown");
+    if (state.kind !== "countdown") throw new Error("state kind mismatch");
+    expect(state.level).toBe("safe");
+    expect(state.ratio).toBeCloseTo(0.9, 3);
+  });
+
+  it("возвращает жёлтый уровень при остатке между 20% и 59%", () => {
+    const state = getDeadlineState(start, due, new Date("2024-01-07T00:00:00.000Z"));
+    expect(state.kind).toBe("countdown");
+    if (state.kind !== "countdown") throw new Error("state kind mismatch");
+    expect(state.level).toBe("warn");
+    expect(state.ratio).toBeCloseTo(0.4, 3);
+  });
+
+  it("возвращает оранжевый уровень при остатке менее 20%", () => {
+    const state = getDeadlineState(start, due, new Date("2024-01-10T00:00:00.000Z"));
+    expect(state.kind).toBe("countdown");
+    if (state.kind !== "countdown") throw new Error("state kind mismatch");
+    expect(state.level).toBe("danger");
+    expect(state.ratio).toBeCloseTo(0.1, 3);
+  });
+
+  it("фиксирует просрочку при дате в прошлом", () => {
+    const state = getDeadlineState(start, due, new Date("2024-01-12T00:00:00.000Z"));
+    expect(state.kind).toBe("overdue");
+  });
+
+  it("обрабатывает отсутствие срока", () => {
+    const state = getDeadlineState(start, undefined, new Date("2024-01-02T00:00:00.000Z"));
+    expect(state.kind).toBe("invalid");
+  });
+
+  it("сигнализирует об обратном диапазоне", () => {
+    const state = getDeadlineState(
+      "2024-01-20T00:00:00.000Z",
+      "2024-01-10T00:00:00.000Z",
+      new Date("2024-01-05T00:00:00.000Z"),
+    );
+    expect(state.kind).toBe("pending");
+    if (state.kind !== "pending") throw new Error("state kind mismatch");
+    expect(state.issue).toBe("invalid-range");
+  });
+});
+
+describe("formatDurationShort", () => {
+  it("возвращает два значимых компонента", () => {
+    expect(formatDurationShort(5 * 24 * 60 * 60 * 1000 + 3 * 60 * 60 * 1000)).toBe("5д 3ч");
+  });
+
+  it("возвращает минуты при коротком интервале", () => {
+    expect(formatDurationShort(5 * 60 * 1000)).toBe("5м");
+  });
+
+  it("корректно форматирует отрицательные значения", () => {
+    expect(formatDurationShort(-90 * 60 * 1000)).toBe("1ч 30м");
+  });
+
+  it("возвращает специальную метку для интервалов меньше минуты", () => {
+    expect(formatDurationShort(20 * 1000)).toBe("<1м");
+  });
+});
+

--- a/apps/web/src/columns/taskDeadline.ts
+++ b/apps/web/src/columns/taskDeadline.ts
@@ -1,0 +1,170 @@
+// Назначение файла: функции расчёта и форматирования сроков задач.
+// Основные модули: стандартный объект Date.
+
+export type DeadlineLevel = "safe" | "warn" | "danger";
+
+type PendingIssue = "missing-start" | "invalid-range";
+
+type InvalidReason = "missing" | "invalid";
+
+export interface DeadlineStateBase {
+  dueDate: Date | null;
+  startDate: Date | null;
+  remainingMs: number | null;
+}
+
+export interface CountdownState extends DeadlineStateBase {
+  kind: "countdown";
+  remainingMs: number;
+  ratio: number;
+  level: DeadlineLevel;
+}
+
+export interface PendingState extends DeadlineStateBase {
+  kind: "pending";
+  remainingMs: number;
+  issue: PendingIssue;
+}
+
+export interface OverdueState extends DeadlineStateBase {
+  kind: "overdue";
+  remainingMs: number;
+}
+
+export interface InvalidState extends DeadlineStateBase {
+  kind: "invalid";
+  reason: InvalidReason;
+}
+
+export type DeadlineState =
+  | CountdownState
+  | PendingState
+  | OverdueState
+  | InvalidState;
+
+const DAY = 24 * 60 * 60 * 1000;
+const HOUR = 60 * 60 * 1000;
+const MINUTE = 60 * 1000;
+
+const parseDateValue = (value?: string) => {
+  if (!value) {
+    return null;
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+const clampRatio = (value: number) => {
+  if (Number.isNaN(value)) {
+    return 0;
+  }
+  if (value > 1) {
+    return 1;
+  }
+  if (value < 0) {
+    return 0;
+  }
+  return value;
+};
+
+export const getDeadlineState = (
+  startValue?: string,
+  dueValue?: string,
+  referenceDate = new Date(),
+): DeadlineState => {
+  const dueDate = parseDateValue(dueValue);
+  const startDate = parseDateValue(startValue);
+
+  if (!dueDate) {
+    return {
+      kind: "invalid",
+      reason: dueValue ? "invalid" : "missing",
+      dueDate: null,
+      startDate,
+      remainingMs: null,
+    };
+  }
+
+  const remainingMs = dueDate.getTime() - referenceDate.getTime();
+
+  if (remainingMs < 0) {
+    return {
+      kind: "overdue",
+      dueDate,
+      startDate,
+      remainingMs,
+    };
+  }
+
+  if (!startDate) {
+    return {
+      kind: "pending",
+      issue: "missing-start",
+      dueDate,
+      startDate: null,
+      remainingMs,
+    };
+  }
+
+  if (startDate.getTime() >= dueDate.getTime()) {
+    return {
+      kind: "pending",
+      issue: "invalid-range",
+      dueDate,
+      startDate,
+      remainingMs,
+    };
+  }
+
+  const totalMs = dueDate.getTime() - startDate.getTime();
+  const ratio = clampRatio(remainingMs / totalMs);
+  let level: DeadlineLevel;
+  if (ratio > 0.6) {
+    level = "safe";
+  } else if (ratio >= 0.2) {
+    level = "warn";
+  } else {
+    level = "danger";
+  }
+
+  return {
+    kind: "countdown",
+    ratio,
+    level,
+    dueDate,
+    startDate,
+    remainingMs,
+  };
+};
+
+export const formatDurationShort = (value: number) => {
+  if (!Number.isFinite(value) || value === 0) {
+    return "0м";
+  }
+  const abs = Math.abs(value);
+  const parts: string[] = [];
+  let rest = abs;
+
+  const pushPart = (divisor: number, suffix: string) => {
+    const amount = Math.floor(rest / divisor);
+    if (amount > 0) {
+      parts.push(`${amount}${suffix}`);
+      rest -= amount * divisor;
+    }
+  };
+
+  pushPart(DAY, "д");
+  if (parts.length < 2) {
+    pushPart(HOUR, "ч");
+  }
+  if (parts.length < 2) {
+    pushPart(MINUTE, "м");
+  }
+
+  if (parts.length === 0) {
+    return "<1м";
+  }
+
+  return parts.slice(0, 2).join(" ");
+};
+

--- a/tests/playwright/deadline.timer.spec.ts
+++ b/tests/playwright/deadline.timer.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * Назначение файла: e2e-тест расчёта прогресса сроков задач.
+ * Основные модули: @playwright/test, taskDeadline.
+ */
+import { test, expect } from '@playwright/test';
+import { getDeadlineState } from '../../apps/web/src/columns/taskDeadline';
+
+test.describe('Калькулятор сроков задач', () => {
+  const reference = new Date('2024-03-01T12:00:00.000Z');
+
+  test('корректно распределяет уровни рисков', () => {
+    const variants = [
+      {
+        start: '2024-02-20T12:00:00.000Z',
+        due: '2024-03-20T12:00:00.000Z',
+        expectKind: 'countdown' as const,
+        expectLevel: 'safe' as const,
+      },
+      {
+        start: '2024-02-01T12:00:00.000Z',
+        due: '2024-03-15T12:00:00.000Z',
+        expectKind: 'countdown' as const,
+        expectLevel: 'warn' as const,
+      },
+      {
+        start: '2024-02-15T12:00:00.000Z',
+        due: '2024-03-02T12:00:00.000Z',
+        expectKind: 'countdown' as const,
+        expectLevel: 'danger' as const,
+      },
+      {
+        start: '2024-02-01T12:00:00.000Z',
+        due: '2024-02-20T12:00:00.000Z',
+        expectKind: 'overdue' as const,
+      },
+    ];
+
+    for (const variant of variants) {
+      const state = getDeadlineState(variant.start, variant.due, reference);
+      expect(state.kind).toBe(variant.expectKind);
+      if (state.kind === 'countdown') {
+        expect(state.level).toBe(variant.expectLevel);
+      }
+    }
+  });
+
+  test('обрабатывает отсутствующие и повреждённые даты', () => {
+    const withoutDue = getDeadlineState('2024-02-01T12:00:00.000Z', undefined, reference);
+    expect(withoutDue.kind).toBe('invalid');
+
+    const withoutStart = getDeadlineState(undefined, '2024-03-05T12:00:00.000Z', reference);
+    expect(withoutStart.kind).toBe('pending');
+
+    const reversed = getDeadlineState('2024-03-10T12:00:00.000Z', '2024-03-01T12:00:00.000Z', reference);
+    expect(reversed.kind).toBe('pending');
+    if (reversed.kind === 'pending') {
+      expect(reversed.issue).toBe('invalid-range');
+    }
+
+    const invalid = getDeadlineState('2024-02-01T12:00:00.000Z', 'неизвестно', reference);
+    expect(invalid.kind).toBe('invalid');
+  });
+});


### PR DESCRIPTION
## Что сделано и зачем
- добавлен расчёт остатка времени по задачам и цветовые индикаторы с учётом просрочек
- вынесена логика обработки дат в утилиту, покрытa unit- и e2e-тестами, обновлена колонка «Выполнить до»

## Чек-лист
- [x] `pnpm lint`
- [x] `pnpm test:unit`
- [x] `pnpm test:api`
- [x] `pnpm test:e2e`
- [x] `pnpm build`
- [x] Обратная совместимость сохранена

## Логи
- `pnpm lint`
- `pnpm test:unit`
- `pnpm test:api`
- `pnpm test:e2e`
- `pnpm build`

## Самопроверка
- стили и подписи на русском языке
- обработаны ошибки парсинга дат и отсутствующие значения
- пороги цвета соответствуют требованиям (>60%, 20–59%, <20%, просрочка)
- юнит- и e2e-тесты фиксируют критичные сценарии
- линтер и сборка проходят без ошибок

------
https://chatgpt.com/codex/tasks/task_b_68d38b45ebf8832086f979ef560aa371