### PR TITLE
fix: изолировать кэш mongodb-memory-server

### DIFF
--- a/tests/setupMongoMemoryServer.ts
+++ b/tests/setupMongoMemoryServer.ts
@@ -14,6 +14,8 @@ if (!process.env.MONGOMS_DOWNLOAD_DIR) {
 
   mkdirSync(downloadDir, { recursive: true });
   process.env.MONGOMS_DOWNLOAD_DIR = downloadDir;
+  process.env.MONGOMS_CACHE_DIR ||= downloadDir;
 }
 
 process.env.MONGOMS_DISABLE_MD5_CHECK ||= '1';
+process.env.MONGOMS_PREFER_GLOBAL_PATH ||= '0';


### PR DESCRIPTION
## Что сделано
- добавил явную установку `MONGOMS_CACHE_DIR` в каталог временных бинарей
- выключил использование глобального пути через `MONGOMS_PREFER_GLOBAL_PATH`

## Почему
- без явного каталога библиотека искала кеш в `/home/runner`, которого нет в CI, из-за чего падали тесты `mongodb-memory-server`

## Чек-лист
- [x] тесты (`pnpm test:unit -- repairCollections`)
- [ ] линтер (`pnpm lint`)
- [ ] сборка (`pnpm build`)
- [ ] dev-сервер (`pnpm run dev`)

## Логи
```
$ pnpm test:unit -- repairCollections
PASS tests/repairCollections.spec.ts (4.066 s)
```

## Самопроверка
- проверил, что временные каталоги создаются рекурсивно
- удостоверился, что настройки применяются только при отсутствии переменных окружения
- запуск unit-теста с `MongoMemoryServer` проходит успешно


------
https://chatgpt.com/codex/tasks/task_b_68d97ac6e52883209943a3d9cfc91bb0