### PR TITLE
fix: show readable data in settings tables

### DIFF
--- a/apps/web/src/columns/collectionColumns.tsx
+++ b/apps/web/src/columns/collectionColumns.tsx
@@ -12,12 +12,12 @@ export const collectionColumns: ColumnDef<CollectionTableRow>[] = [
   {
     accessorKey: "name",
     header: "Название",
-    meta: { minWidth: "8rem", maxWidth: "16rem" },
+    meta: { minWidth: "8rem", maxWidth: "16rem", renderAsBadges: false },
   },
   {
     accessorKey: "value",
     header: "Значение",
-    meta: { minWidth: "8rem", maxWidth: "20rem" },
+    meta: { minWidth: "8rem", maxWidth: "20rem", renderAsBadges: false },
   },
   {
     accessorKey: "displayValue",
@@ -27,17 +27,17 @@ export const collectionColumns: ColumnDef<CollectionTableRow>[] = [
   {
     accessorKey: "type",
     header: "Тип",
-    meta: { minWidth: "6rem", maxWidth: "12rem" },
+    meta: { minWidth: "6rem", maxWidth: "12rem", renderAsBadges: false },
   },
   {
     accessorKey: "_id",
     header: "Идентификатор",
-    meta: { minWidth: "10rem", maxWidth: "16rem" },
+    meta: { minWidth: "10rem", maxWidth: "16rem", renderAsBadges: false },
   },
   {
     accessorKey: "metaSummary",
     header: "Доп. сведения",
-    meta: { minWidth: "10rem", maxWidth: "24rem" },
+    meta: { minWidth: "10rem", maxWidth: "24rem", renderAsBadges: false },
   },
 ];
 

--- a/apps/web/src/columns/fleetVehicleColumns.tsx
+++ b/apps/web/src/columns/fleetVehicleColumns.tsx
@@ -26,50 +26,110 @@ export type FleetVehicleRow = FleetVehicleDto & {
 };
 
 export const fleetVehicleColumns: ColumnDef<FleetVehicleRow>[] = [
-  { accessorKey: "name", header: "Название", meta: { minWidth: "8rem", maxWidth: "16rem" } },
-  { accessorKey: "registrationNumber", header: "Рег. номер", meta: { minWidth: "8rem", maxWidth: "16rem" } },
-  { accessorKey: "odometerInitial", header: "Одометр начальный", meta: { minWidth: "8rem", maxWidth: "14rem" } },
-  { accessorKey: "odometerCurrent", header: "Одометр текущий", meta: { minWidth: "8rem", maxWidth: "14rem" } },
-  { accessorKey: "mileageTotal", header: "Пробег", meta: { minWidth: "6rem", maxWidth: "12rem" } },
-  { accessorKey: "transportType", header: "Тип транспорта", meta: { minWidth: "8rem", maxWidth: "14rem" } },
-  { accessorKey: "fuelType", header: "Тип топлива", meta: { minWidth: "6rem", maxWidth: "12rem" } },
-  { accessorKey: "fuelRefilled", header: "Заправлено", meta: { minWidth: "6rem", maxWidth: "10rem" } },
-  { accessorKey: "fuelAverageConsumption", header: "Расход", meta: { minWidth: "6rem", maxWidth: "10rem" } },
-  { accessorKey: "fuelSpentTotal", header: "Израсходовано", meta: { minWidth: "6rem", maxWidth: "10rem" } },
+  {
+    accessorKey: "name",
+    header: "Название",
+    meta: { minWidth: "8rem", maxWidth: "16rem", renderAsBadges: false },
+  },
+  {
+    accessorKey: "registrationNumber",
+    header: "Рег. номер",
+    meta: { minWidth: "8rem", maxWidth: "16rem", renderAsBadges: false },
+  },
+  {
+    accessorKey: "odometerInitial",
+    header: "Одометр начальный",
+    meta: { minWidth: "8rem", maxWidth: "14rem", renderAsBadges: false },
+  },
+  {
+    accessorKey: "odometerCurrent",
+    header: "Одометр текущий",
+    meta: { minWidth: "8rem", maxWidth: "14rem", renderAsBadges: false },
+  },
+  {
+    accessorKey: "mileageTotal",
+    header: "Пробег",
+    meta: { minWidth: "6rem", maxWidth: "12rem", renderAsBadges: false },
+  },
+  {
+    accessorKey: "transportType",
+    header: "Тип транспорта",
+    meta: { minWidth: "8rem", maxWidth: "14rem", renderAsBadges: false },
+  },
+  {
+    accessorKey: "fuelType",
+    header: "Тип топлива",
+    meta: { minWidth: "6rem", maxWidth: "12rem", renderAsBadges: false },
+  },
+  {
+    accessorKey: "fuelRefilled",
+    header: "Заправлено",
+    meta: { minWidth: "6rem", maxWidth: "10rem", renderAsBadges: false },
+  },
+  {
+    accessorKey: "fuelAverageConsumption",
+    header: "Расход",
+    meta: { minWidth: "6rem", maxWidth: "10rem", renderAsBadges: false },
+  },
+  {
+    accessorKey: "fuelSpentTotal",
+    header: "Израсходовано",
+    meta: { minWidth: "6rem", maxWidth: "10rem", renderAsBadges: false },
+  },
   {
     accessorKey: "currentTasks",
     header: "Текущие задачи",
     cell: ({ getValue }) => stringify(getValue<string[] | undefined>()),
     meta: { minWidth: "10rem", maxWidth: "24rem" },
   },
-  { accessorKey: "createdAt", header: "Создан", meta: { minWidth: "10rem", maxWidth: "16rem" } },
-  { accessorKey: "updatedAt", header: "Обновлён", meta: { minWidth: "10rem", maxWidth: "16rem" } },
-  { accessorKey: "unitId", header: "Устройство", meta: { minWidth: "8rem", maxWidth: "12rem" } },
-  { accessorKey: "remoteName", header: "Удалённое имя", meta: { minWidth: "8rem", maxWidth: "16rem" } },
-  { accessorKey: "notes", header: "Примечания", meta: { minWidth: "10rem", maxWidth: "20rem" } },
+  {
+    accessorKey: "createdAt",
+    header: "Создан",
+    meta: { minWidth: "10rem", maxWidth: "16rem", renderAsBadges: false },
+  },
+  {
+    accessorKey: "updatedAt",
+    header: "Обновлён",
+    meta: { minWidth: "10rem", maxWidth: "16rem", renderAsBadges: false },
+  },
+  {
+    accessorKey: "unitId",
+    header: "Устройство",
+    meta: { minWidth: "8rem", maxWidth: "12rem", renderAsBadges: false },
+  },
+  {
+    accessorKey: "remoteName",
+    header: "Удалённое имя",
+    meta: { minWidth: "8rem", maxWidth: "16rem", renderAsBadges: false },
+  },
+  {
+    accessorKey: "notes",
+    header: "Примечания",
+    meta: { minWidth: "10rem", maxWidth: "20rem", renderAsBadges: false },
+  },
   {
     accessorKey: "positionInfo",
     header: "Позиция",
     cell: ({ getValue }) => stringify(getValue<string | undefined>()),
-    meta: { minWidth: "12rem", maxWidth: "24rem" },
+    meta: { minWidth: "12rem", maxWidth: "24rem", renderAsBadges: false },
   },
   {
     accessorKey: "sensorsInfo",
     header: "Датчики",
     cell: ({ getValue }) => stringify(getValue<string | undefined>()),
-    meta: { minWidth: "12rem", maxWidth: "24rem" },
+    meta: { minWidth: "12rem", maxWidth: "24rem", renderAsBadges: false },
   },
   {
     accessorKey: "customSensorsInfo",
     header: "Польз. датчики",
     cell: ({ getValue }) => stringify(getValue<string | undefined>()),
-    meta: { minWidth: "12rem", maxWidth: "24rem" },
+    meta: { minWidth: "12rem", maxWidth: "24rem", renderAsBadges: false },
   },
   {
     accessorKey: "trackInfo",
     header: "Трек",
     cell: ({ getValue }) => stringify(getValue<string | undefined>()),
-    meta: { minWidth: "12rem", maxWidth: "24rem" },
+    meta: { minWidth: "12rem", maxWidth: "24rem", renderAsBadges: false },
   },
 ];
 

--- a/apps/web/src/columns/settingsEmployeeColumns.tsx
+++ b/apps/web/src/columns/settingsEmployeeColumns.tsx
@@ -15,63 +15,71 @@ const renderAccess = (value: number | undefined) =>
   value === undefined || value === null ? "" : String(value);
 
 export const settingsEmployeeColumns: ColumnDef<EmployeeRow>[] = [
-  { accessorKey: "telegram_id", header: "Telegram ID", meta: { minWidth: "8rem" } },
+  {
+    accessorKey: "telegram_id",
+    header: "Telegram ID",
+    meta: { minWidth: "8rem", renderAsBadges: false },
+  },
   {
     accessorKey: "username",
     header: "Логин",
     cell: ({ row }) => row.original.telegram_username ?? row.original.username ?? "",
-    meta: { minWidth: "8rem", maxWidth: "16rem" },
+    meta: { minWidth: "8rem", maxWidth: "16rem", renderAsBadges: false },
   },
-  { accessorKey: "name", header: "Имя", meta: { minWidth: "8rem", maxWidth: "16rem" } },
+  {
+    accessorKey: "name",
+    header: "Имя",
+    meta: { minWidth: "8rem", maxWidth: "16rem", renderAsBadges: false },
+  },
   {
     accessorKey: "phone",
     header: "Телефон",
-    meta: { minWidth: "8rem", maxWidth: "16rem" },
+    meta: { minWidth: "8rem", maxWidth: "16rem", renderAsBadges: false },
   },
   {
     accessorKey: "mobNumber",
     header: "Моб. номер",
-    meta: { minWidth: "8rem", maxWidth: "16rem" },
+    meta: { minWidth: "8rem", maxWidth: "16rem", renderAsBadges: false },
   },
   {
     accessorKey: "email",
     header: "E-mail",
-    meta: { minWidth: "10rem", maxWidth: "20rem" },
+    meta: { minWidth: "10rem", maxWidth: "20rem", renderAsBadges: false },
   },
   {
     accessorKey: "role",
     header: "Роль",
     cell: ({ getValue }) => formatRoleName(getValue<string | undefined>()),
-    meta: { minWidth: "6rem", maxWidth: "12rem" },
+    meta: { minWidth: "6rem", maxWidth: "12rem", renderAsBadges: false },
   },
   {
     accessorKey: "access",
     header: "Доступ",
     cell: ({ getValue }) => renderAccess(getValue<number | undefined>()),
-    meta: { minWidth: "6rem", maxWidth: "10rem" },
+    meta: { minWidth: "6rem", maxWidth: "10rem", renderAsBadges: false },
   },
   {
     accessorKey: "roleId",
     header: "Роль ID",
     cell: ({ row }) => formatRoleName(row.original.roleName),
-    meta: { minWidth: "8rem", maxWidth: "16rem" },
+    meta: { minWidth: "8rem", maxWidth: "16rem", renderAsBadges: false },
   },
   {
     accessorKey: "departmentId",
     header: "Департамент",
     cell: ({ row }) => row.original.departmentName || "—",
-    meta: { minWidth: "8rem", maxWidth: "16rem" },
+    meta: { minWidth: "8rem", maxWidth: "16rem", renderAsBadges: false },
   },
   {
     accessorKey: "divisionId",
     header: "Отдел",
     cell: ({ row }) => row.original.divisionName || "—",
-    meta: { minWidth: "8rem", maxWidth: "16rem" },
+    meta: { minWidth: "8rem", maxWidth: "16rem", renderAsBadges: false },
   },
   {
     accessorKey: "positionId",
     header: "Должность",
     cell: ({ row }) => row.original.positionName || "—",
-    meta: { minWidth: "8rem", maxWidth: "16rem" },
+    meta: { minWidth: "8rem", maxWidth: "16rem", renderAsBadges: false },
   },
 ];

--- a/apps/web/src/columns/settingsUserColumns.tsx
+++ b/apps/web/src/columns/settingsUserColumns.tsx
@@ -5,32 +5,68 @@ import type { User } from "../types/user";
 import { formatRoleName } from "../utils/roleDisplay";
 
 export const settingsUserColumns: ColumnDef<User>[] = [
-  { accessorKey: "telegram_id", header: "Telegram ID", meta: { minWidth: "8rem" } },
+  {
+    accessorKey: "telegram_id",
+    header: "Telegram ID",
+    meta: { minWidth: "8rem", renderAsBadges: false },
+  },
   {
     accessorKey: "username",
     header: "Логин",
     cell: ({ row }) => row.original.telegram_username ?? row.original.username ?? "",
-    meta: { minWidth: "8rem", maxWidth: "16rem" },
+    meta: { minWidth: "8rem", maxWidth: "16rem", renderAsBadges: false },
   },
-  { accessorKey: "name", header: "Имя", meta: { minWidth: "8rem", maxWidth: "16rem" } },
-  { accessorKey: "phone", header: "Телефон", meta: { minWidth: "8rem", maxWidth: "16rem" } },
-  { accessorKey: "mobNumber", header: "Моб. номер", meta: { minWidth: "8rem", maxWidth: "16rem" } },
-  { accessorKey: "email", header: "E-mail", meta: { minWidth: "10rem", maxWidth: "20rem" } },
+  {
+    accessorKey: "name",
+    header: "Имя",
+    meta: { minWidth: "8rem", maxWidth: "16rem", renderAsBadges: false },
+  },
+  {
+    accessorKey: "phone",
+    header: "Телефон",
+    meta: { minWidth: "8rem", maxWidth: "16rem", renderAsBadges: false },
+  },
+  {
+    accessorKey: "mobNumber",
+    header: "Моб. номер",
+    meta: { minWidth: "8rem", maxWidth: "16rem", renderAsBadges: false },
+  },
+  {
+    accessorKey: "email",
+    header: "E-mail",
+    meta: { minWidth: "10rem", maxWidth: "20rem", renderAsBadges: false },
+  },
   {
     accessorKey: "role",
     header: "Роль",
     cell: ({ getValue }) => formatRoleName(getValue<string | undefined>()),
-    meta: { minWidth: "6rem", maxWidth: "12rem" },
+    meta: { minWidth: "6rem", maxWidth: "12rem", renderAsBadges: false },
   },
   {
     accessorKey: "access",
     header: "Доступ",
     cell: ({ getValue }) => String(getValue<number | undefined>() ?? ""),
-    meta: { minWidth: "6rem", maxWidth: "10rem" },
+    meta: { minWidth: "6rem", maxWidth: "10rem", renderAsBadges: false },
   },
-  { accessorKey: "roleId", header: "Роль ID", meta: { minWidth: "8rem", maxWidth: "16rem" } },
-  { accessorKey: "departmentId", header: "Департамент", meta: { minWidth: "8rem", maxWidth: "16rem" } },
-  { accessorKey: "divisionId", header: "Отдел", meta: { minWidth: "8rem", maxWidth: "16rem" } },
-  { accessorKey: "positionId", header: "Должность", meta: { minWidth: "8rem", maxWidth: "16rem" } },
+  {
+    accessorKey: "roleId",
+    header: "Роль ID",
+    meta: { minWidth: "8rem", maxWidth: "16rem", renderAsBadges: false },
+  },
+  {
+    accessorKey: "departmentId",
+    header: "Департамент",
+    meta: { minWidth: "8rem", maxWidth: "16rem", renderAsBadges: false },
+  },
+  {
+    accessorKey: "divisionId",
+    header: "Отдел",
+    meta: { minWidth: "8rem", maxWidth: "16rem", renderAsBadges: false },
+  },
+  {
+    accessorKey: "positionId",
+    header: "Должность",
+    meta: { minWidth: "8rem", maxWidth: "16rem", renderAsBadges: false },
+  },
 ];
 

--- a/apps/web/src/components/DataTable.tsx
+++ b/apps/web/src/components/DataTable.tsx
@@ -42,6 +42,7 @@ interface ColumnMeta {
   width?: string;
   cellClassName?: string;
   headerClassName?: string;
+  renderAsBadges?: boolean;
 }
 
 export const defaultBadgeClassName = [
@@ -234,6 +235,8 @@ export default function DataTable<T>({
                   cell.column.columnDef.cell,
                   cell.getContext(),
                 );
+                const shouldWrapWithBadges =
+                  wrapCellsAsBadges && meta.renderAsBadges !== false;
                 return (
                   <TableCell
                     key={cell.id}
@@ -245,7 +248,7 @@ export default function DataTable<T>({
                     className={cellClassName}
                     // фиксируем ширину ячейки данных
                   >
-                    {wrapCellsAsBadges
+                    {shouldWrapWithBadges
                       ? renderBadgeContent(
                           cellContent,
                           badgeClassName,

--- a/apps/web/src/pages/Settings/CollectionsPage.tsx
+++ b/apps/web/src/pages/Settings/CollectionsPage.tsx
@@ -766,17 +766,17 @@ export default function CollectionsPage() {
   );
 
   const departmentColumns = useMemo(
-    () => buildCollectionColumns(["value", "_id", "type", "metaSummary"]),
+    () => buildCollectionColumns(["value", "type", "metaSummary"]),
     [buildCollectionColumns],
   );
 
   const divisionColumns = useMemo(
-    () => buildCollectionColumns(["value", "_id", "type", "metaSummary"]),
+    () => buildCollectionColumns(["type", "metaSummary"]),
     [buildCollectionColumns],
   );
 
   const positionColumns = useMemo(
-    () => buildCollectionColumns(["value", "_id"]),
+    () => buildCollectionColumns(["type", "metaSummary"]),
     [buildCollectionColumns],
   );
 


### PR DESCRIPTION
## Summary
- add a column meta switch that keeps important cells in settings tables as plain text instead of badges
- expose identifiers and values for departments, divisions, positions, users, employees and fleets so their data shows up in the grids

## Testing
- pnpm --filter web lint

------
https://chatgpt.com/codex/tasks/task_b_68d94b8bd6b0832080e6839bf1905068