### PR TITLE
fix: ensure settings badges use complete reference data

### DIFF
--- a/apps/web/src/pages/Settings/CollectionsPage.test.tsx
+++ b/apps/web/src/pages/Settings/CollectionsPage.test.tsx
@@ -11,7 +11,10 @@ import {
 } from "@testing-library/react";
 import CollectionsPage from "./CollectionsPage";
 import type { CollectionItem } from "../../services/collections";
-import { fetchCollectionItems } from "../../services/collections";
+import {
+  fetchCollectionItems,
+  fetchAllCollectionItems,
+} from "../../services/collections";
 import { settingsUserColumns } from "../../columns/settingsUserColumns";
 import { settingsEmployeeColumns } from "../../columns/settingsEmployeeColumns";
 
@@ -28,6 +31,7 @@ const extractHeaderText = (header: unknown): string => {
 
 jest.mock("../../services/collections", () => ({
   fetchCollectionItems: jest.fn(),
+  fetchAllCollectionItems: jest.fn(),
   createCollectionItem: jest.fn(),
   updateCollectionItem: jest.fn(),
   removeCollectionItem: jest.fn(),
@@ -168,6 +172,9 @@ describe("CollectionsPage", () => {
   const mockedFetch = fetchCollectionItems as jest.MockedFunction<
     typeof fetchCollectionItems
   >;
+  const mockedFetchAll = fetchAllCollectionItems as jest.MockedFunction<
+    typeof fetchAllCollectionItems
+  >;
   const dataset: Record<
     string,
     Record<string, { items: CollectionItem[]; total: number }>
@@ -214,10 +221,16 @@ describe("CollectionsPage", () => {
 
   beforeEach(() => {
     mockedFetch.mockReset();
+    mockedFetchAll.mockReset();
     mockedFetch.mockImplementation(async (type: string, search = "") => {
       const byType = dataset[type] ?? {};
       const key = search || "";
       return byType[key] ?? byType[""] ?? { items: [], total: 0 };
+    });
+    mockedFetchAll.mockImplementation(async (type: string) => {
+      const byType = dataset[type] ?? {};
+      const defaultEntry = byType[""] ?? { items: [] };
+      return (defaultEntry.items ?? []) as CollectionItem[];
     });
   });
 

--- a/apps/web/src/services/collections.test.ts
+++ b/apps/web/src/services/collections.test.ts
@@ -1,0 +1,70 @@
+/** @jest-environment jsdom */
+// Назначение файла: проверяет загрузку всех страниц коллекций
+// Основные модули: jest, fetchAllCollectionItems
+import authFetch from "../utils/authFetch";
+import { fetchAllCollectionItems } from "./collections";
+
+jest.mock("../utils/authFetch", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockedAuthFetch = authFetch as jest.MockedFunction<typeof authFetch>;
+
+const createResponse = (body: unknown): Response =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  }) as unknown as Response;
+
+describe("fetchAllCollectionItems", () => {
+  beforeEach(() => {
+    mockedAuthFetch.mockReset();
+  });
+
+  it("загружает все страницы пока не будет получено нужное количество", async () => {
+    mockedAuthFetch
+      .mockResolvedValueOnce(
+        createResponse({
+          items: [
+            { _id: "a", type: "departments", name: "A", value: "" },
+            { _id: "b", type: "departments", name: "B", value: "" },
+          ],
+          total: 3,
+        }),
+      )
+      .mockResolvedValueOnce(
+        createResponse({
+          items: [
+            { _id: "c", type: "departments", name: "C", value: "" },
+          ],
+          total: 3,
+        }),
+      );
+
+    const result = await fetchAllCollectionItems("departments", "", 2);
+
+    expect(result).toHaveLength(3);
+    expect(result.map((item) => item._id)).toEqual(["a", "b", "c"]);
+    expect(mockedAuthFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("останавливается, если страница вернула меньше элементов, чем лимит", async () => {
+    mockedAuthFetch.mockResolvedValue(
+      createResponse({
+        items: [
+          { _id: "a", type: "departments", name: "A", value: "" },
+        ],
+        total: 10,
+      }),
+    );
+
+    const result = await fetchAllCollectionItems("departments", "", 50);
+
+    expect(result).toHaveLength(1);
+    expect(mockedAuthFetch).toHaveBeenCalledTimes(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `fetchAllCollectionItems` helper to gather all pages of collection data for reference lookups
- preload full department, division and position lists concurrently and reuse existing error hints when requests fail
- extend unit coverage for the new helper and update CollectionsPage tests to mock the additional loader

## Testing
- pnpm test
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68d6ffeb352c83209e61ccf1ab255719