### PR TITLE
feat: redesign deadline badge

### DIFF
--- a/apps/web/src/columns/__tests__/taskColumns.test.tsx
+++ b/apps/web/src/columns/__tests__/taskColumns.test.tsx
@@ -82,9 +82,9 @@ describe("taskColumns", () => {
     render(<MemoryRouter>{cell as React.ReactElement}</MemoryRouter>);
 
     const label = screen.getByText(
-      "осталось 04 дней 03 часов 30 минут",
+      "До дедлайна 4 дня 3 часа 30 минут",
     );
-    const badge = label.parentElement;
+    const badge = label.closest("[title]");
     expect(badge).not.toBeNull();
     expect(badge as HTMLElement).toHaveClass("bg-emerald-500/25");
   });
@@ -118,9 +118,9 @@ describe("taskColumns", () => {
     render(<MemoryRouter>{cell as React.ReactElement}</MemoryRouter>);
 
     const label = screen.getByText(
-      "просрочено 04 дней 17 часов 45 минут",
+      "Просрочено на 4 дня 17 часов 45 минут",
     );
-    const badge = label.parentElement;
+    const badge = label.closest("[title]");
     expect(badge).not.toBeNull();
     expect(badge as HTMLElement).toHaveClass("bg-rose-500/30");
   });


### PR DESCRIPTION
## Что сделано
- переработал бейдж обратного отсчёта: показ цифр в три блока, склонения единиц измерения и новый заголовок «Дедлайн» в таблице
- добавил функцию склонения по-русски и обновил подписи для состояний «Просрочено» и «Ожидается старт»
- обновил модульные тесты колонки задач на новые формулировки и структуру бейджа

## Почему
- требуется визуальное соответствие макету, избавление от слова «осталось» и корректные склонения «дней»

## Чек-лист
- [x] Линтер `pnpm lint`
- [x] Сборка `pnpm build`
- [x] Тесты `pnpm test:unit`
- [x] Тесты API `pnpm test:api`
- [x] Тесты E2E `pnpm test:e2e`

## Логи ключевых команд
- `pnpm lint`
- `pnpm build`
- `pnpm test:unit`
- `pnpm test:api`
- `pnpm test:e2e`

## Самопроверка
- бейдж отображает дни/часы/минуты в одну строку с подписью и без слова «осталось»
- подсказки (title) сохраняют «Выполнить до …»
- склонения «день/дня/дней» работают на числах с суффиксами 1, 2–4, 5+
- состояние просрочки показывает «Просрочено на …»
- тесты покрывают новые подписи и структуру бейджа

------
https://chatgpt.com/codex/tasks/task_b_68d3aff66d64832089ce0370bf2173d8