### PR TITLE
fix: allow empty department collection value

### DIFF
--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -87,6 +87,9 @@ router.post(
         if (typeof raw !== 'string') return false;
         const type = typeof req.body?.type === 'string' ? req.body.type.trim() : '';
         const normalized = normalizeValueByType(type, raw);
+        if (type === 'departments') {
+          return true;
+        }
         return normalized.length > 0;
       })
       .withMessage('Значение элемента обязательно'),
@@ -96,8 +99,9 @@ router.post(
       const body = req.body as CollectionItemAttrs;
       const type = body.type.trim();
       const name = body.name.trim();
-      const value = normalizeValueByType(type, body.value);
-      if (!value) {
+      const rawValue = typeof body.value === 'string' ? body.value : '';
+      const value = normalizeValueByType(type, rawValue);
+      if (type !== 'departments' && !value) {
         sendProblem(req, res, {
           type: 'about:blank',
           title: 'Ошибка валидации',

--- a/tests/api/collections.post.spec.ts
+++ b/tests/api/collections.post.spec.ts
@@ -80,7 +80,7 @@ describe('POST /api/v1/collections', function () {
     }
   });
 
-  it('возвращает 400 для департамента без отделов', async () => {
+  it('создаёт департамент без отделов', async () => {
     const response = await request(app)
       .post('/api/v1/collections')
       .set('Authorization', authHeader)
@@ -90,13 +90,11 @@ describe('POST /api/v1/collections', function () {
         value: '',
       });
 
-    assert.equal(response.status, 400, JSON.stringify(response.body));
-    assert.equal(response.body.status, 400);
-    assert.equal(response.body.title, 'Ошибка валидации');
-    assert.equal(
-      response.body.detail,
-      'Поля: value — Значение элемента обязательно',
-    );
+    assert.equal(response.status, 201, JSON.stringify(response.body));
+    assert.equal(response.body.type, 'departments');
+    assert.equal(response.body.name, 'Без отдела');
+    assert.equal(response.body.value, '');
+    assert.ok(response.body._id, 'Не получен идентификатор созданного департамента');
   });
 
   it('возвращает 400 для других типов с пустым value', async () => {


### PR DESCRIPTION
## Что изменилось и почему
- разрешил создавать элементы коллекции типа `departments` без заполненного `value`, чтобы соответствовать бизнес-логике и обновлённым тестам
- синхронизировал интеграционный тест `POST /api/v1/collections` с новым поведением API

## Чек-лист
- [x] Тесты проходят (`pnpm test:unit`, `pnpm test:api`)
- [x] Линтер без ошибок (`pnpm lint`)
- [x] Сборка успешна (`pnpm build`)
- [x] Обратная совместимость сохранена

## Логи
- `pnpm test:unit`
- `pnpm test:api`
- `pnpm lint`
- `pnpm build`

## Самопроверка
- проверил, что валидация пропускает пустое значение только для департаментов
- убедился, что unit и API тесты отражают новое требование
- прогнал lint и build для контроля регрессий

------
https://chatgpt.com/codex/tasks/task_b_68d8ea049bac83209b538cd6c4fc4ce1