### PR TITLE
feat: improve settings header spacing and badges

### DIFF
--- a/apps/web/src/AuthenticatedApp.tsx
+++ b/apps/web/src/AuthenticatedApp.tsx
@@ -32,8 +32,13 @@ const ThemeProviderLazy = lazy(async () => {
 
 function AppShell() {
   const { user } = useAuth();
-  const { open, toggle } = useSidebar();
+  const { open, toggle, collapsed } = useSidebar();
   const { t } = useTranslation();
+  const contentOffsetClass = open
+    ? collapsed
+      ? "lg:pl-20"
+      : "lg:pl-60"
+    : "lg:pl-0";
   return (
     <>
       {user && <Sidebar />}
@@ -48,110 +53,114 @@ function AppShell() {
           }}
         />
       )}
-      {user && <Header />}
-      <main className="p-4 pt-3 transition-all lg:pt-4">
-        <Suspense fallback={<div>{t("loading")}</div>}>
-          <Routes>
-            <Route
-              path="/profile"
-              element={
-                <ProtectedRoute>
-                  <Profile />
-                </ProtectedRoute>
-              }
-            />
-            <Route
-              path="/tasks"
-              element={
-                <ProtectedRoute>
-                  <TasksPage />
-                </ProtectedRoute>
-              }
-            />
-            <Route
-              path="/mg/kanban"
-              element={
-                <ManagerRoute>
-                  <TaskKanban />
-                </ManagerRoute>
-              }
-            />
-            <Route
-              path="/mg/reports"
-              element={
-                <ManagerRoute>
-                  <Reports />
-                </ManagerRoute>
-              }
-            />
-            <Route
-              path="/mg/routes"
-              element={
-                <ManagerRoute>
-                  <RoutesPage />
-                </ManagerRoute>
-              }
-            />
-            <Route
-              path="/cp/kanban"
-              element={
-                <AdminRoute>
-                  <TaskKanban />
-                </AdminRoute>
-              }
-            />
-            <Route
-              path="/cp/reports"
-              element={
-                <AdminRoute>
-                  <Reports />
-                </AdminRoute>
-              }
-            />
-            <Route
-              path="/cp/routes"
-              element={
-                <AdminRoute>
-                  <RoutesPage />
-                </AdminRoute>
-              }
-            />
-            <Route
-              path="/cp/settings"
-              element={
-                <AdminRoute>
-                  <SettingsPage />
-                </AdminRoute>
-              }
-            />
-            <Route
-              path="/cp/logs"
-              element={
-                <AdminRoute>
-                  <LogsPage />
-                </AdminRoute>
-              }
-            />
-            <Route
-              path="/cp/storage"
-              element={
-                <AdminRoute>
-                  <StoragePage />
-                </AdminRoute>
-              }
-            />
-            <Route
-              path="/theme"
-              element={
-                <ProtectedRoute>
-                  <ThemeSettings />
-                </ProtectedRoute>
-              }
-            />
-            <Route path="*" element={<Navigate to="/tasks" />} />
-          </Routes>
-        </Suspense>
-      </main>
+      <div
+        className={`flex min-h-screen flex-col bg-slate-50/40 transition-[padding] duration-200 ease-out dark:bg-slate-900/40 ${contentOffsetClass}`}
+      >
+        {user && <Header />}
+        <main className="flex-1 p-4 pt-3 transition-all lg:pt-4">
+          <Suspense fallback={<div>{t("loading")}</div>}>
+            <Routes>
+              <Route
+                path="/profile"
+                element={
+                  <ProtectedRoute>
+                    <Profile />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/tasks"
+                element={
+                  <ProtectedRoute>
+                    <TasksPage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/mg/kanban"
+                element={
+                  <ManagerRoute>
+                    <TaskKanban />
+                  </ManagerRoute>
+                }
+              />
+              <Route
+                path="/mg/reports"
+                element={
+                  <ManagerRoute>
+                    <Reports />
+                  </ManagerRoute>
+                }
+              />
+              <Route
+                path="/mg/routes"
+                element={
+                  <ManagerRoute>
+                    <RoutesPage />
+                  </ManagerRoute>
+                }
+              />
+              <Route
+                path="/cp/kanban"
+                element={
+                  <AdminRoute>
+                    <TaskKanban />
+                  </AdminRoute>
+                }
+              />
+              <Route
+                path="/cp/reports"
+                element={
+                  <AdminRoute>
+                    <Reports />
+                  </AdminRoute>
+                }
+              />
+              <Route
+                path="/cp/routes"
+                element={
+                  <AdminRoute>
+                    <RoutesPage />
+                  </AdminRoute>
+                }
+              />
+              <Route
+                path="/cp/settings"
+                element={
+                  <AdminRoute>
+                    <SettingsPage />
+                  </AdminRoute>
+                }
+              />
+              <Route
+                path="/cp/logs"
+                element={
+                  <AdminRoute>
+                    <LogsPage />
+                  </AdminRoute>
+                }
+              />
+              <Route
+                path="/cp/storage"
+                element={
+                  <AdminRoute>
+                    <StoragePage />
+                  </AdminRoute>
+                }
+              />
+              <Route
+                path="/theme"
+                element={
+                  <ProtectedRoute>
+                    <ThemeSettings />
+                  </ProtectedRoute>
+                }
+              />
+              <Route path="*" element={<Navigate to="/tasks" />} />
+            </Routes>
+          </Suspense>
+        </main>
+      </div>
       <TaskDialogRoute />
       <EmployeeDialogRoute />
     </>

--- a/apps/web/src/components/DataTable.tsx
+++ b/apps/web/src/components/DataTable.tsx
@@ -44,8 +44,8 @@ interface ColumnMeta {
 }
 
 export const defaultBadgeClassName =
-  "inline-flex items-center justify-center gap-1 rounded-full bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700 ring-1 ring-blue-200 dark:bg-blue-500/20 dark:text-blue-100 dark:ring-blue-400/40";
-export const defaultBadgeWrapperClassName = "flex flex-wrap gap-1.5";
+  "inline-flex min-h-[1.75rem] max-w-full items-center justify-start gap-1 rounded-full border border-slate-200 bg-white px-3 py-0.5 text-xs font-semibold text-slate-700 shadow-sm ring-1 ring-inset ring-slate-100 dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-100 dark:ring-slate-700/60";
+export const defaultBadgeWrapperClassName = "flex flex-wrap items-center gap-2";
 
 const extractBadgeItems = (value: React.ReactNode): string[] => {
   const items: string[] = [];
@@ -90,12 +90,16 @@ const renderBadgeContent = (
     return <span className={badgeClassName}>—</span>;
   }
   if (items.length === 1) {
-    return <span className={badgeClassName}>{items[0]}</span>;
+    return (
+      <span className={badgeClassName} title={items[0]}>
+        {items[0]}
+      </span>
+    );
   }
   return (
     <div className={wrapperClassName}>
       {items.map((item, index) => (
-        <span key={`${item}-${index}`} className={badgeClassName}>
+        <span key={`${item}-${index}`} className={badgeClassName} title={item}>
           {item}
         </span>
       ))}

--- a/apps/web/src/layouts/Header.tsx
+++ b/apps/web/src/layouts/Header.tsx
@@ -9,12 +9,13 @@ import { Bars3Icon, UserCircleIcon } from "@heroicons/react/24/outline";
 import { useTranslation } from "react-i18next";
 
 export default function Header() {
-  const { toggle, collapsed, open } = useSidebar();
+  const { toggle } = useSidebar();
   const { user } = useAuth();
   const { t, i18n } = useTranslation();
   return (
     <header
-      className={`border-stroke sticky top-0 z-10 flex h-14 items-center justify-between border-b bg-white px-4 transition-all ${open ? (collapsed ? "lg:ml-20" : "lg:ml-60") : "lg:ml-0"}`}
+      className="border-stroke sticky top-0 z-40 flex h-16 w-full items-center justify-between border-b bg-white/90 px-4 shadow-sm backdrop-blur transition-colors dark:bg-slate-900/90"
+      data-testid="app-header"
     >
       <div className="flex items-center gap-2">
         <button

--- a/apps/web/src/pages/Settings/CollectionsPage.tsx
+++ b/apps/web/src/pages/Settings/CollectionsPage.tsx
@@ -121,8 +121,8 @@ const tabIcons: Record<
   users: KeyIcon,
 };
 
-const settingsBadgeClassName = `${defaultBadgeClassName} whitespace-nowrap`;
-const settingsBadgeWrapperClassName = defaultBadgeWrapperClassName;
+const settingsBadgeClassName = `${defaultBadgeClassName} whitespace-nowrap sm:text-sm`;
+const settingsBadgeWrapperClassName = `${defaultBadgeWrapperClassName} justify-start`;
 
 const renderBadgeList = (items: string[]) => {
   if (!items.length) {
@@ -728,7 +728,7 @@ export default function CollectionsPage() {
   }, [selectedCollection, users]);
 
   return (
-    <div className="space-y-6 p-4">
+    <div className="mx-auto flex w-full max-w-screen-2xl flex-col gap-6 px-3 pb-12 pt-4 sm:px-4 lg:px-8">
       {hint && <div className="text-sm text-red-600">{hint}</div>}
       <Tabs
         value={active}
@@ -760,7 +760,7 @@ export default function CollectionsPage() {
           </select>
         </div>
         <TabsList
-          className="hidden overflow-x-auto rounded-2xl bg-white/80 p-2 shadow-inner ring-1 ring-slate-200 backdrop-blur dark:bg-slate-900/40 dark:ring-slate-700 sm:grid sm:gap-3 sm:p-3 sm:[grid-template-columns:repeat(6,minmax(11rem,1fr))]"
+          className="hidden overflow-x-auto rounded-2xl bg-white/85 p-2 shadow-inner ring-1 ring-slate-200 backdrop-blur dark:bg-slate-900/50 dark:ring-slate-700 sm:grid sm:gap-3 sm:overflow-visible sm:p-3 sm:[grid-template-columns:repeat(6,minmax(11rem,1fr))] lg:p-4 lg:shadow"
         >
           {types.map((t) => {
             const Icon = tabIcons[t.key as CollectionKey];


### PR DESCRIPTION
## Summary
- align the header and main container with the sidebar offsets so the top bar stays visible on desktop
- refresh the settings tabs and badge styling to match the task table presentation
- add badge titles and layout tweaks so multi-value cells remain readable

## Testing
- pnpm lint
- pnpm --filter web test:types

------
https://chatgpt.com/codex/tasks/task_b_68d640bed4d88320916224e9a2ee5cc3