### PR TITLE
fix: relax validation for department collections and user email

### DIFF
--- a/apps/api/src/dto/users.dto.ts
+++ b/apps/api/src/dto/users.dto.ts
@@ -19,7 +19,7 @@ export class UpdateUserDto {
       body('name').optional().isString(),
       body('phone').optional().isString(),
       body('mobNumber').optional().isString(),
-      body('email').optional().isEmail(),
+      body('email').optional({ checkFalsy: true }).isEmail(),
       body('roleId').optional().isMongoId(),
       body('departmentId').optional().isMongoId(),
       body('divisionId').optional().isMongoId(),

--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -87,6 +87,9 @@ router.post(
         if (typeof raw !== 'string') return false;
         const type = typeof req.body?.type === 'string' ? req.body.type.trim() : '';
         const normalized = normalizeValueByType(type, raw);
+        if (type === 'departments') {
+          return true;
+        }
         return normalized.length > 0;
       })
       .withMessage('Значение элемента обязательно'),
@@ -97,7 +100,7 @@ router.post(
       const type = body.type.trim();
       const name = body.name.trim();
       const value = normalizeValueByType(type, body.value);
-      if (!value) {
+      if (!value && type !== 'departments') {
         sendProblem(req, res, {
           type: 'about:blank',
           title: 'Ошибка валидации',


### PR DESCRIPTION
## Summary
- allow department collection items to be created without assigning divisions immediately
- permit clearing the email field when updating a user profile

## Testing
- pnpm --filter telegram-task-bot lint

------
https://chatgpt.com/codex/tasks/task_b_68d7e6acf3f48320acf321c6247d949e