### PR TITLE
fix: align Wialon base URL during sync

### DIFF
--- a/apps/api/src/services/fleetVehicles.ts
+++ b/apps/api/src/services/fleetVehicles.ts
@@ -96,8 +96,8 @@ async function upsertVehicle(
 export async function syncFleetVehicles(fleet: FleetDocument): Promise<void> {
   const updatedFleet = await ensureFleetFields(fleet);
   let loginResult = await login(updatedFleet.token, updatedFleet.baseUrl);
-  await persistBaseUrl(updatedFleet, loginResult.baseUrl);
-  let resolvedBaseUrl = updatedFleet.baseUrl;
+  let resolvedBaseUrl = loginResult.baseUrl;
+  await persistBaseUrl(updatedFleet, resolvedBaseUrl);
   let units: UnitInfo[];
   try {
     units = await loadUnits(loginResult.sid, resolvedBaseUrl);
@@ -109,8 +109,8 @@ export async function syncFleetVehicles(fleet: FleetDocument): Promise<void> {
       `Сессия Wialon недействительна для флота ${updatedFleet._id}, выполняем повторную авторизацию`,
     );
     loginResult = await login(updatedFleet.token, resolvedBaseUrl);
-    await persistBaseUrl(updatedFleet, loginResult.baseUrl);
-    resolvedBaseUrl = updatedFleet.baseUrl;
+    resolvedBaseUrl = loginResult.baseUrl;
+    await persistBaseUrl(updatedFleet, resolvedBaseUrl);
     units = await loadUnits(loginResult.sid, resolvedBaseUrl);
   }
   const ids = units.map((unit) => unit.id);

--- a/apps/api/tests/fleetVehicles.test.ts
+++ b/apps/api/tests/fleetVehicles.test.ts
@@ -104,6 +104,29 @@ describe('fleetVehicles sync', () => {
     expect(mockedLoadUnits).toHaveBeenCalledWith('sid', 'https://hst-api.wialon.com');
   });
 
+  it('использует базовый адрес из Wialon при загрузке транспорта', async () => {
+    const fleet = await Fleet.create({
+      name: 'Флот',
+      token: 'token',
+      locatorUrl: 'https://hosting.wialon.com/locator?t=dG9rZW4=',
+      baseUrl: 'https://hst-api.wialon.com',
+      locatorKey: 'dG9rZW4=',
+    });
+    mockedLogin.mockResolvedValue({
+      sid: 'sid',
+      eid: 'eid',
+      user: { id: 1 },
+      baseUrl: 'http://wialon.gps-garant.com.ua',
+    });
+    mockedLoadUnits.mockResolvedValue([]);
+
+    await syncFleetVehicles(fleet);
+
+    expect(mockedLoadUnits).toHaveBeenCalledWith('sid', 'http://wialon.gps-garant.com.ua');
+    const updatedFleet = await Fleet.findById(fleet._id).lean();
+    expect(updatedFleet?.baseUrl).toBe('http://wialon.gps-garant.com.ua');
+  });
+
   it('не перезаписывает ручное имя и примечания', async () => {
     const fleet = await Fleet.create({
       name: 'Флот',


### PR DESCRIPTION
## Summary
- ensure the fleet vehicles sync uses the base URL returned from Wialon login for data requests
- persist the refreshed base URL even after session renewals and cover the behaviour with a unit test

## Testing
- `pnpm test --filter fleetVehicles`
- `pnpm test:e2e`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68d43e260f108320a2f8b2097c41cdf5