### PR TITLE
feat: handle fleet sync fallback

### DIFF
--- a/apps/web/src/pages/Settings/CollectionsPage.tsx
+++ b/apps/web/src/pages/Settings/CollectionsPage.tsx
@@ -362,6 +362,14 @@ export default function CollectionsPage() {
       if (!saved) {
         throw new Error("Сервер не вернул сохранённый элемент");
       }
+      const syncHint =
+        active === "fleets"
+          ? typeof saved.meta?.syncWarning === "string"
+            ? saved.meta.syncWarning
+            : saved.meta?.syncPending && typeof saved.meta?.syncError === "string"
+              ? saved.meta.syncError
+              : ""
+          : "";
       if (active === "fleets") {
         setItems((prev) => {
           const index = prev.findIndex((item) => item._id === saved._id);
@@ -374,7 +382,7 @@ export default function CollectionsPage() {
         });
         setSelectedFleetId(saved._id);
         setForm({ _id: saved._id, name: saved.name, value: saved.value });
-        setHint("");
+        setHint(syncHint);
       } else {
         setForm({ name: "", value: "" });
         setHint("");

--- a/apps/web/src/services/collections.ts
+++ b/apps/web/src/services/collections.ts
@@ -12,6 +12,10 @@ export interface CollectionItem {
     invalidReason?: string;
     invalidCode?: string;
     invalidAt?: string;
+    syncPending?: boolean;
+    syncWarning?: string;
+    syncError?: string;
+    syncFailedAt?: string;
     [key: string]: unknown;
   };
 }


### PR DESCRIPTION
## Что сделано
- При создании автопарка сохраняю запись даже при временной ошибке синхронизации, логирую причину и отправляю предупреждение вместе с ответом.
- Добавил описание ошибки в meta-данные ответа и вывод подсказки на странице настроек.
- Расширил тесты маршрута коллекций, чтобы проверить новый сценарий с предупреждением.

## Почему
- Запрос `/api/v1/collections` возвращал 502 при недоступности Wialon, из-за чего автопарк не сохранялся.

## Чек-лист
- [x] `pnpm lint`
- [ ] `pnpm test` *(playwright не нашёл тест по пути `apps/api/tests/collectionsFleetsRoute.test.ts`)*
- [x] `pnpm --filter telegram-task-bot test -- --runTestsByPath tests/collectionsFleetsRoute.test.ts`

## Логи
- `pnpm lint`
  - см. вывод: chunk `f6f363`
- `pnpm --filter telegram-task-bot test -- --runTestsByPath tests/collectionsFleetsRoute.test.ts`
  - см. вывод: chunk `2137cd`

## Самопроверка
- [x] В UI появляется подсказка, если синхронизация не удалась.
- [x] На бэкенде нет удаления автопарка при временной ошибке Wialon.
- [x] Возвращается человекочитаемое сообщение об ошибке Wialon.

## Риски и откат
- Возможна длительная задержка синхронизации транспорта: повторный запуск фонового планировщика или обновление страницы.


------
https://chatgpt.com/codex/tasks/task_b_68d40045e6a8832090806837bfdae175