### PR TITLE
fix: remove unused params in collections tests

### DIFF
--- a/apps/web/src/pages/Settings/CollectionsPage.test.tsx
+++ b/apps/web/src/pages/Settings/CollectionsPage.test.tsx
@@ -384,17 +384,15 @@ describe("CollectionsPage", () => {
       if (type === "positions") return [];
       return [];
     });
-    mockedFetch.mockImplementation(
-      async (type: string, search = "", page = 1, limit = 10) => {
-        if (type === "departments") {
-          return { items: [department], total: 1 };
-        }
-        if (type === "divisions") {
-          return { items: [newDivision], total: 2 };
-        }
-        return { items: [], total: 0 };
-      },
-    );
+    mockedFetch.mockImplementation(async (type: string) => {
+      if (type === "departments") {
+        return { items: [department], total: 1 };
+      }
+      if (type === "divisions") {
+        return { items: [newDivision], total: 2 };
+      }
+      return { items: [], total: 0 };
+    });
 
     render(<CollectionsPage />);
 


### PR DESCRIPTION
## Что изменено и почему
- убрал неиспользуемые параметры в моках `mockedFetch`, чтобы линтер не падал на `@typescript-eslint/no-unused-vars`
- сохранил актуальную проверку возврата данных для департаментов и отделов без изменения логики теста

## Чек-лист
- [x] Линтер `pnpm --filter web lint`
- [ ] Тесты `pnpm test`
- [ ] Сборка `pnpm build`
- [ ] Dev-сервер `pnpm run dev`

## Логи ключевых команд
- `pnpm --filter web lint`

## Самопроверка
- изменения касаются только тестов и не влияют на рантайм
- линтер проходит без ошибок (остались лишь предупреждения fast refresh)
- форматирование соответствует текущему стилю файла
- проверил, что логика теста сохраняется


------
https://chatgpt.com/codex/tasks/task_b_68d9196c8c04832087488fc5a06fd833