### PR TITLE
fix: stabilize TaskDialog tests

### DIFF
--- a/apps/web/src/components/TaskDialog.test.tsx
+++ b/apps/web/src/components/TaskDialog.test.tsx
@@ -6,8 +6,10 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import TaskDialog from "./TaskDialog";
 
+const mockUser = { telegram_id: 99, role: "admin" } as const;
+
 jest.mock("../context/useAuth", () => ({
-  useAuth: () => ({ user: { telegram_id: 99, role: "admin" } }),
+  useAuth: () => ({ user: mockUser }),
 }));
 
 jest.mock("react-i18next", () => ({
@@ -133,7 +135,7 @@ describe("TaskDialog", () => {
     const dueInput = screen.getByLabelText("dueDate");
     fireEvent.change(dueInput, { target: { value: "2024-02-02T12:30" } });
 
-    fireEvent.click(screen.getByText("save"));
+    fireEvent.click(screen.getByText("create"));
 
     await waitFor(() => expect(createTaskMock).toHaveBeenCalled());
     expect(createTaskMock.mock.calls[0][0]).toMatchObject({

--- a/apps/web/src/components/TaskDialog.tsx
+++ b/apps/web/src/components/TaskDialog.tsx
@@ -1042,10 +1042,11 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
         <>
           <div className="grid gap-3 md:[grid-template-columns:repeat(auto-fit,minmax(220px,1fr))]">
             <div>
-              <label className="block text-sm font-medium">
+              <label className="block text-sm font-medium" htmlFor="task-dialog-start-date">
                 {t("startDate")}
               </label>
               <input
+                id="task-dialog-start-date"
                 type="datetime-local"
                 {...register("startDate")}
                 className="w-full rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1.5 text-sm focus:outline-none focus:ring focus:ring-brand-200 focus:border-accentPrimary"
@@ -1053,10 +1054,11 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium">
+              <label className="block text-sm font-medium" htmlFor="task-dialog-due-date">
                 {t("dueDate")}
               </label>
               <input
+                id="task-dialog-due-date"
                 type="datetime-local"
                 {...register("dueDate", { onChange: handleDueDateChange })}
                 className="w-full rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1.5 text-sm focus:outline-none focus:ring focus:ring-brand-200 focus:border-accentPrimary"


### PR DESCRIPTION
## Summary
- ensure TaskDialog tests use a stable mocked auth user to avoid rerender loops
- connect date field labels with inputs so getByLabelText works reliably
- align TaskDialog tests with actual button labels when saving vs creating

## Testing
- pnpm test:unit --runInBand --testPathPattern TaskDialog

------
https://chatgpt.com/codex/tasks/task_b_68da69262ab88320b66cb0a81fcd7a3a