### PR TITLE
fix: validate department collection value

### DIFF
--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -87,9 +87,6 @@ router.post(
         if (typeof raw !== 'string') return false;
         const type = typeof req.body?.type === 'string' ? req.body.type.trim() : '';
         const normalized = normalizeValueByType(type, raw);
-        if (type === 'departments') {
-          return true;
-        }
         return normalized.length > 0;
       })
       .withMessage('Значение элемента обязательно'),
@@ -100,7 +97,7 @@ router.post(
       const type = body.type.trim();
       const name = body.name.trim();
       const value = normalizeValueByType(type, body.value);
-      if (type !== 'departments' && !value) {
+      if (!value) {
         sendProblem(req, res, {
           type: 'about:blank',
           title: 'Ошибка валидации',


### PR DESCRIPTION
## Summary
- enforce non-empty normalized values for every collection type during creation
- ensure department items without divisions trigger the validation problem response

## Testing
- pnpm test:api

------
https://chatgpt.com/codex/tasks/task_b_68d8e2c659348320b69abe1ffde3448b