### PR TITLE
feat: redesign settings tables layout

### DIFF
--- a/apps/web/src/columns/collectionColumns.tsx
+++ b/apps/web/src/columns/collectionColumns.tsx
@@ -1,0 +1,43 @@
+// Назначение файла: колонки таблицы универсальных коллекций настроек
+// Основные модули: @tanstack/react-table, services/collections
+import type { ColumnDef } from "@tanstack/react-table";
+import type { CollectionItem } from "../services/collections";
+
+export interface CollectionTableRow extends CollectionItem {
+  displayValue: string;
+  metaSummary: string;
+}
+
+export const collectionColumns: ColumnDef<CollectionTableRow>[] = [
+  {
+    accessorKey: "name",
+    header: "Название",
+    meta: { minWidth: "8rem", maxWidth: "16rem" },
+  },
+  {
+    accessorKey: "value",
+    header: "Значение",
+    meta: { minWidth: "8rem", maxWidth: "20rem" },
+  },
+  {
+    accessorKey: "displayValue",
+    header: "Связанные данные",
+    meta: { minWidth: "10rem", maxWidth: "24rem" },
+  },
+  {
+    accessorKey: "type",
+    header: "Тип",
+    meta: { minWidth: "6rem", maxWidth: "12rem" },
+  },
+  {
+    accessorKey: "_id",
+    header: "Идентификатор",
+    meta: { minWidth: "10rem", maxWidth: "16rem" },
+  },
+  {
+    accessorKey: "metaSummary",
+    header: "Доп. сведения",
+    meta: { minWidth: "10rem", maxWidth: "24rem" },
+  },
+];
+

--- a/apps/web/src/columns/fleetVehicleColumns.tsx
+++ b/apps/web/src/columns/fleetVehicleColumns.tsx
@@ -1,0 +1,74 @@
+// Назначение файла: колонки таблицы автопарка на странице настроек
+// Основные модули: @tanstack/react-table, shared/types
+import type { ColumnDef } from "@tanstack/react-table";
+import type { FleetVehicleDto } from "shared";
+
+const stringify = (value: unknown) => {
+  if (value === undefined || value === null) return "";
+  if (Array.isArray(value)) {
+    return value.length ? value.join(", ") : "";
+  }
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+};
+
+export type FleetVehicleRow = FleetVehicleDto & {
+  sensorsInfo: string;
+  customSensorsInfo: string;
+  trackInfo: string;
+  positionInfo: string;
+};
+
+export const fleetVehicleColumns: ColumnDef<FleetVehicleRow>[] = [
+  { accessorKey: "name", header: "Название", meta: { minWidth: "8rem", maxWidth: "16rem" } },
+  { accessorKey: "registrationNumber", header: "Рег. номер", meta: { minWidth: "8rem", maxWidth: "16rem" } },
+  { accessorKey: "odometerInitial", header: "Одометр начальный", meta: { minWidth: "8rem", maxWidth: "14rem" } },
+  { accessorKey: "odometerCurrent", header: "Одометр текущий", meta: { minWidth: "8rem", maxWidth: "14rem" } },
+  { accessorKey: "mileageTotal", header: "Пробег", meta: { minWidth: "6rem", maxWidth: "12rem" } },
+  { accessorKey: "fuelType", header: "Тип топлива", meta: { minWidth: "6rem", maxWidth: "12rem" } },
+  { accessorKey: "fuelRefilled", header: "Заправлено", meta: { minWidth: "6rem", maxWidth: "10rem" } },
+  { accessorKey: "fuelAverageConsumption", header: "Расход", meta: { minWidth: "6rem", maxWidth: "10rem" } },
+  { accessorKey: "fuelSpentTotal", header: "Израсходовано", meta: { minWidth: "6rem", maxWidth: "10rem" } },
+  {
+    accessorKey: "currentTasks",
+    header: "Текущие задачи",
+    cell: ({ getValue }) => stringify(getValue<string[] | undefined>()),
+    meta: { minWidth: "10rem", maxWidth: "24rem" },
+  },
+  { accessorKey: "createdAt", header: "Создан", meta: { minWidth: "10rem", maxWidth: "16rem" } },
+  { accessorKey: "updatedAt", header: "Обновлён", meta: { minWidth: "10rem", maxWidth: "16rem" } },
+  { accessorKey: "unitId", header: "Устройство", meta: { minWidth: "8rem", maxWidth: "12rem" } },
+  { accessorKey: "remoteName", header: "Удалённое имя", meta: { minWidth: "8rem", maxWidth: "16rem" } },
+  { accessorKey: "notes", header: "Примечания", meta: { minWidth: "10rem", maxWidth: "20rem" } },
+  {
+    accessorKey: "positionInfo",
+    header: "Позиция",
+    cell: ({ getValue }) => stringify(getValue<string | undefined>()),
+    meta: { minWidth: "12rem", maxWidth: "24rem" },
+  },
+  {
+    accessorKey: "sensorsInfo",
+    header: "Датчики",
+    cell: ({ getValue }) => stringify(getValue<string | undefined>()),
+    meta: { minWidth: "12rem", maxWidth: "24rem" },
+  },
+  {
+    accessorKey: "customSensorsInfo",
+    header: "Польз. датчики",
+    cell: ({ getValue }) => stringify(getValue<string | undefined>()),
+    meta: { minWidth: "12rem", maxWidth: "24rem" },
+  },
+  {
+    accessorKey: "trackInfo",
+    header: "Трек",
+    cell: ({ getValue }) => stringify(getValue<string | undefined>()),
+    meta: { minWidth: "12rem", maxWidth: "24rem" },
+  },
+];
+

--- a/apps/web/src/columns/settingsUserColumns.tsx
+++ b/apps/web/src/columns/settingsUserColumns.tsx
@@ -1,0 +1,25 @@
+// Назначение файла: колонки таблицы пользователей в настройках
+// Основные модули: @tanstack/react-table, shared/types
+import type { ColumnDef } from "@tanstack/react-table";
+import type { User } from "shared";
+
+export const settingsUserColumns: ColumnDef<User>[] = [
+  { accessorKey: "telegram_id", header: "Telegram ID", meta: { minWidth: "8rem" } },
+  { accessorKey: "username", header: "Логин", meta: { minWidth: "8rem", maxWidth: "16rem" } },
+  { accessorKey: "name", header: "Имя", meta: { minWidth: "8rem", maxWidth: "16rem" } },
+  { accessorKey: "phone", header: "Телефон", meta: { minWidth: "8rem", maxWidth: "16rem" } },
+  { accessorKey: "mobNumber", header: "Моб. номер", meta: { minWidth: "8rem", maxWidth: "16rem" } },
+  { accessorKey: "email", header: "E-mail", meta: { minWidth: "10rem", maxWidth: "20rem" } },
+  { accessorKey: "role", header: "Роль", meta: { minWidth: "6rem", maxWidth: "12rem" } },
+  {
+    accessorKey: "access",
+    header: "Доступ",
+    cell: ({ getValue }) => String(getValue<number | undefined>() ?? ""),
+    meta: { minWidth: "6rem", maxWidth: "10rem" },
+  },
+  { accessorKey: "roleId", header: "Роль ID", meta: { minWidth: "8rem", maxWidth: "16rem" } },
+  { accessorKey: "departmentId", header: "Департамент", meta: { minWidth: "8rem", maxWidth: "16rem" } },
+  { accessorKey: "divisionId", header: "Отдел", meta: { minWidth: "8rem", maxWidth: "16rem" } },
+  { accessorKey: "positionId", header: "Должность", meta: { minWidth: "8rem", maxWidth: "16rem" } },
+];
+

--- a/apps/web/src/components/DataTable.tsx
+++ b/apps/web/src/components/DataTable.tsx
@@ -28,6 +28,8 @@ interface DataTableProps<T> {
   onPageSizeChange?: (size: number) => void;
   onRowClick?: (row: T) => void;
   toolbarChildren?: React.ReactNode;
+  showGlobalSearch?: boolean;
+  showFilters?: boolean;
 }
 
 interface ColumnMeta {
@@ -48,6 +50,8 @@ export default function DataTable<T>({
   onPageSizeChange,
   onRowClick,
   toolbarChildren,
+  showGlobalSearch = true,
+  showFilters = true,
 }: DataTableProps<T>) {
   const [columnVisibility, setColumnVisibility] = React.useState({});
   const [columnOrder, setColumnOrder] = React.useState<string[]>([]);
@@ -69,7 +73,11 @@ export default function DataTable<T>({
 
   return (
     <div className="w-full space-y-1.5 px-0 font-ui text-[13px] sm:px-1.5 sm:text-sm">
-      <TableToolbar table={table as TableType<T>}>
+      <TableToolbar
+        table={table as TableType<T>}
+        showGlobalSearch={showGlobalSearch}
+        showFilters={showFilters}
+      >
         {toolbarChildren}
       </TableToolbar>
       <Table className="text-left">

--- a/apps/web/src/components/TableToolbar.tsx
+++ b/apps/web/src/components/TableToolbar.tsx
@@ -9,9 +9,16 @@ import SearchFilters from "./SearchFilters";
 interface Props<T> {
   table: Table<T>;
   children?: React.ReactNode;
+  showGlobalSearch?: boolean;
+  showFilters?: boolean;
 }
 
-export default function TableToolbar<T>({ table, children }: Props<T>) {
+export default function TableToolbar<T>({
+  table,
+  children,
+  showGlobalSearch = true,
+  showFilters = true,
+}: Props<T>) {
   const columns = table.getAllLeafColumns();
   const { t } = useTranslation();
 
@@ -69,7 +76,7 @@ export default function TableToolbar<T>({ table, children }: Props<T>) {
   return (
     <div className="flex w-full flex-wrap items-center gap-1 text-xs sm:text-sm">
       <div className="flex flex-1 flex-wrap items-center gap-1">
-        <GlobalSearch />
+        {showGlobalSearch ? <GlobalSearch /> : null}
         {children}
       </div>
       <div className="ml-auto flex w-full flex-wrap items-center justify-end gap-1 sm:w-auto">
@@ -97,7 +104,7 @@ export default function TableToolbar<T>({ table, children }: Props<T>) {
             {t("settings")}
           </summary>
           <div className="absolute right-0 z-10 mt-1 w-64 space-y-1 rounded border bg-white p-1.5 shadow">
-            <SearchFilters inline />
+            {showFilters ? <SearchFilters inline /> : null}
             <div className="border-t pt-1">
               {columns.map((col) => (
                 <div

--- a/apps/web/src/pages/Settings/CollectionsPage.test.tsx
+++ b/apps/web/src/pages/Settings/CollectionsPage.test.tsx
@@ -28,13 +28,16 @@ jest.mock("../../services/users", () => ({
 
 jest.mock("./FleetVehiclesTab", () => () => <div data-testid="fleet-tab" />);
 
-jest.mock(
-  "../../components/Breadcrumbs",
-  () =>
-    ({ items }: { items: any[] }) => (
-      <nav data-testid="breadcrumbs">{items.length}</nav>
-    ),
-);
+jest.mock("../../components/DataTable", () => ({
+  __esModule: true,
+  default: ({ data }: { data: Array<Record<string, unknown>> }) => (
+    <div data-testid="data-table">
+      {data.map((row, index) => (
+        <div key={index}>{(row.name as string) ?? "row"}</div>
+      ))}
+    </div>
+  ),
+}));
 
 jest.mock("../../components/Tabs", () => {
   type TabsContextValue = {
@@ -192,7 +195,7 @@ describe("CollectionsPage", () => {
 
     await screen.findByText("Главный департамент");
 
-    const searchInput = screen.getByPlaceholderText("Поиск");
+    const searchInput = screen.getByPlaceholderText("Название или значение");
     fireEvent.change(searchInput, { target: { value: "финансы" } });
     fireEvent.click(screen.getByText("Искать"));
 
@@ -211,7 +214,7 @@ describe("CollectionsPage", () => {
 
     const divisionsPanel = screen.getByTestId("tab-content-divisions");
     const activeSearch = within(divisionsPanel).getByPlaceholderText(
-      "Поиск",
+      "Название или значение",
     ) as HTMLInputElement;
     expect(activeSearch.value).toBe("");
   });

--- a/apps/web/src/services/osrm.ts
+++ b/apps/web/src/services/osrm.ts
@@ -1,9 +1,18 @@
 // Назначение: получение маршрута через OSRM
 // Основные модули: fetch
+const isValidPoint = (point?: { lng: number; lat: number }) => {
+  if (!point) return false;
+  const { lng, lat } = point;
+  return Number.isFinite(lng) && Number.isFinite(lat);
+};
+
 export const fetchRouteGeometry = async (
   start: { lng: number; lat: number },
   end: { lng: number; lat: number },
 ) => {
+  if (!isValidPoint(start) || !isValidPoint(end)) {
+    return null;
+  }
   const base =
     import.meta.env.VITE_ROUTING_URL ||
     "https://router.project-osrm.org/route/v1/driving";


### PR DESCRIPTION
## What
- add guards in OSRM client to avoid requests with пустыми координатами
- перевести настройки на табы с DataTable и карточками объектов
- вынести конфигурации колонок для коллекций, пользователей и автопарка

## Why
- исправить ошибки обращения к OSRM при отсутствии координат
- унифицировать вывод коллекций и пользователей в таблицы и модальные карточки
- упростить повторное использование колонок и тулбаров таблиц

## Checklist
- [x] `pnpm test:unit -- --runTestsByPath apps/web/src/pages/Settings/CollectionsPage.test.tsx`
- [x] `pnpm lint`

## Logs
- `pnpm test:unit -- --runTestsByPath apps/web/src/pages/Settings/CollectionsPage.test.tsx`
- `pnpm lint`

## Self-check
- [x] хлебные крошки убраны, вкладки в один ряд
- [x] таблицы показывают все свойства объектов
- [x] карточки коллекций, пользователей и сотрудников открываются в модалках
- [x] вкладка автопарка обновлена на DataTable и карточку
- [x] запросы к OSRM выполняются только при валидных точках


------
https://chatgpt.com/codex/tasks/task_b_68d53f7fc5988320b86c8bce30d1b366