### PR TITLE
feat: compact header tabs and enterprise subtitle

### DIFF
--- a/apps/web/src/components/ProfileDropdown.tsx
+++ b/apps/web/src/components/ProfileDropdown.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { UserCircleIcon } from "@heroicons/react/24/outline";
 
+import { cn } from "@/lib/utils";
 import { useAuth } from "../context/useAuth";
 import { Button } from "./ui/button";
 import {
@@ -16,10 +17,12 @@ import useEmployeeDialog from "../hooks/useEmployeeDialog";
 
 interface ProfileDropdownProps {
   children?: React.ReactNode;
+  triggerClassName?: string;
 }
 
 export default function ProfileDropdown({
   children,
+  triggerClassName,
 }: ProfileDropdownProps) {
   const { user, logout } = useAuth();
   const { open } = useEmployeeDialog();
@@ -35,9 +38,12 @@ export default function ProfileDropdown({
       <DropdownMenuTrigger asChild>
         <Button
           variant="ghost"
-          size="icon"
+          size="sm"
           aria-label="Профиль"
-          className="size-12"
+          className={cn(
+            "h-auto rounded-full border border-slate-200/80 bg-white/70 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-700 shadow-sm transition-colors hover:border-slate-300 hover:bg-white focus-visible:ring-2 focus-visible:ring-primary/60 dark:border-slate-700 dark:bg-slate-800/70 dark:text-slate-100 dark:hover:border-slate-500 dark:hover:bg-slate-800",
+            triggerClassName,
+          )}
         >
           {children ?? <UserCircleIcon className="h-5 w-5" />}
         </Button>

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -2,18 +2,26 @@
 // Модули: React, контекст темы, кнопка shadcn
 import React, { useContext } from "react";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { ThemeContext } from "../context/ThemeContext";
 
-export default function ThemeToggle() {
+interface ThemeToggleProps {
+  className?: string;
+}
+
+export default function ThemeToggle({ className }: ThemeToggleProps) {
   const { theme, setTheme } = useContext(ThemeContext);
   const toggle = () => setTheme(theme === "dark" ? "light" : "dark");
   return (
     <Button
       variant="ghost"
-      size="icon"
+      size="sm"
       onClick={toggle}
       aria-label="Тема"
-      className="size-12"
+      className={cn(
+        "h-auto rounded-full border border-slate-200/80 bg-white/70 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-700 shadow-sm transition-colors hover:border-slate-300 hover:bg-white focus-visible:ring-2 focus-visible:ring-primary/60 dark:border-slate-700 dark:bg-slate-800/70 dark:text-slate-100 dark:hover:border-slate-500 dark:hover:bg-slate-800",
+        className,
+      )}
     >
       {theme === "dark" ? "🌙" : "☀️"}
     </Button>

--- a/apps/web/src/layouts/Header.tsx
+++ b/apps/web/src/layouts/Header.tsx
@@ -6,49 +6,64 @@ import { useAuth } from "../context/useAuth";
 import ProfileDropdown from "../components/ProfileDropdown";
 import ThemeToggle from "../components/ThemeToggle";
 import { Bars3Icon, UserCircleIcon } from "@heroicons/react/24/outline";
+import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 
 export default function Header() {
   const { toggle } = useSidebar();
   const { user } = useAuth();
   const { t, i18n } = useTranslation();
+  const tabClassName =
+    "inline-flex items-center gap-2 rounded-full border border-slate-200/80 bg-white/70 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-700 shadow-sm transition-colors hover:border-slate-300 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:border-primary focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/60 dark:border-slate-700 dark:bg-slate-800/70 dark:text-slate-100 dark:hover:border-slate-500 dark:hover:bg-slate-800";
   return (
     <header
-      className="border-stroke sticky top-0 z-40 flex h-16 w-full items-center justify-between border-b bg-white/90 px-4 shadow-sm backdrop-blur transition-colors dark:bg-slate-900/90"
+      className="border-stroke sticky top-0 z-40 w-full border-b bg-white/90 px-4 py-3 shadow-sm backdrop-blur transition-colors dark:bg-slate-900/90"
       data-testid="app-header"
     >
-      <div className="flex items-center gap-2">
-        <button
-          onClick={toggle}
-          className="flex h-12 w-12 items-center justify-center"
+      <div className="flex w-full flex-col gap-3">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={toggle}
+            className={cn(tabClassName, "text-xs")}
+            aria-label={t("menu")}
+            type="button"
+          >
+            <Bars3Icon className="h-4 w-4" />
+            <span className="hidden sm:inline">{t("menu")}</span>
+          </button>
+          <h1 className="text-lg font-semibold text-slate-900 dark:text-white">ERM</h1>
+        </div>
+        <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-100">
+          Управление предприятием
+        </h2>
+        <nav
           aria-label={t("menu")}
+          className="flex flex-wrap items-center gap-2 self-start sm:self-end"
         >
-          <Bars3Icon className="h-6 w-6" />
-        </button>
-        <h1 className="font-bold">ERM</h1>
-      </div>
-      <div className="flex items-center gap-4">
-        <label htmlFor="lang-select" className="sr-only">
-          {t("language")}
-        </label>
-        <select
-          id="lang-select"
-          className="h-12 rounded border px-2 text-sm"
-          value={i18n.language}
-          onChange={(e) => i18n.changeLanguage(e.target.value)}
-          aria-label={t("language")}
-        >
-          <option value="ru">RU</option>
-          <option value="en">EN</option>
-        </select>
-        {user && (
-          <>
-            <ThemeToggle />
-            <ProfileDropdown>
-              <UserCircleIcon className="h-5 w-5" />
-            </ProfileDropdown>
-          </>
-        )}
+          <label htmlFor="lang-select" className="sr-only">
+            {t("language")}
+          </label>
+          <div className={tabClassName} role="presentation">
+            <select
+              id="lang-select"
+              className="bg-transparent text-xs font-semibold uppercase tracking-wide text-slate-700 outline-none focus-visible:outline-none dark:text-slate-100"
+              value={i18n.language}
+              onChange={(e) => i18n.changeLanguage(e.target.value)}
+              aria-label={t("language")}
+            >
+              <option value="ru">RU</option>
+              <option value="en">EN</option>
+            </select>
+          </div>
+          {user && (
+            <>
+              <ThemeToggle className={tabClassName} />
+              <ProfileDropdown triggerClassName={tabClassName}>
+                <UserCircleIcon className="h-4 w-4" />
+              </ProfileDropdown>
+            </>
+          )}
+        </nav>
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- переработал шапку, добавив подзаголовок «Управление предприятием» и компактный таб-бар для переключателей
- сделал кнопки меню, темы, профиля и селектор языка компактными и согласованными по стилю
- адаптировал триггеры профиля и темы для повторного использования таб-оформления

## Testing
- pnpm lint
- pnpm test:unit
- pnpm build

## Checklist
- [x] Линтер зелёный
- [x] Юнит-тесты зелёные
- [x] Сборка проходит
- [x] Обратная совместимость сохранена

## Self-check
- [x] Проверил адаптивность на 1280/768/420px
- [x] Проверил контрастность на тёмной теме визуально
- [x] Убедился, что при отсутствии пользователя скрываются профиль и тема


------
https://chatgpt.com/codex/tasks/task_b_68d670e2a40083208a21ef97a224ae4f