### PR TITLE
feat: refresh management layout and navigation

### DIFF
--- a/apps/web/src/AuthenticatedApp.tsx
+++ b/apps/web/src/AuthenticatedApp.tsx
@@ -32,13 +32,9 @@ const ThemeProviderLazy = lazy(async () => {
 
 function AppShell() {
   const { user } = useAuth();
-  const { open, toggle, collapsed } = useSidebar();
+  const { open, toggle } = useSidebar();
   const { t } = useTranslation();
-  const contentOffsetClass = open
-    ? collapsed
-      ? "lg:pl-20"
-      : "lg:pl-60"
-    : "lg:pl-0";
+  const contentOffsetClass = open ? "lg:pl-64" : "lg:pl-0";
   return (
     <>
       {user && <Sidebar />}

--- a/apps/web/src/components/Modal.tsx
+++ b/apps/web/src/components/Modal.tsx
@@ -2,6 +2,7 @@
 // Основные модули: React, ReactDOM
 import React from "react";
 import { createPortal } from "react-dom";
+import { XMarkIcon } from "@heroicons/react/24/outline";
 
 interface ModalProps {
   open: boolean;
@@ -16,7 +17,17 @@ export default function Modal({ open, onClose, children }: ModalProps) {
       <div className="fixed inset-0 bg-black/50" onClick={onClose} />
       <div className="pointer-events-none fixed inset-0 flex items-center justify-center">
         <div className="pointer-events-auto max-h-[90vh] w-[min(900px,90vw)] overflow-auto rounded-2xl bg-white p-6 shadow-xl">
-          {children}
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Закрыть диалог"
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full text-slate-500 transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-slate-200 dark:hover:bg-slate-800"
+            >
+              <XMarkIcon className="h-5 w-5" />
+            </button>
+          </div>
+          <div className="mt-2">{children}</div>
         </div>
       </div>
     </div>,

--- a/apps/web/src/context/SidebarContext.ts
+++ b/apps/web/src/context/SidebarContext.ts
@@ -4,8 +4,6 @@ import { createContext } from "react";
 export interface SidebarState {
   open: boolean;
   toggle: () => void;
-  collapsed: boolean;
-  toggleCollapsed: () => void;
 }
 
 export const SidebarContext = createContext<SidebarState | undefined>(

--- a/apps/web/src/context/SidebarContext.tsx
+++ b/apps/web/src/context/SidebarContext.tsx
@@ -6,14 +6,11 @@ export const SidebarProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const [open, setOpen] = useState(true);
-  const [collapsed, setCollapsed] = useState(false);
   return (
     <SidebarContext.Provider
       value={{
         open,
         toggle: () => setOpen((v) => !v),
-        collapsed,
-        toggleCollapsed: () => setCollapsed((v) => !v),
       }}
     >
       {children}

--- a/apps/web/src/layouts/Header.tsx
+++ b/apps/web/src/layouts/Header.tsx
@@ -20,7 +20,7 @@ export default function Header() {
       className="border-stroke sticky top-0 z-40 w-full border-b bg-white/90 px-4 py-3 shadow-sm backdrop-blur transition-colors dark:bg-slate-900/90"
       data-testid="app-header"
     >
-      <div className="flex w-full flex-col gap-3">
+      <div className="flex w-full flex-col gap-2">
         <div className="flex items-center gap-3">
           <button
             onClick={toggle}
@@ -33,9 +33,6 @@ export default function Header() {
           </button>
           <h1 className="text-lg font-semibold text-slate-900 dark:text-white">ERM</h1>
         </div>
-        <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-100">
-          Управление предприятием
-        </h2>
         <nav
           aria-label={t("menu")}
           className="flex flex-wrap items-center gap-2 self-start sm:self-end"

--- a/apps/web/src/layouts/Sidebar.tsx
+++ b/apps/web/src/layouts/Sidebar.tsx
@@ -11,9 +11,8 @@ import {
   Cog6ToothIcon,
   UserCircleIcon,
   XMarkIcon,
-  ChevronDoubleLeftIcon,
-  ChevronDoubleRightIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@/lib/utils";
 
 const baseItems = [
   { to: "/tasks", label: "Задачи", icon: ClipboardDocumentListIcon },
@@ -36,7 +35,7 @@ const managerItems = [
 ];
 
 export default function Sidebar() {
-  const { open, toggle, collapsed, toggleCollapsed } = useSidebar();
+  const { open, toggle } = useSidebar();
   const { pathname } = useLocation();
   const { user } = useAuth();
   const role = user?.role || "user";
@@ -47,41 +46,36 @@ export default function Sidebar() {
   }, [role]);
   return (
     <aside
-      className={`fixed top-0 left-0 z-50 h-full ${collapsed ? "w-20" : "w-60"} border-stroke border-r bg-white p-4 transition-all ${open ? "translate-x-0" : "-translate-x-full"}`}
+      className={cn(
+        "fixed inset-y-0 left-0 z-50 flex h-full w-64 flex-col border-r border-stroke bg-white p-4 shadow-lg transition-transform duration-200 ease-in-out dark:bg-slate-900",
+        open ? "translate-x-0" : "-translate-x-full",
+        "lg:shadow-none",
+      )}
+      aria-hidden={!open}
     >
       <div className="flex items-center justify-between">
         <button
           onClick={toggle}
-          className="flex h-12 w-12 items-center justify-center"
+          className="flex h-10 w-10 items-center justify-center rounded-lg text-slate-500 transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-slate-300 dark:hover:bg-slate-800"
           aria-label="Закрыть меню"
+          type="button"
         >
           <XMarkIcon className="h-5 w-5" />
         </button>
-        <button
-          onClick={toggleCollapsed}
-          className="hover:text-accentPrimary hidden h-12 w-12 items-center justify-center lg:flex"
-          title="Свернуть меню"
-          aria-label="Свернуть меню"
-        >
-          {collapsed ? (
-            <ChevronDoubleRightIcon className="h-5 w-5" />
-          ) : (
-            <ChevronDoubleLeftIcon className="h-5 w-5" />
-          )}
-        </button>
       </div>
-      <nav className="mt-4 space-y-2">
+      <nav className="mt-4 space-y-1">
         {items.map((i) => (
           <Link
             key={i.to}
             to={i.to}
             aria-label={i.label}
-            className={`flex h-12 items-center gap-2 rounded-lg px-2 text-gray-700 hover:bg-gray-100 ${
-              pathname === i.to ? "bg-gray-100 font-semibold" : ""
-            }`}
+            className={cn(
+              "flex h-11 items-center gap-3 rounded-lg px-3 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-slate-800",
+              pathname === i.to && "bg-slate-100 font-semibold dark:bg-slate-800",
+            )}
           >
             <i.icon className="h-5 w-5" />
-            {!collapsed && <span>{i.label}</span>}
+            <span className="truncate">{i.label}</span>
           </Link>
         ))}
       </nav>

--- a/apps/web/src/pages/Logs.tsx
+++ b/apps/web/src/pages/Logs.tsx
@@ -1,14 +1,10 @@
 // Страница просмотра логов
 import React from "react";
-import Breadcrumbs from "../components/Breadcrumbs";
 import LogViewer from "../components/LogViewer";
 
 export default function Logs() {
   return (
     <div className="space-y-6 p-4">
-      <Breadcrumbs
-        items={[{ label: "Задачи", href: "/tasks" }, { label: "Логи" }]}
-      />
       <LogViewer />
     </div>
   );

--- a/apps/web/src/pages/Profile.tsx
+++ b/apps/web/src/pages/Profile.tsx
@@ -1,7 +1,6 @@
 // Назначение: страница профиля пользователя
 // Основные модули: React, React Router
 import { useEffect, useMemo, useState, type FormEvent } from "react";
-import Breadcrumbs from "../components/Breadcrumbs";
 import { useAuth } from "../context/useAuth";
 import { updateProfile } from "../services/auth";
 import { fetchCollectionItems, type CollectionItem } from "../services/collections";
@@ -155,9 +154,6 @@ export default function Profile() {
 
   return (
     <div className="space-y-6">
-      <Breadcrumbs
-        items={[{ label: "Задачи", href: "/tasks" }, { label: "Профиль" }]}
-      />
       <div className="mx-auto max-w-4xl space-y-4">
         {error && (
           <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">

--- a/apps/web/src/pages/Reports.tsx
+++ b/apps/web/src/pages/Reports.tsx
@@ -2,7 +2,6 @@
 import React from "react";
 import ReportFilterForm from "../components/ReportFilterForm";
 import KPIOverview from "../components/KPIOverview";
-import Breadcrumbs from "../components/Breadcrumbs";
 import authFetch from "../utils/authFetch";
 
 export default function Reports() {
@@ -16,9 +15,6 @@ export default function Reports() {
   React.useEffect(() => load(), []);
   return (
     <div className="space-y-6">
-      <Breadcrumbs
-        items={[{ label: "Задачи", href: "/tasks" }, { label: "Отчёты" }]}
-      />
       <div className="space-y-4 rounded-lg bg-white p-4 shadow-sm">
         <h2 className="text-xl font-semibold">Отчёты</h2>
         <ReportFilterForm onChange={load} />

--- a/apps/web/src/pages/Routes.tsx
+++ b/apps/web/src/pages/Routes.tsx
@@ -1,6 +1,5 @@
 // Страница отображения маршрутов на карте с фильтрами
 import React from "react";
-import Breadcrumbs from "../components/Breadcrumbs";
 import fetchRouteGeometry from "../services/osrm";
 import { fetchTasks } from "../services/tasks";
 import optimizeRoute from "../services/optimizer";
@@ -355,9 +354,6 @@ export default function RoutesPage() {
 
   return (
     <div className="space-y-4">
-      <Breadcrumbs
-        items={[{ label: "Задачи", href: "/tasks" }, { label: "Маршруты" }]}
-      />
       {role === "admin" ? (
         <div className="space-y-2 rounded border p-3">
           <div className="flex flex-wrap items-center gap-3">

--- a/apps/web/src/pages/Settings/CollectionsPage.tsx
+++ b/apps/web/src/pages/Settings/CollectionsPage.tsx
@@ -529,24 +529,42 @@ export default function CollectionsPage() {
   }, [allDepartments]);
 
   const getItemDisplayValue = useCallback(
-    (item: CollectionItem, type: string) => {
+    (item: CollectionItem, type: CollectionKey) => {
       if (type === "departments") {
         const ids = parseIds(item.value);
         if (!ids.length) return EMPTY_BADGE_TEXT;
         const names = ids
-          .map((id) => divisionMap.get(id))
+          .map(
+            (id) =>
+              divisionMap.get(id) ??
+              allDivisions.find((division) => division._id === id)?.name ??
+              id,
+          )
           .filter((name): name is string => Boolean(name));
-        return names.length ? names.join(", ") : EMPTY_BADGE_TEXT;
+        return names.length ? names.join("\n") : EMPTY_BADGE_TEXT;
       }
       if (type === "divisions") {
-        return departmentMap.get(item.value) || EMPTY_BADGE_TEXT;
+        const departmentName =
+          departmentMap.get(item.value) ??
+          allDepartments.find((department) => department._id === item.value)?.name ??
+          item.value;
+        return departmentName || EMPTY_BADGE_TEXT;
       }
       if (type === "positions") {
-        return divisionMap.get(item.value) || EMPTY_BADGE_TEXT;
+        const divisionName =
+          divisionMap.get(item.value) ??
+          allDivisions.find((division) => division._id === item.value)?.name ??
+          item.value;
+        return divisionName || EMPTY_BADGE_TEXT;
       }
-      return item.value;
+      return item.value || EMPTY_BADGE_TEXT;
     },
-    [departmentMap, divisionMap],
+    [
+      allDepartments,
+      allDivisions,
+      departmentMap,
+      divisionMap,
+    ],
   );
 
   const buildCollectionColumns = useCallback(
@@ -762,14 +780,19 @@ export default function CollectionsPage() {
 
   return (
     <div className="mx-auto flex w-full max-w-screen-2xl flex-col gap-6 px-3 pb-12 pt-4 sm:px-4 lg:px-8">
-      {hint && <div className="text-sm text-red-600">{hint}</div>}
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">
+          Управление предприятием
+        </h1>
+        {hint && <div className="text-sm text-red-600">{hint}</div>}
+      </header>
       <Tabs
         value={active}
         onValueChange={(v) => {
           setActive(v as CollectionKey);
           setPage(1);
         }}
-        className="space-y-6"
+        className="space-y-5"
       >
         <div className="sm:hidden">
           <label htmlFor="settings-section-select" className="sr-only">
@@ -863,12 +886,12 @@ export default function CollectionsPage() {
                 <div className="space-y-4">
                   <form
                     onSubmit={submitUserSearch}
-                    className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2 lg:grid lg:grid-cols-[minmax(0,18rem)_auto_auto] lg:items-center lg:gap-2"
+                    className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2 lg:grid lg:grid-cols-[minmax(0,18rem)_auto_auto] lg:items-center lg:gap-3 lg:mt-1"
                   >
                     <label className="flex flex-col gap-1 sm:w-64 lg:w-full lg:min-w-0">
                       <span className="text-sm font-medium">Поиск</span>
                       <input
-                        className="h-10 w-full rounded border px-3 lg:h-9"
+                        className="h-10 w-full rounded border px-3 text-sm lg:h-9 lg:text-xs"
                         value={userSearchDraft}
                         onChange={(event) => setUserSearchDraft(event.target.value)}
                         placeholder="Имя или логин"
@@ -876,16 +899,16 @@ export default function CollectionsPage() {
                     </label>
                     <button
                       type="submit"
-                      className="btn btn-blue h-10 rounded px-4 lg:h-9 lg:px-3"
+                      className="btn btn-blue h-10 rounded px-4 text-sm font-semibold lg:h-8 lg:px-3 lg:text-xs"
                     >
                       Искать
                     </button>
                     <button
                       type="button"
-                      className="btn btn-green h-10 rounded px-4 lg:h-9 lg:px-3"
+                      className="btn btn-green h-10 rounded px-4 text-sm font-semibold lg:h-8 lg:px-3 lg:text-xs"
                       onClick={() => openUserModal()}
                     >
-                      Новый пользователь
+                      Добавить
                     </button>
                   </form>
                   <DataTable
@@ -908,12 +931,12 @@ export default function CollectionsPage() {
                 <div className="space-y-4">
                   <form
                     onSubmit={submitUserSearch}
-                    className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2 lg:grid lg:grid-cols-[minmax(0,18rem)_auto_auto] lg:items-center lg:gap-2"
+                    className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2 lg:grid lg:grid-cols-[minmax(0,18rem)_auto_auto] lg:items-center lg:gap-3 lg:mt-1"
                   >
                     <label className="flex flex-col gap-1 sm:w-64 lg:w-full lg:min-w-0">
                       <span className="text-sm font-medium">Поиск</span>
                       <input
-                        className="h-10 w-full rounded border px-3 lg:h-9"
+                        className="h-10 w-full rounded border px-3 text-sm lg:h-9 lg:text-xs"
                         value={userSearchDraft}
                         onChange={(event) => setUserSearchDraft(event.target.value)}
                         placeholder="Имя или логин"
@@ -921,16 +944,16 @@ export default function CollectionsPage() {
                     </label>
                     <button
                       type="submit"
-                      className="btn btn-blue h-10 rounded px-4 lg:h-9 lg:px-3"
+                      className="btn btn-blue h-10 rounded px-4 text-sm font-semibold lg:h-8 lg:px-3 lg:text-xs"
                     >
                       Искать
                     </button>
                     <button
                       type="button"
-                      className="btn btn-green h-10 rounded px-4 lg:h-9 lg:px-3"
+                      className="btn btn-green h-10 rounded px-4 text-sm font-semibold lg:h-8 lg:px-3 lg:text-xs"
                       onClick={() => openEmployeeModal()}
                     >
-                      Новый сотрудник
+                      Добавить
                     </button>
                   </form>
                   <DataTable
@@ -955,12 +978,12 @@ export default function CollectionsPage() {
                 <div className="space-y-4">
                   <form
                     onSubmit={submitCollectionSearch}
-                    className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2 lg:grid lg:grid-cols-[minmax(0,18rem)_auto_auto] lg:items-center lg:gap-2"
+                    className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2 lg:grid lg:grid-cols-[minmax(0,18rem)_auto_auto] lg:items-center lg:gap-3 lg:mt-1"
                   >
                     <label className="flex flex-col gap-1 sm:w-64 lg:w-full lg:min-w-0">
                       <span className="text-sm font-medium">Поиск</span>
                       <input
-                        className="h-10 w-full rounded border px-3 lg:h-9"
+                        className="h-10 w-full rounded border px-3 text-sm lg:h-9 lg:text-xs"
                         value={currentSearchDraft}
                         onChange={(event) =>
                           updateCollectionSearchDraft(event.target.value)
@@ -970,13 +993,13 @@ export default function CollectionsPage() {
                     </label>
                     <button
                       type="submit"
-                      className="btn btn-blue h-10 rounded px-4 lg:h-9 lg:px-3"
+                      className="btn btn-blue h-10 rounded px-4 text-sm font-semibold lg:h-8 lg:px-3 lg:text-xs"
                     >
                       Искать
                     </button>
                     <button
                       type="button"
-                      className="btn btn-green h-10 rounded px-4 lg:h-9 lg:px-3"
+                      className="btn btn-green h-10 rounded px-4 text-sm font-semibold lg:h-8 lg:px-3 lg:text-xs"
                       onClick={() => openCollectionModal()}
                     >
                       Добавить

--- a/apps/web/src/pages/Settings/FleetVehiclesTab.tsx
+++ b/apps/web/src/pages/Settings/FleetVehiclesTab.tsx
@@ -243,15 +243,15 @@ export default function FleetVehiclesTab() {
 
   return (
     <section className="space-y-4">
-      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-start sm:gap-3 lg:items-center lg:gap-2">
+      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-start sm:gap-3 lg:items-center lg:gap-3">
         <form
           onSubmit={handleSearchSubmit}
-          className="flex w-full flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2 lg:grid lg:flex-1 lg:grid-cols-[minmax(0,18rem)_auto] lg:items-center lg:gap-2"
+          className="flex w-full flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2 lg:grid lg:flex-1 lg:grid-cols-[minmax(0,18rem)_auto] lg:items-center lg:gap-3 lg:mt-1"
         >
           <label className="flex w-full flex-col gap-1 sm:w-64 lg:w-full lg:min-w-0">
             <span className="text-sm font-medium">Поиск</span>
             <input
-              className="h-10 w-full rounded border px-3 lg:h-9"
+              className="h-10 w-full rounded border px-3 text-sm lg:h-9 lg:text-xs"
               value={search}
               onChange={(event) => setSearch(event.target.value)}
               placeholder="Название или номер"
@@ -259,17 +259,17 @@ export default function FleetVehiclesTab() {
           </label>
           <button
             type="submit"
-            className="btn btn-blue h-10 rounded px-4 sm:h-10 sm:px-4 lg:h-9 lg:px-3"
+            className="btn btn-blue h-10 rounded px-4 text-sm font-semibold sm:h-10 sm:px-4 lg:h-8 lg:px-3 lg:text-xs"
           >
             Искать
           </button>
         </form>
         <button
           type="button"
-          className="btn btn-green h-10 rounded px-4 lg:h-9 lg:px-3"
+          className="btn btn-green h-10 rounded px-4 text-sm font-semibold lg:h-8 lg:px-3 lg:text-xs"
           onClick={openCreate}
         >
-          Добавить транспорт
+          Добавить
         </button>
       </div>
       {loading ? <p className="text-sm text-gray-500">Загрузка транспорта…</p> : null}


### PR DESCRIPTION
## Summary
- simplify sidebar state to match the two-mode mobile behaviour and add explicit close controls to dialogs
- move the "Управление предприятием" heading into the settings page, sync badge data with card details, and resize management buttons
- drop breadcrumbs from non-task pages and align fleet tab actions with the new button style

## Testing
- pnpm lint
- pnpm test:unit


------
https://chatgpt.com/codex/tasks/task_b_68d6a56ec1b88320bd63bbc08c8b0010