### PR TITLE
fix: validate department collection payloads

### DIFF
--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -86,9 +86,6 @@ router.post(
       .custom((raw, { req }) => {
         if (typeof raw !== 'string') return false;
         const type = typeof req.body?.type === 'string' ? req.body.type.trim() : '';
-        if (type === 'departments') {
-          return true;
-        }
         const normalized = normalizeValueByType(type, raw);
         return normalized.length > 0;
       })
@@ -100,7 +97,7 @@ router.post(
       const type = body.type.trim();
       const name = body.name.trim();
       const value = normalizeValueByType(type, body.value);
-      if (type !== 'departments' && !value) {
+      if (!value) {
         sendProblem(req, res, {
           type: 'about:blank',
           title: 'Ошибка валидации',
@@ -172,7 +169,7 @@ router.put(
       }
       if (typeof body.value === 'string') {
         const normalizedValue = normalizeValueByType(existing.type, body.value);
-        if (existing.type !== 'departments' && !normalizedValue) {
+        if (!normalizedValue) {
           sendProblem(req, res, {
             type: 'about:blank',
             title: 'Ошибка валидации',

--- a/tests/api/collections.post.spec.ts
+++ b/tests/api/collections.post.spec.ts
@@ -80,7 +80,7 @@ describe('POST /api/v1/collections', function () {
     }
   });
 
-  it('создаёт департамент без связей с пустым value', async () => {
+  it('возвращает 400 для департаментов с пустым value', async () => {
     const response = await request(app)
       .post('/api/v1/collections')
       .set('Authorization', authHeader)
@@ -90,10 +90,10 @@ describe('POST /api/v1/collections', function () {
         value: '',
       });
 
-    assert.equal(response.status, 201, JSON.stringify(response.body));
-    assert.equal(response.body.type, 'departments');
-    assert.equal(response.body.name, 'Без отдела');
-    assert.equal(response.body.value, '');
+    assert.equal(response.status, 400, JSON.stringify(response.body));
+    assert.equal(response.body.status, 400);
+    assert.equal(response.body.title, 'Ошибка валидации');
+    assert.match(String(response.body.detail), /Значение элемента обязательно/);
   });
 
   it('возвращает 400 для других типов с пустым value', async () => {


### PR DESCRIPTION
## Что сделано
- Добавил нормализацию и запрет пустого `value` для POST/PATCH коллекций.
- Обновил интеграционный тест `collections.post.spec.ts`, проверяющий новую ошибку.

## Почему
- Пустое значение департамента приводило к обходу валидации и падению нового теста CI.

## Чек-лист
- [x] `pnpm test:unit`
- [x] `pnpm test:api -- tests/api/collections.post.spec.ts`
- [ ] `pnpm test:e2e` (не запускал — дорого по времени)

## Логи
- `pnpm test:unit`
- `pnpm test:api -- tests/api/collections.post.spec.ts`

## Самопроверка
- [x] Валидация срабатывает до обращения к репозиторию.
- [x] Ответ API сообщает о причине отказа.
- [x] Обновлённый тест покрывает новый сценарий.
- [x] Изменения обратимы без миграций.


------
https://chatgpt.com/codex/tasks/task_b_68d805564d548320a4a4d9a9ef6b4190