### PR TITLE
feat: rename settings menu to management

### DIFF
--- a/apps/web/src/layouts/Sidebar.tsx
+++ b/apps/web/src/layouts/Sidebar.tsx
@@ -24,7 +24,7 @@ const adminItems = [
   { to: "/cp/kanban", label: "Канбан", icon: ClipboardDocumentListIcon },
   { to: "/cp/reports", label: "Отчёты", icon: ChartPieIcon },
   { to: "/cp/routes", label: "Маршруты", icon: MapIcon },
-  { to: "/cp/settings", label: "Настройки", icon: Cog6ToothIcon },
+  { to: "/cp/settings", label: "Управление", icon: Cog6ToothIcon },
   { to: "/cp/logs", label: "Логи", icon: Cog6ToothIcon },
   { to: "/cp/storage", label: "Файлы", icon: RectangleStackIcon },
 ];

--- a/apps/web/src/locales/en/translation.json
+++ b/apps/web/src/locales/en/translation.json
@@ -51,7 +51,7 @@
   "search": "Search",
   "find": "Find",
   "export": "Export",
-  "settings": "Settings",
+  "settings": "Management",
   "selectOption": "Select option",
   "startDate": "Start date",
   "startPoint": "Start point",

--- a/apps/web/src/locales/ru/translation.json
+++ b/apps/web/src/locales/ru/translation.json
@@ -55,7 +55,7 @@
   "search": "Поиск",
   "find": "Найти",
   "export": "Экспорт",
-  "settings": "Настройки",
+  "settings": "Управление",
   "selectOption": "Выберите вариант",
   "startDate": "Дата начала",
   "startPoint": "Старт точка",


### PR DESCRIPTION
## Summary
- rename the admin sidebar link from “Настройки” to “Управление” to reflect the new terminology
- align the `settings` locale string in Russian and English with the updated label

## Testing
- `pnpm lint`
- `pnpm test` *(unit and API suites passed; aborted during Playwright setup so e2e not executed)*

## Checklist
- [x] Lint
- [ ] Tests (full suite including e2e)
- [ ] Build
- [ ] Dev server
- [x] Backward compatibility preserved

## Self-check
- Verified the admin navigation renders the new label in code
- Confirmed RU and EN locale entries reference the new wording
- Ensured no transient artefacts remain in the working tree after tests

## Logs
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_68d67a5d227c8320a65755e6f3c060a8