### PR TITLE
fix: корректно отклонять пустые значения коллекций

### DIFF
--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -86,10 +86,8 @@ router.post(
       .custom((raw, { req }) => {
         if (typeof raw !== 'string') return false;
         const type = typeof req.body?.type === 'string' ? req.body.type.trim() : '';
-        if (type === 'departments') {
-          return true;
-        }
-        return raw.trim().length > 0;
+        const normalized = normalizeValueByType(type, raw);
+        return normalized.length > 0;
       })
       .withMessage('Значение элемента обязательно'),
   ]),
@@ -99,7 +97,7 @@ router.post(
       const type = body.type.trim();
       const name = body.name.trim();
       const value = normalizeValueByType(type, body.value);
-      if (type !== 'departments' && !value) {
+      if (!value) {
         sendProblem(req, res, {
           type: 'about:blank',
           title: 'Ошибка валидации',


### PR DESCRIPTION
## Что сделано и зачем
- нормализуем значение коллекции ещё на этапе express-validator, чтобы пустые строки не проходили проверку
- возвращаем HTTP 400 для любых пустых значений (включая департаменты), чтобы репозиторий не вызывался зря

## Проверки
- [x] pnpm --filter telegram-task-bot test -- collectionsValidation.test.ts
- [x] pnpm lint
- [x] pnpm build

## Логи
- `pnpm --filter telegram-task-bot test -- collectionsValidation.test.ts`
- `pnpm lint`
- `pnpm build`

## Самопроверка
- [x] тест, падавший в CI, повторно запускается и зелёный
- [x] логика департаментов не нарушает другие ветки валидации
- [x] репозиторий не вызывается при некорректных данных
- [x] линтер и сборка проходят без ошибок

------
https://chatgpt.com/codex/tasks/task_b_68d7a05f8780832081c13ad905371aae