### PR TITLE
fix: show explicit placeholders in settings tables

### DIFF
--- a/apps/web/src/components/DataTable.tsx
+++ b/apps/web/src/components/DataTable.tsx
@@ -33,6 +33,7 @@ interface DataTableProps<T> {
   wrapCellsAsBadges?: boolean;
   badgeClassName?: string;
   badgeWrapperClassName?: string;
+  badgeEmptyPlaceholder?: string;
 }
 
 interface ColumnMeta {
@@ -43,8 +44,12 @@ interface ColumnMeta {
   headerClassName?: string;
 }
 
-export const defaultBadgeClassName =
-  "inline-flex min-h-[1.75rem] max-w-full items-center justify-start gap-1 rounded-full border border-slate-200 bg-white px-3 py-0.5 text-xs font-semibold text-slate-700 shadow-sm ring-1 ring-inset ring-slate-100 dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-100 dark:ring-slate-700/60";
+export const defaultBadgeClassName = [
+  "inline-flex min-h-[1.75rem] max-w-full items-center justify-start gap-1",
+  "rounded-full border border-slate-200 bg-white px-3 py-0.5 text-xs font-semibold text-slate-700 shadow-sm",
+  "ring-1 ring-inset ring-slate-100",
+  "dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-100 dark:ring-slate-700/60",
+].join(" ");
 export const defaultBadgeWrapperClassName = "flex flex-wrap items-center gap-2";
 
 const extractBadgeItems = (value: React.ReactNode): string[] => {
@@ -84,10 +89,15 @@ const renderBadgeContent = (
   content: React.ReactNode,
   badgeClassName: string,
   wrapperClassName: string,
+  emptyPlaceholder: string,
 ) => {
   const items = extractBadgeItems(content);
   if (!items.length) {
-    return <span className={badgeClassName}>—</span>;
+    return (
+      <span className={badgeClassName} title={emptyPlaceholder}>
+        {emptyPlaceholder}
+      </span>
+    );
   }
   if (items.length === 1) {
     return (
@@ -122,6 +132,7 @@ export default function DataTable<T>({
   wrapCellsAsBadges = false,
   badgeClassName = defaultBadgeClassName,
   badgeWrapperClassName = defaultBadgeWrapperClassName,
+  badgeEmptyPlaceholder = "—",
 }: DataTableProps<T>) {
   const [columnVisibility, setColumnVisibility] = React.useState({});
   const [columnOrder, setColumnOrder] = React.useState<string[]>([]);
@@ -237,6 +248,7 @@ export default function DataTable<T>({
                           cellContent,
                           badgeClassName,
                           badgeWrapperClassName,
+                          badgeEmptyPlaceholder,
                         )
                       : cellContent}
                   </TableCell>

--- a/apps/web/src/services/users.ts
+++ b/apps/web/src/services/users.ts
@@ -85,8 +85,14 @@ export const fetchUser = async (
   return res.json();
 };
 
-export const fetchUsers = () =>
-  authFetch("/api/v1/users").then((r) => (r.ok ? r.json() : []));
+export const fetchUsers = async (): Promise<User[]> => {
+  const response = await authFetch("/api/v1/users");
+  if (response.ok) {
+    return response.json();
+  }
+  const text = await response.text().catch(() => "");
+  throw new Error(text || "Не удалось загрузить пользователей");
+};
 
 export const createUser = (
   id?: number | string,


### PR DESCRIPTION
## Что сделано
- добавил в `DataTable` параметр плейсхолдера и гарантировал корректную верстку бейджей
- обновил страницы настроек: единый текст «Нет данных», корректное разрешение справочных названий и вызовы `loadUsers`
- усилил `fetchUsers`, чтобы выбрасывать ошибку и очищать таблицы при сбоях API

## Почему
- бейджи оставались пустыми при незагруженных справочниках и не сообщали о сбое загрузки пользователей

## Проверки
- `pnpm lint`
- `pnpm test:unit -- --runTestsByPath apps/web/src/pages/Settings/CollectionsPage.test.tsx`

## Логи
```text
> pnpm -r lint
Scope: 3 of 4 workspace projects
...
```
```text
> jest -- --runTestsByPath apps/web/src/pages/Settings/CollectionsPage.test.tsx
Tests:       2 passed, 2 total
```

## Самопроверка
- [x] Плейсхолдеры отображают «Нет данных» при пустых значениях
- [x] Ошибки загрузки пользователей выводятся во всплывающих подсказках
- [x] Для ролей без справочника используется локальное отображение

------
https://chatgpt.com/codex/tasks/task_b_68d685bb1e208320b863ad0bb47d7ea5