### PR TITLE
Allow empty department value and fix employee badges

### DIFF
--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -86,6 +86,7 @@ router.post(
       .custom((raw, { req }) => {
         if (typeof raw !== 'string') return false;
         const type = typeof req.body?.type === 'string' ? req.body.type.trim() : '';
+        if (type === 'departments') return true;
         const normalized = normalizeValueByType(type, raw);
         return normalized.length > 0;
       })
@@ -97,7 +98,7 @@ router.post(
       const type = body.type.trim();
       const name = body.name.trim();
       const value = normalizeValueByType(type, body.value);
-      if (!value) {
+      if (!value && type !== 'departments') {
         sendProblem(req, res, {
           type: 'about:blank',
           title: 'Ошибка валидации',
@@ -169,7 +170,7 @@ router.put(
       }
       if (typeof body.value === 'string') {
         const normalizedValue = normalizeValueByType(existing.type, body.value);
-        if (!normalizedValue) {
+        if (!normalizedValue && existing.type !== 'departments') {
           sendProblem(req, res, {
             type: 'about:blank',
             title: 'Ошибка валидации',

--- a/apps/web/src/pages/Profile.tsx
+++ b/apps/web/src/pages/Profile.tsx
@@ -75,19 +75,44 @@ export default function Profile() {
   const positionMap = useMemo(() => parseCollection(positions), [positions]);
 
   const departmentName = useMemo(() => {
-    if (!user?.departmentId) return "";
-    return departmentMap.get(user.departmentId) || "";
-  }, [departmentMap, user?.departmentId]);
+    const fallback =
+      typeof user?.departmentName === "string"
+        ? user.departmentName.trim()
+        : "";
+    if (fallback) return fallback;
+    const id =
+      typeof user?.departmentId === "string"
+        ? user.departmentId.trim()
+        : "";
+    if (!id) return "";
+    return departmentMap.get(id) || id;
+  }, [departmentMap, user?.departmentId, user?.departmentName]);
 
   const divisionName = useMemo(() => {
-    if (!user?.divisionId) return "";
-    return divisionMap.get(user.divisionId) || "";
-  }, [divisionMap, user?.divisionId]);
+    const fallback =
+      typeof user?.divisionName === "string"
+        ? user.divisionName.trim()
+        : "";
+    if (fallback) return fallback;
+    const id =
+      typeof user?.divisionId === "string" ? user.divisionId.trim() : "";
+    if (!id) return "";
+    return divisionMap.get(id) || id;
+  }, [divisionMap, user?.divisionId, user?.divisionName]);
 
   const positionName = useMemo(() => {
-    if (!user?.positionId) return "";
-    return positionMap.get(user.positionId) || "";
-  }, [positionMap, user?.positionId]);
+    const fallback =
+      typeof user?.positionName === "string"
+        ? user.positionName.trim()
+        : "";
+    if (fallback) return fallback;
+    const id =
+      typeof user?.positionId === "string"
+        ? user.positionId.trim()
+        : "";
+    if (!id) return "";
+    return positionMap.get(id) || id;
+  }, [positionMap, user?.positionId, user?.positionName]);
 
   const updateField = <K extends keyof EditableProfileForm>(
     key: K,

--- a/apps/web/src/pages/Settings/CollectionsPage.tsx
+++ b/apps/web/src/pages/Settings/CollectionsPage.tsx
@@ -162,7 +162,13 @@ const parseIds = (value: string) =>
 const resolveReferenceName = (
   map: Map<string, string>,
   id?: string | null,
+  fallbackName?: string | null,
 ): string => {
+  const directName =
+    typeof fallbackName === "string" && fallbackName.trim().length
+      ? fallbackName.trim()
+      : "";
+  if (directName) return directName;
   if (typeof id !== "string") return "";
   const trimmed = id.trim();
   if (!trimmed) return "";
@@ -762,23 +768,42 @@ export default function CollectionsPage() {
   const employeeRows = useMemo<EmployeeRow[]>(
     () =>
       paginatedUsers.map((user) => {
-        const roleNameFromMap = resolveReferenceName(roleMap, user.roleId);
+        const roleId =
+          typeof user.roleId === "string" ? user.roleId.trim() : "";
+        const departmentId =
+          typeof user.departmentId === "string" ? user.departmentId.trim() : "";
+        const divisionId =
+          typeof user.divisionId === "string" ? user.divisionId.trim() : "";
+        const positionId =
+          typeof user.positionId === "string" ? user.positionId.trim() : "";
+        const roleNameFromMap = resolveReferenceName(
+          roleMap,
+          roleId,
+          user.roleName,
+        );
         const departmentName = resolveReferenceName(
           departmentMap,
-          user.departmentId,
+          departmentId,
+          user.departmentName,
         );
         const divisionName = resolveReferenceName(
           divisionMap,
-          user.divisionId,
+          divisionId,
+          user.divisionName,
         );
         const positionName = resolveReferenceName(
           positionMap,
-          user.positionId,
+          positionId,
+          user.positionName,
         );
         const roleLabel =
           roleNameFromMap || (user.role ? formatRoleName(user.role) : "");
         return {
           ...user,
+          roleId,
+          departmentId,
+          divisionId,
+          positionId,
           roleName: roleLabel,
           departmentName,
           divisionName,

--- a/apps/web/src/services/auth.ts
+++ b/apps/web/src/services/auth.ts
@@ -3,6 +3,7 @@
 // Основные модули: authFetch
 import authFetch from "../utils/authFetch";
 import type { User } from "../types/user";
+import { normalizeUser } from "./normalizeUser";
 
 type FetchOptions = Parameters<typeof authFetch>[1];
 
@@ -10,7 +11,8 @@ export const getProfile = async (options?: FetchOptions): Promise<User> => {
   const res = await authFetch("/api/v1/auth/profile", options);
   if (!res.ok) throw new Error("unauthorized");
   const data = await res.json();
-  return { ...data, id: String(data.telegram_id ?? "") } as User;
+  const normalized = normalizeUser(data);
+  return { ...normalized, id: String(normalized.telegram_id ?? "") } as User;
 };
 
 interface ProfileData {
@@ -46,7 +48,8 @@ export const updateProfile = async (data: ProfileData): Promise<User> => {
     throw new Error(text || "Не удалось обновить профиль");
   }
   const updated = await res.json();
-  return { ...updated, id: String(updated.telegram_id ?? "") } as User;
+  const normalized = normalizeUser(updated);
+  return { ...normalized, id: String(normalized.telegram_id ?? "") } as User;
 };
 
 export const logout = () =>

--- a/apps/web/src/services/normalizeUser.ts
+++ b/apps/web/src/services/normalizeUser.ts
@@ -1,0 +1,106 @@
+// Назначение: нормализация данных пользователя и связанных ссылок
+// Основные модули: types/user
+import type { User } from "../types/user";
+
+type ReferenceLike =
+  | string
+  | { _id?: unknown; id?: unknown; name?: unknown; label?: unknown }
+  | null
+  | undefined;
+
+const toTrimmedString = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+export const getReferenceId = (value: ReferenceLike): string | undefined => {
+  if (!value) return undefined;
+  if (typeof value === "string") return toTrimmedString(value);
+  if (typeof value !== "object") return undefined;
+  const withId = value as { _id?: unknown; id?: unknown };
+  return (
+    toTrimmedString(withId._id) ||
+    toTrimmedString(withId.id)
+  );
+};
+
+export const getReferenceName = (value: ReferenceLike): string | undefined => {
+  if (!value || typeof value === "string") return undefined;
+  if (typeof value !== "object") return undefined;
+  const withName = value as { name?: unknown; label?: unknown };
+  return toTrimmedString(withName.name) || toTrimmedString(withName.label);
+};
+
+type NormalizedFields = Pick<
+  User,
+  | "roleId"
+  | "roleName"
+  | "departmentId"
+  | "departmentName"
+  | "divisionId"
+  | "divisionName"
+  | "positionId"
+  | "positionName"
+>;
+
+export const normalizeUser = <T extends Partial<User>>(user: T): T & NormalizedFields => {
+  const source = user as Record<string, unknown>;
+
+  const roleId =
+    getReferenceId(source.roleId as ReferenceLike) ||
+    (typeof user.roleId === "string" ? user.roleId.trim() || undefined : undefined);
+  const roleName =
+    getReferenceName(source.roleId as ReferenceLike) ||
+    (typeof user.roleName === "string" ? user.roleName.trim() || undefined : undefined);
+
+  const departmentId =
+    getReferenceId(source.departmentId as ReferenceLike) ||
+    (typeof user.departmentId === "string"
+      ? user.departmentId.trim() || undefined
+      : undefined);
+  const departmentName =
+    getReferenceName(source.departmentId as ReferenceLike) ||
+    (typeof user.departmentName === "string"
+      ? user.departmentName.trim() || undefined
+      : undefined);
+
+  const divisionId =
+    getReferenceId(source.divisionId as ReferenceLike) ||
+    (typeof user.divisionId === "string"
+      ? user.divisionId.trim() || undefined
+      : undefined);
+  const divisionName =
+    getReferenceName(source.divisionId as ReferenceLike) ||
+    (typeof user.divisionName === "string"
+      ? user.divisionName.trim() || undefined
+      : undefined);
+
+  const positionId =
+    getReferenceId(source.positionId as ReferenceLike) ||
+    (typeof user.positionId === "string"
+      ? user.positionId.trim() || undefined
+      : undefined);
+  const positionName =
+    getReferenceName(source.positionId as ReferenceLike) ||
+    (typeof user.positionName === "string"
+      ? user.positionName.trim() || undefined
+      : undefined);
+
+  return {
+    ...user,
+    roleId,
+    roleName,
+    departmentId,
+    departmentName,
+    divisionId,
+    divisionName,
+    positionId,
+    positionName,
+  } as T & NormalizedFields;
+};
+
+export const normalizeUsers = <T extends Partial<User>>(users: T[]): Array<T & NormalizedFields> =>
+  users.map((item) => normalizeUser(item));
+
+export default normalizeUser;

--- a/apps/web/src/services/users.ts
+++ b/apps/web/src/services/users.ts
@@ -2,6 +2,7 @@
 // Основные модули: authFetch
 import authFetch from "../utils/authFetch";
 import type { User } from "../types/user";
+import { normalizeUser, normalizeUsers } from "./normalizeUser";
 
 export interface UserDetails extends User {
   email?: string;
@@ -81,13 +82,15 @@ export const fetchUser = async (
     const text = await res.text().catch(() => "");
     throw new Error(text || "Не удалось загрузить пользователя");
   }
-  return res.json();
+  const data = await res.json();
+  return normalizeUser(data) as UserDetails;
 };
 
 export const fetchUsers = async (): Promise<User[]> => {
   const response = await authFetch("/api/v1/users");
   if (response.ok) {
-    return response.json();
+    const data = await response.json();
+    return Array.isArray(data) ? (normalizeUsers(data) as User[]) : [];
   }
   const text = await response.text().catch(() => "");
   throw new Error(text || "Не удалось загрузить пользователей");
@@ -122,7 +125,8 @@ export const createUser = (
       }
       throw new Error(message);
     }
-    return r.json();
+    const data = await r.json();
+    return normalizeUser(data);
   });
 };
 
@@ -189,6 +193,7 @@ export const updateUser = (
       }
       throw new Error(message);
     }
-    return r.json();
+    const data = await r.json();
+    return normalizeUser(data) as UserDetails;
   });
 };

--- a/apps/web/src/types/user.ts
+++ b/apps/web/src/types/user.ts
@@ -26,10 +26,18 @@ export interface User {
   permissions?: string[];
   /** Идентификатор роли */
   roleId?: string;
+  /** Название роли, если пришло с сервера */
+  roleName?: string;
   /** Идентификатор департамента */
   departmentId?: string;
+  /** Название департамента */
+  departmentName?: string;
   /** Идентификатор отдела */
   divisionId?: string;
+  /** Название отдела */
+  divisionName?: string;
   /** Идентификатор должности */
   positionId?: string;
+  /** Название должности */
+  positionName?: string;
 }

--- a/tests/api/collections.post.spec.ts
+++ b/tests/api/collections.post.spec.ts
@@ -80,7 +80,7 @@ describe('POST /api/v1/collections', function () {
     }
   });
 
-  it('возвращает 400 для департаментов с пустым value', async () => {
+  it('создаёт департамент без отделов', async () => {
     const response = await request(app)
       .post('/api/v1/collections')
       .set('Authorization', authHeader)
@@ -90,22 +90,11 @@ describe('POST /api/v1/collections', function () {
         value: '',
       });
 
-    assert.equal(response.status, 400, JSON.stringify(response.body));
-    assert.equal(response.body.status, 400);
-    assert.equal(response.body.title, 'Ошибка валидации');
-    assert.equal(
-      response.body.detail,
-      'Поля: value — Значение элемента обязательно',
-    );
-    const messages = Array.isArray(response.body.errors)
-      ? response.body.errors
-          .map((error: { msg?: string }) => error?.msg)
-          .filter((msg: string | undefined): msg is string => Boolean(msg))
-      : [];
-    assert.ok(
-      messages.some((msg: string) => /Значение элемента обязательно/.test(msg)),
-      JSON.stringify(response.body),
-    );
+    assert.equal(response.status, 201, JSON.stringify(response.body));
+    assert.equal(response.body.type, 'departments');
+    assert.equal(response.body.name, 'Без отдела');
+    assert.equal(response.body.value, '');
+    assert.ok(typeof response.body._id === 'string' && response.body._id.length > 0);
   });
 
   it('возвращает 400 для других типов с пустым value', async () => {


### PR DESCRIPTION
## Что сделано и зачем
- Разрешил API коллекций создавать и обновлять департаменты без обязательного списка отделов, чтобы соответствовать фактическому сценарию использования.
- Добавил нормализацию ссылочных полей пользователя и применил её в сервисах auth/users, чтобы фронтенд получал строки и человекочитаемые названия.
- Обновил таблицу сотрудников и профиль пользователя, чтобы корректно показывать названия департаментов, отделов и должностей даже при приходе данных в виде объектов.
- Обновил интеграционный тест POST /api/v1/collections для проверки новой логики создания департамента без отделов.

## Чек-лист
- [x] Локально протестировано `pnpm lint`
- [x] Локально протестировано `pnpm test:api -- tests/api/collections.post.spec.ts`

## Логи ключевых команд
```bash
pnpm lint
pnpm test:api -- tests/api/collections.post.spec.ts
```

## Самопроверка
- [x] Изменения соответствуют требованиям задачи.
- [x] API остаётся обратимо совместимым с остальными типами коллекций.
- [x] UI корректно обрабатывает как строковые, так и объектные ссылки на справочники.
- [x] Обновлены тесты для новой бизнес-логики.
- [x] Пройдены обязательные линтеры и тесты.


------
https://chatgpt.com/codex/tasks/task_b_68d82c5e87248320a4d33510be108aa2