### PR TITLE
test(api): extend fleets route timeout

### DIFF
--- a/apps/api/tests/fleetsRoute.test.ts
+++ b/apps/api/tests/fleetsRoute.test.ts
@@ -7,6 +7,8 @@ process.env.JWT_SECRET = 'secret';
 process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
 process.env.APP_URL = 'https://localhost';
 
+jest.setTimeout(30_000);
+
 import express from 'express';
 import request from 'supertest';
 import mongoose from 'mongoose';


### PR DESCRIPTION
## Что сделано и зачем
- Добавил вызов `jest.setTimeout(30_000)` в API-тесте автопарка, чтобы дать время на запуск `mongodb-memory-server` в CI.
- Сохранил остальную структуру тестов без изменений, проверил, что CRUD проверки по-прежнему выполняются.

## Чек-лист
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm test`

## Логи ключевых команд
- `pnpm lint`
- `pnpm build`
- `pnpm test`

## Самопроверка
- [x] Фикс охватывает только проблемный тест и не влияет на рабочий код.
- [x] Ветка чистая: только одно тематическое изменение.
- [x] Все предписанные проверки пройдены локально.
- [x] Артефакты сборки удалены перед коммитом.
- [x] Риск отката минимален: изменение касается лишь таймаута теста.


------
https://chatgpt.com/codex/tasks/task_b_68d50b607e0083208292b63de8090d60