### PR TITLE
fix: avoid jest timer leaks from metrics and disk monitor

### DIFF
--- a/apps/api/src/api/server.ts
+++ b/apps/api/src/api/server.ts
@@ -100,7 +100,9 @@ export async function buildApp(): Promise<express.Express> {
 
   await registerRoutes(app, cookieFlags, pub);
 
-  startDiskMonitor();
+  if (process.env.NODE_ENV !== 'test') {
+    startDiskMonitor();
+  }
 
   return app;
 }

--- a/apps/api/src/metrics/index.ts
+++ b/apps/api/src/metrics/index.ts
@@ -9,7 +9,18 @@ export const register: client.Registry =
   globalSymbols[globalKey] ||
   (globalSymbols[globalKey] = new client.Registry());
 
-client.collectDefaultMetrics({ register });
+const isJest =
+  typeof process !== 'undefined' &&
+  (process.env.NODE_ENV === 'test' ||
+    process.env.JEST_WORKER_ID !== undefined);
+
+let defaultMetricsInterval: NodeJS.Timeout | undefined;
+if (!isJest) {
+  defaultMetricsInterval = client.collectDefaultMetrics({ register }) as
+    | NodeJS.Timeout
+    | undefined;
+  defaultMetricsInterval?.unref?.();
+}
 
 export const httpRequestsTotal = new client.Counter({
   name: 'http_requests_total',

--- a/apps/api/src/services/diskSpace.ts
+++ b/apps/api/src/services/diskSpace.ts
@@ -44,6 +44,16 @@ export async function checkDiskSpace(): Promise<void> {
 }
 
 export function startDiskMonitor(): void {
+  if (
+    typeof process !== 'undefined' &&
+    (process.env.NODE_ENV === 'test' ||
+      process.env.JEST_WORKER_ID !== undefined)
+  ) {
+    return;
+  }
   checkDiskSpace();
-  setInterval(checkDiskSpace, 60 * 60 * 1000);
+  const interval = setInterval(checkDiskSpace, 60 * 60 * 1000);
+  if (typeof interval.unref === 'function') {
+    interval.unref();
+  }
 }

--- a/tests/toast.unmount.spec.tsx
+++ b/tests/toast.unmount.spec.tsx
@@ -1,7 +1,13 @@
 /** @jest-environment jsdom */
 // Назначение файла: тест размонтирования ToastProvider.
 // Основные модули: React, @testing-library/react.
-process.env.NODE_ENV = 'development';
+const originalNodeEnv = process.env.NODE_ENV;
+beforeAll(() => {
+  process.env.NODE_ENV = 'development';
+});
+afterAll(() => {
+  process.env.NODE_ENV = originalNodeEnv;
+});
 import React, { useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import { ToastProvider } from '../apps/web/src/context/ToastContext';


### PR DESCRIPTION
## Summary
- restore NODE_ENV cleanup in the skipped toast unmount test so Jest always stays in "test"
- skip Prometheus default metrics and disk space monitor when running under Jest and unref their timers
- guard API bootstrap so the disk monitor never runs in unit tests

## Testing
- pnpm test:unit --runTestsByPath tests/messageQueue.test.ts
- pnpm test:unit --runTestsByPath tests/tasks.crud.spec.ts


------
https://chatgpt.com/codex/tasks/task_b_68da57efc9508320a9c3aa5656e00a12