### PR TITLE
fix: исправить фильтрацию колонок коллекций

### DIFF
--- a/apps/web/src/pages/Settings/CollectionsPage.tsx
+++ b/apps/web/src/pages/Settings/CollectionsPage.tsx
@@ -129,6 +129,13 @@ const parseIds = (value: string) =>
     .map((v) => v.trim())
     .filter(Boolean);
 
+type CollectionColumn = (typeof collectionColumns)[number];
+
+const hasAccessorKey = (
+  column: CollectionColumn,
+): column is CollectionColumn & { accessorKey: string } =>
+  typeof (column as { accessorKey?: unknown }).accessorKey === "string";
+
 export default function CollectionsPage() {
   const [active, setActive] = useState<CollectionKey>("departments");
   const [items, setItems] = useState<CollectionItem[]>([]);
@@ -487,7 +494,9 @@ export default function CollectionsPage() {
   const slimCollectionColumns = useMemo(
     () =>
       collectionColumns.filter(
-        (column) => column.accessorKey !== "value" && column.accessorKey !== "_id",
+        (column) =>
+          !hasAccessorKey(column) ||
+          (column.accessorKey !== "value" && column.accessorKey !== "_id"),
       ),
     [],
   );

--- a/apps/web/src/services/fleets.spec.ts
+++ b/apps/web/src/services/fleets.spec.ts
@@ -58,6 +58,7 @@ describe("mutations", () => {
     odometerInitial: 0,
     odometerCurrent: 10,
     mileageTotal: 10,
+    transportType: "Легковой",
     fuelType: "Бензин",
     fuelRefilled: 5,
     fuelAverageConsumption: 0.2,


### PR DESCRIPTION
## Что сделано
- добавил типовой гард для колонок таблицы коллекций, чтобы фильтровать только по `accessorKey`
- дополнил тестовые данные автопарка обязательным полем `transportType`

## Почему
- jest падал из-за обращения к необязательному полю колонки в строгом режиме TypeScript
- unit-тесты сервиса автопарка не соответствовали актуальному интерфейсу payload

## Проверки
- [x] `pnpm test`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] Обратная совместимость сохранена

## Логи ключевых команд
- `pnpm test`
- `pnpm lint`
- `pnpm build`

## Самопроверка
- убедился, что таблица получает все колонки кроме скрытых идентификаторов
- проверил, что тесты создают валидный payload
- прогнал тесты, линтер и сборку


------
https://chatgpt.com/codex/tasks/task_b_68d55e740e8083209a19adc4243df433