### PR TITLE
feat: repair collection references

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "pretest:unit": "pnpm --filter shared build",
     "pretest:api": "pnpm --filter shared build",
     "pretest:e2e": "./scripts/ensure_playwright_browsers.sh && ./scripts/run_playwright_diagnostics.sh && ./scripts/build_with_tmp.sh",
-    "build": "pnpm --filter shared build && pnpm -r --filter '!shared' build && npx tsc scripts/db/ensureDefaults.ts --module commonjs --target ES2020 --outDir dist --rootDir . --types node && node dist/scripts/db/ensureDefaults.js",
+    "build": "pnpm --filter shared build && pnpm -r --filter '!shared' build && npx tsc scripts/db/ensureDefaults.ts scripts/db/repairCollections.ts --module commonjs --target ES2020 --outDir dist --rootDir . --types node && node dist/scripts/db/ensureDefaults.js",
     "dev": "PNPM_SCRIPT_TIMEOUT=0 pnpm -r dev",
     "lint": "pnpm -r lint",
     "a11y": "ts-node scripts/a11y.ts",
@@ -19,7 +19,8 @@
     "format": "prettier --write .",
     "test": "pnpm test:unit && pnpm test:api && pnpm test:e2e",
     "prepare-client": "./scripts/build_client.sh",
-    "size": "size-limit"
+    "size": "size-limit",
+    "repair:collections": "node dist/scripts/db/repairCollections.js"
   },
   "devDependencies": {
     "@axe-core/cli": "^4.10.2",

--- a/scripts/db/repairCollections.ts
+++ b/scripts/db/repairCollections.ts
@@ -1,0 +1,352 @@
+// Назначение файла: восстановление целостности коллекций департаментов, отделов и должностей.
+// Основные модули: mongoose, dotenv, path.
+import * as path from 'path';
+
+const dotenv: any = (() => {
+  try {
+    return require('dotenv');
+  } catch {
+    return require(path.resolve(process.cwd(), 'apps/api/node_modules/dotenv'));
+  }
+})();
+
+const mongoose = (() => {
+  try {
+    return require('mongoose');
+  } catch {
+    return require(path.resolve(process.cwd(), 'apps/api/node_modules/mongoose'));
+  }
+})();
+
+const { Schema, Types } = mongoose;
+
+dotenv.config({ path: path.resolve(__dirname, '../..', '.env') });
+
+const mongoUrl = (
+  process.env.MONGO_DATABASE_URL ||
+  process.env.MONGODB_URI ||
+  process.env.MONGO_URL ||
+  process.env.MONGODB_URL ||
+  process.env.DATABASE_URL ||
+  ''
+).trim();
+
+const TARGET_TYPES = new Set(['departments', 'divisions', 'positions']);
+const TYPE_LABELS: Record<string, string> = {
+  departments: 'департамент',
+  divisions: 'отдел',
+  positions: 'должность',
+};
+
+interface LeanCollectionItem {
+  _id: unknown;
+  type: string;
+  name: string;
+  value: string;
+  meta?: Record<string, unknown> | null;
+}
+
+interface ReferenceDoc {
+  _id: unknown;
+  telegram_id?: number;
+  username?: string | null;
+  name?: string | null;
+  title?: string | null;
+  task_number?: string | null;
+  departmentId?: unknown;
+  divisionId?: unknown;
+  positionId?: unknown;
+}
+
+const collectionItemSchema = new Schema(
+  {
+    type: { type: String, required: true },
+    name: { type: String, required: true },
+    value: { type: String, required: true },
+    meta: { type: Schema.Types.Mixed, default: undefined },
+  },
+  { strict: false },
+);
+
+const userSchema = new Schema(
+  {
+    telegram_id: Number,
+    username: String,
+    name: String,
+    departmentId: Schema.Types.ObjectId,
+    divisionId: Schema.Types.ObjectId,
+    positionId: Schema.Types.ObjectId,
+  },
+  { strict: false },
+);
+
+const taskSchema = new Schema(
+  {
+    title: String,
+    task_number: String,
+    departmentId: Schema.Types.ObjectId,
+    divisionId: Schema.Types.ObjectId,
+    positionId: Schema.Types.ObjectId,
+  },
+  { strict: false },
+);
+
+const employeeSchema = new Schema(
+  {
+    name: String,
+    departmentId: Schema.Types.ObjectId,
+    divisionId: Schema.Types.ObjectId,
+    positionId: Schema.Types.ObjectId,
+  },
+  { strict: false },
+);
+
+type RepairCounters = {
+  normalized: number;
+  restored: number;
+  cleared: number;
+};
+
+function ensureModel(name: string, schema: unknown, collection?: string) {
+  return (mongoose.models[name] as any) ?? mongoose.model(name, schema, collection);
+}
+
+const CollectionItem = ensureModel('CollectionItem', collectionItemSchema);
+const User = ensureModel('User', userSchema);
+const Task = ensureModel('Task', taskSchema);
+const Employee = ensureModel('Employee', employeeSchema);
+
+const toObjectIdHex = (value: unknown): string | undefined => {
+  if (!value) return undefined;
+  if (value instanceof Types.ObjectId) return (value as any).toHexString();
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return undefined;
+    if (Types.ObjectId.isValid(trimmed)) {
+      return new Types.ObjectId(trimmed).toHexString();
+    }
+  }
+  return undefined;
+};
+
+const toObjectId = (value: unknown): any => {
+  if (value instanceof Types.ObjectId) return value;
+  if (typeof value === 'string' && Types.ObjectId.isValid(value.trim())) {
+    return new Types.ObjectId(value.trim());
+  }
+  return undefined;
+};
+
+const cloneMeta = (meta?: Record<string, unknown> | null): Record<string, unknown> | undefined =>
+  meta ? { ...meta } : undefined;
+
+const describeContext = (doc: ReferenceDoc, entity: string): string => {
+  const parts: string[] = [entity];
+  if (entity === 'user' && doc.telegram_id) {
+    parts.push(String(doc.telegram_id));
+  } else if (entity === 'task' && doc.task_number) {
+    parts.push(doc.task_number);
+  }
+  const label = doc.name || doc.username || doc.title;
+  if (label) {
+    parts.push(String(label));
+  }
+  return parts.join(':');
+};
+
+const registerItem = (
+  store: Map<string, Map<string, LeanCollectionItem>>,
+  doc: LeanCollectionItem,
+) => {
+  if (!TARGET_TYPES.has(doc.type)) return;
+  const id = toObjectIdHex(doc._id);
+  if (!id) return;
+  if (!store.has(doc.type)) {
+    store.set(doc.type, new Map());
+  }
+  const normalized: LeanCollectionItem = {
+    _id: doc._id,
+    type: doc.type,
+    name: doc.name,
+    value: doc.value,
+    meta: cloneMeta(doc.meta),
+  };
+  store.get(doc.type)?.set(id, normalized);
+};
+
+const normalizeCollectionItems = async (
+  store: Map<string, Map<string, LeanCollectionItem>>,
+): Promise<number> => {
+  const items = (await CollectionItem.find({ type: { $in: Array.from(TARGET_TYPES) } })
+    .lean()) as LeanCollectionItem[];
+  const operations: any[] = [];
+  items.forEach((item) => {
+    const id = toObjectIdHex(item._id);
+    if (!id) return;
+    const trimmedName = typeof item.name === 'string' ? item.name.trim() : '';
+    const trimmedValue = typeof item.value === 'string' ? item.value.trim() : '';
+    const finalName = trimmedName || `Элемент ${id}`;
+    const finalValue = trimmedValue || finalName;
+    const set: Record<string, unknown> = {};
+    if (item.name !== finalName) {
+      set.name = finalName;
+    }
+    if (item.value !== finalValue) {
+      set.value = finalValue;
+    }
+    if (Object.keys(set).length > 0) {
+      operations.push({
+        updateOne: {
+          filter: { _id: item._id },
+          update: { $set: set },
+        },
+      });
+    }
+    registerItem(store, { ...item, name: finalName, value: finalValue });
+  });
+  if (operations.length === 0) return 0;
+  const result = await CollectionItem.bulkWrite(operations, { ordered: false });
+  return (result.modifiedCount ?? 0) + (result.upsertedCount ?? 0);
+};
+
+const ensureCollectionItem = async (
+  store: Map<string, Map<string, LeanCollectionItem>>,
+  type: string,
+  value: unknown,
+  context: string,
+): Promise<'exists' | 'created' | 'invalid'> => {
+  if (!TARGET_TYPES.has(type)) return 'invalid';
+  const idHex = toObjectIdHex(value);
+  if (!idHex) {
+    return 'invalid';
+  }
+  const existing = store.get(type)?.get(idHex);
+  if (existing) {
+    return 'exists';
+  }
+  const objectId = toObjectId(value);
+  if (!objectId) {
+    return 'invalid';
+  }
+  const label = TYPE_LABELS[type] ?? 'элемент';
+  const name = `Восстановленный ${label} ${idHex}`;
+  const meta: Record<string, unknown> = {
+    invalid: true,
+    invalidCode: 'auto_restored',
+    invalidReason:
+      'Элемент восстановлен автоматически: проверьте данные и заполните корректные значения.',
+    invalidAt: new Date(),
+  };
+  if (context) {
+    meta.restoredFrom = context;
+  }
+  const created = await CollectionItem.create({
+    _id: objectId,
+    type,
+    name,
+    value: idHex,
+    meta,
+  });
+  const lean = (created.toObject?.() ?? created) as LeanCollectionItem;
+  registerItem(store, lean);
+  return 'created';
+};
+
+const processReferences = async (
+  store: Map<string, Map<string, LeanCollectionItem>>,
+  Model: any,
+  entity: string,
+): Promise<{ restored: number; cleared: number }> => {
+  const docs = (await Model.find().lean()) as ReferenceDoc[];
+  if (!docs.length) return { restored: 0, cleared: 0 };
+  const updates: any[] = [];
+  let restored = 0;
+  let cleared = 0;
+  for (const doc of docs) {
+    const unset: Record<string, number> = {};
+    const context = describeContext(doc, entity);
+    const pairs: [keyof ReferenceDoc, string][] = [
+      ['departmentId', 'departments'],
+      ['divisionId', 'divisions'],
+      ['positionId', 'positions'],
+    ];
+    for (const [key, type] of pairs) {
+      const raw = doc[key];
+      if (!raw) continue;
+      // eslint-disable-next-line no-await-in-loop
+      const outcome = await ensureCollectionItem(store, type, raw, context);
+      if (outcome === 'created') {
+        restored += 1;
+      } else if (outcome === 'invalid') {
+        unset[key as string] = 1;
+        cleared += 1;
+      }
+    }
+    if (Object.keys(unset).length > 0) {
+      updates.push({
+        updateOne: {
+          filter: { _id: doc._id },
+          update: { $unset: unset },
+        },
+      });
+    }
+  }
+  if (updates.length > 0) {
+    await Model.bulkWrite(updates, { ordered: false });
+  }
+  return { restored, cleared };
+};
+
+export async function repairCollections(): Promise<RepairCounters> {
+  if (!/^mongodb(\+srv)?:\/\//.test(mongoUrl)) {
+    console.warn('Не задан MONGO_DATABASE_URL, пропускаем проверку коллекций');
+    return { normalized: 0, restored: 0, cleared: 0 };
+  }
+
+  let shouldDisconnect = false;
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(mongoUrl, { serverSelectionTimeoutMS: 5000 });
+    shouldDisconnect = true;
+  }
+
+  try {
+    const store = new Map<string, Map<string, LeanCollectionItem>>();
+    const normalized = await normalizeCollectionItems(store);
+    const userResult = await processReferences(store, User, 'user');
+    const taskResult = await processReferences(store, Task, 'task');
+    const employeeResult = await processReferences(store, Employee, 'employee');
+    const restored = userResult.restored + taskResult.restored + employeeResult.restored;
+    const cleared = userResult.cleared + taskResult.cleared + employeeResult.cleared;
+    if (normalized) {
+      console.log(`Нормализовано элементов коллекций: ${normalized}`);
+    }
+    if (restored) {
+      console.log(`Восстановлено ссылок на коллекции: ${restored}`);
+    }
+    if (cleared) {
+      console.log(`Удалено битых ссылок: ${cleared}`);
+    }
+    if (!normalized && !restored && !cleared) {
+      console.log('Коллекции уже в корректном состоянии');
+    }
+    return { normalized, restored, cleared };
+  } finally {
+    if (shouldDisconnect) {
+      await mongoose.disconnect().catch(() => undefined);
+    }
+  }
+}
+
+if (require.main === module) {
+  repairCollections()
+    .catch((e: unknown) => {
+      const err = e as { message?: string };
+      console.error('Ошибка восстановления коллекций:', err.message);
+      process.exitCode = 1;
+    })
+    .finally(() => {
+      if (!process.exitCode) {
+        process.exitCode = 0;
+      }
+    });
+}

--- a/tests/repairCollections.spec.ts
+++ b/tests/repairCollections.spec.ts
@@ -1,0 +1,120 @@
+// Назначение: проверяет восстановление и очистку ссылок коллекций.
+// Основные модули: mongoose, mongodb-memory-server, repairCollections.
+import { MongoMemoryServer } from 'mongodb-memory-server';
+
+import { repairCollections } from '../scripts/db/repairCollections';
+
+jest.setTimeout(30000);
+
+const mongoose = (() => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return require('mongoose');
+  } catch {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return require('../apps/api/node_modules/mongoose');
+  }
+})();
+
+const getModel = (name: string) => mongoose.model(name);
+
+describe('repairCollections', () => {
+  let server: MongoMemoryServer;
+  let uri: string;
+
+  beforeAll(async () => {
+    server = await MongoMemoryServer.create();
+    uri = server.getUri();
+    process.env.MONGO_DATABASE_URL = uri;
+    await mongoose.connect(uri);
+  });
+
+  afterEach(async () => {
+    if (mongoose.connection.readyState === 1 && mongoose.connection.db) {
+      await mongoose.connection.db.dropDatabase();
+    }
+  });
+
+  afterAll(async () => {
+    if (mongoose.connection.readyState !== 0) {
+      await mongoose.disconnect();
+    }
+    if (server) {
+      await server.stop();
+    }
+    delete process.env.MONGO_DATABASE_URL;
+  });
+
+  test('восстанавливает отсутствующие элементы и нормализует значения', async () => {
+    const CollectionItem = getModel('CollectionItem');
+    const User = getModel('User');
+    const Task = getModel('Task');
+    const Employee = getModel('Employee');
+
+    const existingDepartmentId = new mongoose.Types.ObjectId();
+    await CollectionItem.create({
+      _id: existingDepartmentId,
+      type: 'departments',
+      name: '  Финансовый отдел  ',
+      value: '  finance  ',
+    });
+
+    const missingDivisionId = new mongoose.Types.ObjectId();
+    const missingPositionId = new mongoose.Types.ObjectId();
+    const missingTaskDepartmentId = new mongoose.Types.ObjectId();
+
+    await User.create({
+      telegram_id: 101,
+      email: '101@example.com',
+      access: 1,
+      departmentId: existingDepartmentId,
+      divisionId: missingDivisionId,
+      positionId: missingPositionId,
+    });
+
+    await Task.create({
+      title: 'Тестовая задача',
+      task_number: 'ERM_000001',
+      departmentId: missingTaskDepartmentId,
+    });
+
+    await Employee.create({
+      name: 'Иван',
+      departmentId: existingDepartmentId,
+      positionId: missingPositionId,
+    });
+
+    const result = await repairCollections();
+
+    expect(result.normalized).toBe(1);
+    expect(result.restored).toBe(3);
+    expect(result.cleared).toBe(0);
+
+    const items = await CollectionItem.find().lean();
+    const names = items.map((item: any) => item.name);
+    expect(names).toContain('Финансовый отдел');
+    const restoredDivision = await CollectionItem.findOne({ _id: missingDivisionId });
+    expect(restoredDivision).not.toBeNull();
+    expect(restoredDivision?.get('meta')).toMatchObject({ invalid: true });
+    const restoredPosition = await CollectionItem.findOne({ _id: missingPositionId });
+    expect(restoredPosition?.get('value')).toBe(missingPositionId.toHexString());
+    const restoredDepartment = await CollectionItem.findOne({ _id: missingTaskDepartmentId });
+    expect(restoredDepartment?.get('name')).toContain(missingTaskDepartmentId.toHexString());
+  });
+
+  test('очищает ссылки с недопустимыми идентификаторами', async () => {
+    const usersCollection = mongoose.connection.collection('users');
+    await usersCollection.insertOne({
+      telegram_id: 202,
+      email: '202@example.com',
+      access: 1,
+      divisionId: 'неверный-id',
+    });
+
+    const result = await repairCollections();
+
+    expect(result.cleared).toBe(1);
+    const stored = await usersCollection.findOne({ telegram_id: 202 });
+    expect(stored?.divisionId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add a repairCollections maintenance script to normalize collection items and recreate missing references
- expose the script through package.json and ensure it is compiled during the build step
- cover the repair routine with Mongo memory server tests for restoration and cleanup paths

## Testing
- pnpm lint
- pnpm test:unit -- --runTestsByPath tests/repairCollections.spec.ts
- pnpm build


------
https://chatgpt.com/codex/tasks/task_b_68d78aa4802c8320b660c40a1e1a87fa