### PR TITLE
fix: валидация пустых значений коллекций

### DIFF
--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -87,9 +87,6 @@ router.post(
         if (typeof raw !== 'string') return false;
         const type = typeof req.body?.type === 'string' ? req.body.type.trim() : '';
         const normalized = normalizeValueByType(type, raw);
-        if (type === 'departments') {
-          return true;
-        }
         return normalized.length > 0;
       })
       .withMessage('Значение элемента обязательно'),
@@ -100,7 +97,7 @@ router.post(
       const type = body.type.trim();
       const name = body.name.trim();
       const value = normalizeValueByType(type, body.value);
-      if (!value && type !== 'departments') {
+      if (!value) {
         sendProblem(req, res, {
           type: 'about:blank',
           title: 'Ошибка валидации',


### PR DESCRIPTION
## Что сделано и зачем
- Добавил обязательную проверку `value` при создании элементов коллекций, чтобы пустые значения не проходили валидацию.
- Синхронизировал серверную проверку с валидацией маршрута, исключив особый случай для отделов.

## Чек-лист
- [x] `pnpm test:api`
- [x] `pnpm lint`
- [x] `pnpm build`

## Логи ключевых команд
- `pnpm test:api`
- `pnpm lint`
- `pnpm build`

## Самопроверка
- Поведение соответствует ожиданию теста `collectionsValidation`.
- Валидация не пропускает пустые значения ни для одного типа коллекций.
- Роут по-прежнему возвращает 201 при корректном вводе.
- Существующие API-тесты проходят.
- Статический анализ и сборка завершены без ошибок.


------
https://chatgpt.com/codex/tasks/task_b_68d7eb0381088320a445f059191179a9