### PR TITLE
feat: update settings navigation and styling

### DIFF
--- a/apps/web/src/columns/settingsEmployeeColumns.tsx
+++ b/apps/web/src/columns/settingsEmployeeColumns.tsx
@@ -2,6 +2,7 @@
 // Основные модули: @tanstack/react-table, shared/types
 import type { ColumnDef } from "@tanstack/react-table";
 import type { User } from "shared";
+import { formatRoleName } from "../utils/roleDisplay";
 
 export interface EmployeeRow extends User {
   roleName: string;
@@ -36,7 +37,12 @@ export const settingsEmployeeColumns: ColumnDef<EmployeeRow>[] = [
     header: "E-mail",
     meta: { minWidth: "10rem", maxWidth: "20rem" },
   },
-  { accessorKey: "role", header: "Роль", meta: { minWidth: "6rem", maxWidth: "12rem" } },
+  {
+    accessorKey: "role",
+    header: "Роль",
+    cell: ({ getValue }) => formatRoleName(getValue<string | undefined>()),
+    meta: { minWidth: "6rem", maxWidth: "12rem" },
+  },
   {
     accessorKey: "access",
     header: "Доступ",
@@ -46,7 +52,7 @@ export const settingsEmployeeColumns: ColumnDef<EmployeeRow>[] = [
   {
     accessorKey: "roleId",
     header: "Роль ID",
-    cell: ({ row }) => row.original.roleName || "—",
+    cell: ({ row }) => formatRoleName(row.original.roleName),
     meta: { minWidth: "8rem", maxWidth: "16rem" },
   },
   {

--- a/apps/web/src/columns/settingsUserColumns.tsx
+++ b/apps/web/src/columns/settingsUserColumns.tsx
@@ -2,6 +2,7 @@
 // Основные модули: @tanstack/react-table, shared/types
 import type { ColumnDef } from "@tanstack/react-table";
 import type { User } from "shared";
+import { formatRoleName } from "../utils/roleDisplay";
 
 export const settingsUserColumns: ColumnDef<User>[] = [
   { accessorKey: "telegram_id", header: "Telegram ID", meta: { minWidth: "8rem" } },
@@ -10,7 +11,12 @@ export const settingsUserColumns: ColumnDef<User>[] = [
   { accessorKey: "phone", header: "Телефон", meta: { minWidth: "8rem", maxWidth: "16rem" } },
   { accessorKey: "mobNumber", header: "Моб. номер", meta: { minWidth: "8rem", maxWidth: "16rem" } },
   { accessorKey: "email", header: "E-mail", meta: { minWidth: "10rem", maxWidth: "20rem" } },
-  { accessorKey: "role", header: "Роль", meta: { minWidth: "6rem", maxWidth: "12rem" } },
+  {
+    accessorKey: "role",
+    header: "Роль",
+    cell: ({ getValue }) => formatRoleName(getValue<string | undefined>()),
+    meta: { minWidth: "6rem", maxWidth: "12rem" },
+  },
   {
     accessorKey: "access",
     header: "Доступ",

--- a/apps/web/src/components/EmployeeCardForm.tsx
+++ b/apps/web/src/components/EmployeeCardForm.tsx
@@ -14,6 +14,7 @@ import {
   type CollectionItem,
 } from "../services/collections";
 import { fetchRoles, type Role } from "../services/roles";
+import { ROLE_OPTIONS } from "../utils/roleDisplay";
 import {
   createUser,
   fetchUser,
@@ -433,9 +434,11 @@ export default function EmployeeCardForm({
                 onChange={(e) => handleRoleChange(e.target.value)}
                 disabled={!canEdit}
               >
-                <option value="user">user</option>
-                <option value="manager">manager</option>
-                <option value="admin">admin</option>
+                {ROLE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
               </select>
             </label>
             <label className="space-y-1">

--- a/apps/web/src/pages/Settings/UserForm.tsx
+++ b/apps/web/src/pages/Settings/UserForm.tsx
@@ -7,6 +7,7 @@ import {
   type CollectionItem,
 } from "../../services/collections";
 import { fetchRoles } from "../../services/roles";
+import { ROLE_OPTIONS } from "../../utils/roleDisplay";
 
 export interface UserFormData {
   telegram_id?: number;
@@ -135,9 +136,11 @@ export default function UserForm({ form, onChange, onSubmit, onReset }: Props) {
           value={form.role || "user"}
           onChange={(e) => handleRoleChange(e.target.value)}
         >
-          <option value="user">user</option>
-          <option value="manager">manager</option>
-          <option value="admin">admin</option>
+          {ROLE_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
         </select>
       </div>
       <div>

--- a/apps/web/src/utils/roleDisplay.ts
+++ b/apps/web/src/utils/roleDisplay.ts
@@ -1,0 +1,24 @@
+// Назначение файла: функции и константы для отображения названий ролей
+// Основные модули: словарь соответствий ролей и экспортируемые утилиты
+
+export const ROLE_LABELS: Record<string, string> = {
+  admin: "Администратор",
+  manager: "Менеджер",
+  user: "Сотрудник",
+};
+
+export interface RoleOption {
+  value: string;
+  label: string;
+}
+
+export const ROLE_OPTIONS: RoleOption[] = [
+  { value: "admin", label: ROLE_LABELS.admin },
+  { value: "manager", label: ROLE_LABELS.manager },
+  { value: "user", label: ROLE_LABELS.user },
+];
+
+export const formatRoleName = (role?: string | null): string => {
+  if (!role) return "—";
+  return ROLE_LABELS[role] ?? role;
+};


### PR DESCRIPTION
## Summary
- redesign the settings navigation with a responsive desktop row and mobile dropdown
- wrap settings data tables and detail cards with unified badge styling and enhanced department/division info
- unify role display labels across forms, tables, and cards using shared helpers

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68d63258af6c8320b4196dbaf8d1cb02