### PR TITLE
fix: filter font preload tags

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -76,6 +76,8 @@ const modulePreloadPattern = new RegExp(
   "gi",
 );
 
+const fontPreloadPattern = /<link\s[^>]*rel=["'][^"']*preload[^"']*["'][^>]*href=["'][^"']*fonts\/fonts\.css["'][^>]*>/gi;
+
 function filterModulePreloadLinks() {
   return {
     name: "filter-modulepreload-links",
@@ -83,7 +85,15 @@ function filterModulePreloadLinks() {
       if (ctx?.server) {
         return html;
       }
-      return html.replace(modulePreloadPattern, "");
+      const withoutModulePreload = html.replace(modulePreloadPattern, "");
+      return withoutModulePreload.replace(fontPreloadPattern, (tag) => {
+        const hasStylesheet = /rel=["'][^"']*stylesheet[^"']*["']/i.test(tag);
+        const hasAsStyle = /\sas\s*=\s*["']style["']/i.test(tag);
+        if (hasStylesheet && hasAsStyle) {
+          return tag;
+        }
+        return "";
+      });
     },
   };
 }


### PR DESCRIPTION
## Summary
- исключил из финального index.html лишние preload-ссылки на fonts.css во время сборки
- сохранил корректную загрузку шрифтов через базовый линк и проверил доступность css

## Testing
- pnpm lint
- pnpm --filter web build


------
https://chatgpt.com/codex/tasks/task_b_68d39316dfe88320b0c582d4d8e29b5e