### PR TITLE
fix: simplify normalizeId bracket regex

### DIFF
--- a/apps/web/src/pages/Settings/CollectionsPage.tsx
+++ b/apps/web/src/pages/Settings/CollectionsPage.tsx
@@ -157,7 +157,7 @@ const normalizeId = (value: string) => {
   const trimmed = value.trim();
   if (!trimmed) return "";
   const withoutQuotes = trimmed.replace(/^['"]+|['"]+$/g, "");
-  const withoutBrackets = withoutQuotes.replace(/^[\[]+|[\]]+$/g, "");
+  const withoutBrackets = withoutQuotes.replace(/^\[+|\]+$/g, "");
   const withoutBraces = withoutBrackets.replace(/^[{}]+|[{}]+$/g, "");
   const withoutTrailingComma = withoutBraces.replace(/,+$/g, "");
   return withoutTrailingComma.trim();


### PR DESCRIPTION
## Что сделано
- упростил регулярное выражение очистки идентификаторов от квадратных скобок в `CollectionsPage`

## Зачем
- чтобы убрать предупреждение `no-useless-escape` и восстановить успешное прохождение линтера

## Чек-лист
- [x] Локально проходят тесты `pnpm test`
- [x] Линтер `pnpm lint`
- [x] Сборка `pnpm build`
- [ ] Dev-сервер `pnpm run dev`
- [x] Обратная совместимость сохранена

## Логи
- `pnpm lint`
- `pnpm test`
- `pnpm build`

## Самопроверка
- регулярное выражение эквивалентно прежнему поведению
- коллекции с JSON-форматом продолжают нормализоваться


------
https://chatgpt.com/codex/tasks/task_b_68d941fa74888320ba911245c3ef2d97