### PR TITLE
feat: расширить поиск пользователей по логину

### DIFF
--- a/apps/web/src/pages/Settings/CollectionsPage.test.tsx
+++ b/apps/web/src/pages/Settings/CollectionsPage.test.tsx
@@ -414,4 +414,34 @@ describe("CollectionsPage", () => {
     const modal = await screen.findByTestId("modal");
     expect(within(modal).getByText("operator")).toBeInTheDocument();
   });
+
+  it("возвращает пользователя при поиске по фактическому логину", async () => {
+    const user: User = {
+      telegram_id: 202,
+      telegram_username: "operator",
+      username: "202",
+      name: "Оператор",
+      role: "user",
+    };
+    mockedFetchUsers.mockResolvedValueOnce([user]);
+
+    render(<CollectionsPage />);
+
+    await screen.findByText("Главный департамент");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Пользователь" }));
+
+    const usersPanel = await screen.findByTestId("tab-content-users");
+    const rowsContainer = within(usersPanel).getByTestId("data-table-rows");
+
+    await waitFor(() => expect(rowsContainer.children).toHaveLength(1));
+
+    const searchInput = within(usersPanel).getByPlaceholderText("Имя или логин");
+    fireEvent.change(searchInput, { target: { value: "202" } });
+
+    fireEvent.click(within(usersPanel).getByRole("button", { name: "Искать" }));
+
+    await waitFor(() => expect(rowsContainer.children).toHaveLength(1));
+    expect(within(usersPanel).getByText("operator")).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/Settings/CollectionsPage.tsx
+++ b/apps/web/src/pages/Settings/CollectionsPage.tsx
@@ -744,8 +744,14 @@ export default function CollectionsPage() {
   const totalPages = Math.ceil(total / limit) || 1;
   const filteredUsers = users.filter((u) => {
     const q = userQuery.toLowerCase();
-    const login = (u.telegram_username ?? u.username ?? "").toLowerCase();
-    return !q || login.includes(q) || u.name?.toLowerCase().includes(q);
+    const login = (u.username ?? "").toLowerCase();
+    const telegramLogin = u.telegram_username?.toLowerCase() ?? "";
+    return (
+      !q ||
+      login.includes(q) ||
+      telegramLogin.includes(q) ||
+      u.name?.toLowerCase().includes(q)
+    );
   });
   const userTotalPages = Math.ceil(filteredUsers.length / limit) || 1;
   const paginatedUsers = filteredUsers.slice(


### PR DESCRIPTION
## Что сделано
- добавил поиск пользователя по обоим логинам (telegram и системному) во вкладке настроек
- дополнил тест, подтверждающий поиск по фактическому логину

## Почему
- при наличии Telegram-ника нельзя было найти пользователя по служебному логину

## Логи
- `pnpm test:unit -- --runTestsByPath apps/web/src/pages/Settings/CollectionsPage.test.tsx`

## Чек-лист
- [x] Тесты
- [ ] Линтер
- [ ] Сборка
- [x] Обратная совместимость сохранена

## Самопроверка
- ручной прогон сценария в тесте
- убедился, что фильтр учитывает оба логина
- проверил, что лишние артефакты сборки удалены из коммита

------
https://chatgpt.com/codex/tasks/task_b_68d7cb81251883209b75a87696e2e6e5