### PR TITLE
fix: surface all legacy departments in collections

### DIFF
--- a/apps/api/src/services/collectionsAggregator.ts
+++ b/apps/api/src/services/collectionsAggregator.ts
@@ -1,6 +1,6 @@
 // Назначение файла: объединение данных CollectionItem с устаревшими коллекциями.
 // Основные модули: mongoose, модели CollectionItem, Department, Employee.
-import { Types, type FilterQuery } from 'mongoose';
+import { type FilterQuery } from 'mongoose';
 import { CollectionItem } from '../db/models/CollectionItem';
 import { Department } from '../db/models/department';
 import { Employee } from '../db/models/employee';
@@ -42,26 +42,6 @@ const toStringId = (value: unknown): string => String(value);
 
 const normalizeMeta = (meta?: Record<string, unknown>): Record<string, unknown> | undefined =>
   meta ? { ...meta } : undefined;
-
-const toObjectId = (value: unknown): Types.ObjectId | undefined => {
-  if (!value) return undefined;
-  if (value instanceof Types.ObjectId) return value;
-  if (typeof value === 'string' && Types.ObjectId.isValid(value)) {
-    return new Types.ObjectId(value);
-  }
-  return undefined;
-};
-
-const getObjectIdHex = (value: unknown): string | undefined => {
-  const objectId = toObjectId(value);
-  return objectId?.toHexString();
-};
-
-const isLegacyDocument = (id: unknown, cutoff?: string): boolean => {
-  if (!cutoff) return true;
-  const objectIdHex = getObjectIdHex(id);
-  return objectIdHex === undefined || objectIdHex <= cutoff;
-};
 
 const mapCollectionItem = (doc: LeanCollectionItem): AggregatedCollectionItem => ({
   _id: toStringId(doc._id),
@@ -129,27 +109,6 @@ const paginate = <T>(items: T[], page: number, limit: number): T[] => {
   return items.slice(start, end);
 };
 
-const resolveLegacyCutoffs = async (
-  typeFilter?: string,
-): Promise<Map<string, string>> => {
-  const typesToCheck = typeFilter && SUPPORTED_LEGACY_TYPES.has(typeFilter)
-    ? [typeFilter]
-    : Array.from(SUPPORTED_LEGACY_TYPES);
-
-  const entries = await Promise.all(
-    typesToCheck.map(async (type) => {
-      const doc = await CollectionItem.findOne({ type })
-        .sort({ _id: 1 })
-        .select({ _id: 1 })
-        .lean();
-      const cutoff = doc ? getObjectIdHex(doc._id) : undefined;
-      return cutoff !== undefined ? ([type, cutoff] as const) : undefined;
-    }),
-  );
-
-  return new Map(entries.filter(Boolean) as [string, string][]);
-};
-
 export async function listCollectionsWithLegacy(
   filters: CollectionFilters = {},
   page = 1,
@@ -164,9 +123,6 @@ export async function listCollectionsWithLegacy(
   const items = baseItemsRaw.map(mapCollectionItem);
 
   const typeFilter = filters.type;
-  const legacyCutoffs = shouldIncludeLegacyType(typeFilter)
-    ? await resolveLegacyCutoffs(typeFilter)
-    : new Map<string, string>();
   const byTypeName = new Map<string, Set<string>>();
   const byTypeId = new Map<string, Set<string>>();
   items.forEach((item) => {
@@ -185,12 +141,10 @@ export async function listCollectionsWithLegacy(
       const departmentsRaw = (await Department.find().lean()) as LeanDepartment[];
       const existingNames = byTypeName.get('departments') ?? new Set<string>();
       const existingIds = byTypeId.get('departments') ?? new Set<string>();
-      const cutoff = legacyCutoffs.get('departments');
       departmentsRaw.forEach((dept) => {
         const name = dept.name;
         const id = toStringId(dept._id);
         if (existingNames.has(name) || existingIds.has(id)) return;
-        if (!isLegacyDocument(dept._id, cutoff)) return;
         items.push(mapDepartment(dept));
         existingNames.add(name);
         existingIds.add(id);
@@ -200,12 +154,10 @@ export async function listCollectionsWithLegacy(
       const employeesRaw = (await Employee.find().lean()) as LeanEmployee[];
       const existingNames = byTypeName.get('employees') ?? new Set<string>();
       const existingIds = byTypeId.get('employees') ?? new Set<string>();
-      const cutoff = legacyCutoffs.get('employees');
       employeesRaw.forEach((emp) => {
         const name = emp.name;
         const id = toStringId(emp._id);
         if (existingNames.has(name) || existingIds.has(id)) return;
-        if (!isLegacyDocument(emp._id, cutoff)) return;
         items.push(mapEmployee(emp));
         existingNames.add(name);
         existingIds.add(id);

--- a/apps/api/tests/collectionsAggregator.test.ts
+++ b/apps/api/tests/collectionsAggregator.test.ts
@@ -60,9 +60,11 @@ describe('Агрегация коллекций', () => {
   it('возвращает департаменты из CollectionItem и Department', async () => {
     const res = await request(app).get('/api/v1/collections').query({ type: 'departments' });
     expect(res.status).toBe(200);
-    expect(res.body.total).toBe(2);
+    expect(res.body.total).toBe(3);
     const names = res.body.items.map((item: { name: string }) => item.name);
-    expect(names).toEqual(expect.arrayContaining(['Каталог департаментов', 'Легаси департамент']));
+    expect(names).toEqual(
+      expect.arrayContaining(['Каталог департаментов', 'Легаси департамент', 'Цех']),
+    );
     const legacy = res.body.items.find(
       (item: { name: string }) => item.name === 'Легаси департамент',
     );


### PR DESCRIPTION
## Summary
- drop the legacy cutoff logic so departments and employees from the old collections always appear alongside catalog items
- update the aggregation test to assert all legacy departments are still visible after the change

## Testing
- node -r ./node_modules/ts-node/register ./node_modules/jest/bin/jest.js --runInBand --testPathPatterns=collectionsAggregator.test.ts --testTimeout=30000
- pnpm --dir apps/api lint


------
https://chatgpt.com/codex/tasks/task_b_68d8f6af68408320b2d0105e20d98840