### PR TITLE
fix: guard fleet current tasks

### DIFF
--- a/apps/web/src/pages/Settings/FleetVehicleDialog.tsx
+++ b/apps/web/src/pages/Settings/FleetVehicleDialog.tsx
@@ -63,6 +63,9 @@ export default function FleetVehicleDialog({
 
   useEffect(() => {
     if (open && vehicle) {
+      const currentTasks = Array.isArray(vehicle.currentTasks)
+        ? vehicle.currentTasks.filter(Boolean)
+        : [];
       setForm({
         name: vehicle.name,
         registrationNumber: vehicle.registrationNumber,
@@ -73,7 +76,7 @@ export default function FleetVehicleDialog({
         fuelRefilled: String(vehicle.fuelRefilled),
         fuelAverageConsumption: String(vehicle.fuelAverageConsumption),
         fuelSpentTotal: String(vehicle.fuelSpentTotal),
-        currentTasks: vehicle.currentTasks.join("\n"),
+        currentTasks: currentTasks.join("\n"),
       });
       setError(null);
       setConfirmSave(false);

--- a/apps/web/src/pages/Settings/FleetVehiclesTab.tsx
+++ b/apps/web/src/pages/Settings/FleetVehiclesTab.tsx
@@ -145,8 +145,13 @@ export default function FleetVehiclesTab() {
         <p className="text-sm text-gray-500">Транспорт не найден.</p>
       ) : null}
       <div className="grid gap-3 lg:grid-cols-2 xl:grid-cols-3">
-        {items.map((item) => (
-          <article key={item.id} className="rounded border p-3 shadow-sm">
+        {items.map((item) => {
+          const currentTasks = Array.isArray(item.currentTasks)
+            ? item.currentTasks.filter(Boolean)
+            : [];
+
+          return (
+            <article key={item.id} className="rounded border p-3 shadow-sm">
             <div className="flex items-start justify-between gap-3">
               <div>
                 <div className="text-base font-semibold">{item.name}</div>
@@ -190,13 +195,14 @@ export default function FleetVehiclesTab() {
                 <dd>{item.fuelSpentTotal} л</dd>
               </div>
             </dl>
-            {item.currentTasks.length ? (
+            {currentTasks.length ? (
               <div className="mt-3 rounded bg-blue-50 p-2 text-xs text-blue-900">
-                Текущие задачи: {item.currentTasks.join(", ")}
+                Текущие задачи: {currentTasks.join(", ")}
               </div>
             ) : null}
-          </article>
-        ))}
+            </article>
+          );
+        })}
       </div>
       {totalPages > 1 ? (
         <div className="flex items-center justify-end gap-2">


### PR DESCRIPTION
## Что сделано
- добавлена нормализация списков задач транспорта перед показом
- модальное окно автопарка повторно использует очищенный список задач

## Зачем
- предотвратить падение страницы настроек при отсутствии массива `currentTasks`

## Чек-лист
- [x] pnpm lint
- [x] pnpm test

## Логи
- `pnpm lint`
- `pnpm test`

## Самопроверка
- [x] учтены пустые и невалидные значения `currentTasks`
- [x] модалка корректно открывается в режимах создания и редактирования
- [x] повторный запрос данных после сохранения сохраняет стабильность

------
https://chatgpt.com/codex/tasks/task_b_68d524c296308320a4f590bfe14a9b40