### PR TITLE
fix: unblock fleets router jest tests

### DIFF
--- a/apps/api/tests/fleetsRoute.test.ts
+++ b/apps/api/tests/fleetsRoute.test.ts
@@ -20,7 +20,9 @@ import { FleetVehicle } from '../src/db/models/fleet';
 jest.mock('../src/utils/rateLimiter', () => () => (_req: any, _res: any, next: () => void) => next());
 jest.mock('../src/middleware/auth', () => () => (_req: any, _res: any, next: () => void) => next());
 jest.mock('../src/auth/roles.guard', () => (_req: any, _res: any, next: () => void) => next());
-jest.mock('../src/auth/roles.decorator', () => ({ Roles: () => () => undefined }));
+jest.mock('../src/auth/roles.decorator', () => ({
+  Roles: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
 
 let mongod: MongoMemoryServer;
 let app: express.Express;


### PR DESCRIPTION
## Что сделано
- исправлен jest-мок декоратора Roles, чтобы он передавал управление в цепочке middleware

## Зачем
- без вызова `next()` запросы в тестах зависали и Suite падал по таймауту

## Чек-лист
- [x] pnpm lint
- [x] pnpm test

## Логи
- `pnpm lint`
- `pnpm test`

## Самопроверка
- [x] Проверил, что тест `fleets router` завершается
- [x] Убедился, что изменения затрагивают только тестовую инфраструктуру
- [x] Просмотрел git diff перед коммитом


------
https://chatgpt.com/codex/tasks/task_b_68d51acdcc348320b2a2310faf89b5a6