### PR TITLE
fix: allow creating empty departments

### DIFF
--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -87,6 +87,9 @@ router.post(
         if (typeof raw !== 'string') return false;
         const type = typeof req.body?.type === 'string' ? req.body.type.trim() : '';
         const normalized = normalizeValueByType(type, raw);
+        if (type === 'departments') {
+          return true;
+        }
         return normalized.length > 0;
       })
       .withMessage('Значение элемента обязательно'),
@@ -97,7 +100,7 @@ router.post(
       const type = body.type.trim();
       const name = body.name.trim();
       const value = normalizeValueByType(type, body.value);
-      if (!value) {
+      if (type !== 'departments' && !value) {
         sendProblem(req, res, {
           type: 'about:blank',
           title: 'Ошибка валидации',
@@ -169,7 +172,7 @@ router.put(
       }
       if (typeof body.value === 'string') {
         const normalizedValue = normalizeValueByType(existing.type, body.value);
-        if (!normalizedValue) {
+        if (existing.type !== 'departments' && !normalizedValue) {
           sendProblem(req, res, {
             type: 'about:blank',
             title: 'Ошибка валидации',

--- a/apps/api/tests/collectionsValidation.test.ts
+++ b/apps/api/tests/collectionsValidation.test.ts
@@ -32,15 +32,37 @@ beforeAll(() => {
   app.use('/api/v1/collections', collectionsRouter);
 });
 
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
 afterAll(() => {
   stopScheduler();
   stopQueue();
 });
 
-test('возвращает 400 и не вызывает репозиторий при пустом value', async () => {
+test('создаёт департамент без привязанных отделов', async () => {
+  repo.create.mockResolvedValue({
+    _id: '507f1f77bcf86cd799439011',
+    type: 'departments',
+    name: 'Финансы',
+    value: '',
+  });
   const response = await request(app)
     .post('/api/v1/collections')
     .send({ type: 'departments', name: 'Финансы', value: '' });
+  expect(response.status).toBe(201);
+  expect(repo.create).toHaveBeenCalledWith({
+    type: 'departments',
+    name: 'Финансы',
+    value: '',
+  });
+});
+
+test('возвращает 400 при пустом value для других коллекций', async () => {
+  const response = await request(app)
+    .post('/api/v1/collections')
+    .send({ type: 'divisions', name: 'Продажи', value: '' });
   expect(response.status).toBe(400);
   expect(repo.create).not.toHaveBeenCalled();
   expect(String(response.body.detail)).toContain('value');


### PR DESCRIPTION
## Что сделано
- разрешил сохранять элементы коллекции департаментов без обязательных отделов
- скорректировал проверку обновления, чтобы пустые значения были допустимы только для департаментов
- дополнил тесты сценариями успешного создания департамента и отказа для других типов

## Почему
- без отделов невозможно было создать первый департамент, API всегда отвечало 400

## Чек-лист
- [x] Тесты локально зелёные
- [x] Линтер без ошибок
- [x] Сборка не падает (через setup_and_test.sh)
- [x] Обратная совместимость сохранена

## Логи команд
- `pnpm --dir apps/api test -- --runTestsByPath tests/collectionsValidation.test.ts`
- `./scripts/setup_and_test.sh`

## Самопроверка
- отсутствуют изменения в сгенерированных файлах
- покрыт сценарий пустого списка отделов
- ошибка API для других коллекций сохранена


------
https://chatgpt.com/codex/tasks/task_b_68d8ddc085d8832094769ab3de473d34