### PR TITLE
feat: include field names in validation details

### DIFF
--- a/apps/api/src/utils/validate.ts
+++ b/apps/api/src/utils/validate.ts
@@ -1,8 +1,45 @@
 // Назначение файла: валидация запросов через express-validator
 // Основные модули: express-validator
 import { Request, Response, NextFunction } from 'express';
-import { validationResult, ValidationChain } from 'express-validator';
+import {
+  validationResult,
+  ValidationChain,
+  ValidationError,
+} from 'express-validator';
 import { sendProblem } from './problem';
+
+const hasFieldParam = (
+  error: ValidationError,
+): error is ValidationError & { param: string } =>
+  typeof (error as { param?: unknown }).param === 'string';
+
+const hasFieldPath = (
+  error: ValidationError,
+): error is ValidationError & { path: string } =>
+  typeof (error as { path?: unknown }).path === 'string';
+
+const hasNestedErrors = (
+  error: ValidationError,
+): error is ValidationError & { nestedErrors: ValidationError[] } =>
+  Array.isArray((error as { nestedErrors?: unknown }).nestedErrors);
+
+const getParamName = (error: ValidationError): string => {
+  if (hasFieldPath(error)) {
+    return error.path.trim();
+  }
+  if (hasFieldParam(error)) {
+    return error.param.trim();
+  }
+  if (hasNestedErrors(error)) {
+    for (const nested of error.nestedErrors) {
+      const param = getParamName(nested);
+      if (param) {
+        return param;
+      }
+    }
+  }
+  return '';
+};
 
 export function handleValidation(
   req: Request,
@@ -12,11 +49,34 @@ export function handleValidation(
   const errors = validationResult(req);
   if (errors.isEmpty()) return next();
   const errorList = errors.array();
+  const detailMessages = errorList
+    .map((error) => {
+      const param = getParamName(error);
+      const rawMessage = (error as { msg?: unknown }).msg;
+      const message =
+        typeof rawMessage === 'string'
+          ? rawMessage.trim()
+          : rawMessage != null
+            ? String(rawMessage).trim()
+            : '';
+      if (param && message) {
+        return `${param} — ${message}`;
+      }
+      if (message) {
+        return message;
+      }
+      return null;
+    })
+    .filter((value): value is string => Boolean(value));
+  const detail =
+    detailMessages.length > 0
+      ? `Поля: ${detailMessages.join('; ')}`
+      : 'Ошибка валидации';
   sendProblem(req, res, {
     type: 'about:blank',
     title: 'Ошибка валидации',
     status: 400,
-    detail: 'Ошибка валидации',
+    detail,
     errors: errorList,
   });
 }

--- a/tests/api/collections.post.spec.ts
+++ b/tests/api/collections.post.spec.ts
@@ -93,7 +93,10 @@ describe('POST /api/v1/collections', function () {
     assert.equal(response.status, 400, JSON.stringify(response.body));
     assert.equal(response.body.status, 400);
     assert.equal(response.body.title, 'Ошибка валидации');
-    assert.equal(response.body.detail, 'Ошибка валидации');
+    assert.equal(
+      response.body.detail,
+      'Поля: value — Значение элемента обязательно',
+    );
     const messages = Array.isArray(response.body.errors)
       ? response.body.errors
           .map((error: { msg?: string }) => error?.msg)
@@ -118,7 +121,10 @@ describe('POST /api/v1/collections', function () {
     assert.equal(response.status, 400);
     assert.equal(response.body.status, 400);
     assert.equal(response.body.title, 'Ошибка валидации');
-    assert.equal(response.body.detail, 'Ошибка валидации');
+    assert.equal(
+      response.body.detail,
+      'Поля: value — Значение элемента обязательно',
+    );
     if (Array.isArray(response.body.errors) && response.body.errors.length) {
       const messages = response.body.errors
         .map((error: { msg?: string }) => error?.msg)


### PR DESCRIPTION
## Что сделано
- добавил извлечение названий полей из ошибок express-validator для формирования понятного detail
- обновил API-тесты коллекций под новый формат сообщения, чтобы проверять наличие названия поля

## Зачем
- новые проверки ожидают, что ответ 400 содержит название проблемного поля, иначе тесты падают

## Чек-лист
- [x] тесты проходят локально
- [x] линтер без ошибок
- [x] сборка не нарушена
- [x] обратная совместимость сохранена

## Логи
- `TS_NODE_PROJECT=apps/api/tsconfig.json pnpm exec mocha -r ts-node/register -r tests/setupEnv.ts tests/api/collections.post.spec.ts`
- `pnpm lint`

## Самопроверка
- детали ответа содержат и сообщение, и имя поля
- ошибки без имени поля по-прежнему отображаются
- формат detail соответствует русской локализации
- фронт не требует изменений
- тесты покрывают ожидаемое поведение


------
https://chatgpt.com/codex/tasks/task_b_68d82008fe1483209c136c3f63fc5a55