### PR TITLE
test: extend fleets router timeout

### DIFF
--- a/apps/api/tests/fleetsRoute.test.ts
+++ b/apps/api/tests/fleetsRoute.test.ts
@@ -7,7 +7,8 @@ process.env.JWT_SECRET = 'secret';
 process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
 process.env.APP_URL = 'https://localhost';
 
-jest.setTimeout(30_000);
+// MongoMemoryServer может скачивать бинарники дольше 30 секунд, поэтому увеличиваем таймаут.
+jest.setTimeout(120_000);
 
 import express from 'express';
 import request from 'supertest';


### PR DESCRIPTION
## Summary
- increase Jest timeout for the fleets router API test suite to 120 seconds
- document the reason so slow MongoMemoryServer binary downloads don't fail CI

## Testing
- pnpm test -- apps/api/tests/fleetsRoute.test.ts *(fails: Playwright test filter has no matches)*
- pnpm --filter telegram-task-bot test -- --runInBand --coverage=false tests/fleetsRoute.test.ts --detectOpenHandles --forceExit *(fails: command was interrupted after hanging during MongoMemoryServer startup)*

------
https://chatgpt.com/codex/tasks/task_b_68d51304329c8320aa2d93323dbec1d6