### PR TITLE
fix: normalize completed timestamp handling

### DIFF
--- a/apps/api/src/services/tasks.ts
+++ b/apps/api/src/services/tasks.ts
@@ -1,6 +1,7 @@
 // Сервисные функции задач используют общие запросы к MongoDB
 // Модули: db/queries, services/route, shared
 import * as q from '../db/queries';
+import type { TaskDocument } from '../db/model';
 import { getRouteDistance, Point } from './route';
 import { generateRouteLink, type Task } from 'shared';
 
@@ -13,6 +14,35 @@ export type TaskData = Partial<Omit<Task, 'completed_at'>> & {
   due_date?: Date;
   remind_at?: Date;
   [key: string]: unknown;
+};
+
+const normalizeCompletedAt = (
+  value: TaskData['completed_at'],
+): Date | null | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    return null;
+  }
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+const prepareTaskPayload = (
+  input: TaskData = {},
+): Partial<TaskDocument> => {
+  const { completed_at, ...rest } = input;
+  const payload: Partial<TaskDocument> = {
+    ...(rest as Partial<TaskDocument>),
+  };
+  if (Object.prototype.hasOwnProperty.call(input, 'completed_at')) {
+    payload.completed_at = normalizeCompletedAt(completed_at);
+  }
+  return payload;
 };
 
 async function applyRouteInfo(data: TaskData = {}): Promise<void> {
@@ -39,7 +69,8 @@ export const create = async (
 ): Promise<unknown> => {
   if (data.due_date && !data.remind_at) data.remind_at = data.due_date;
   await applyRouteInfo(data);
-  return q.createTask(data, userId);
+  const payload = prepareTaskPayload(data);
+  return q.createTask(payload, userId);
 };
 
 export const get = (
@@ -56,7 +87,8 @@ export const update = async (
   userId = 0,
 ): Promise<unknown> => {
   await applyRouteInfo(data);
-  return q.updateTask(id, data, userId);
+  const payload = prepareTaskPayload(data);
+  return q.updateTask(id, payload, userId);
 };
 
 export const addTime = (
@@ -69,20 +101,21 @@ export const bulk = (
   ids: string[],
   data: TaskData = {},
 ): Promise<unknown> => {
-  const payload = { ...(data ?? {}) };
-  if (Object.prototype.hasOwnProperty.call(payload, 'status')) {
-    const status = payload.status;
+  const draft: TaskData = { ...(data ?? {}) };
+  if (Object.prototype.hasOwnProperty.call(draft, 'status')) {
+    const status = draft.status;
     const isCompleted = status === 'Выполнена' || status === 'Отменена';
     if (isCompleted) {
-      if (!Object.prototype.hasOwnProperty.call(payload, 'completed_at')) {
-        payload.completed_at = new Date();
-      } else if (payload.completed_at === undefined) {
-        payload.completed_at = new Date();
+      if (!Object.prototype.hasOwnProperty.call(draft, 'completed_at')) {
+        draft.completed_at = new Date();
+      } else if (draft.completed_at === undefined) {
+        draft.completed_at = new Date();
       }
     } else {
-      payload.completed_at = null;
+      draft.completed_at = null;
     }
   }
+  const payload = prepareTaskPayload(draft);
   return q.bulkUpdate(ids, payload);
 };
 

--- a/apps/web/src/columns/taskColumns.tsx
+++ b/apps/web/src/columns/taskColumns.tsx
@@ -269,7 +269,7 @@ const timePartFmt = new Intl.DateTimeFormat("ru-RU", {
   hour12: false,
 });
 
-const parseDateInput = (value?: string) => {
+const parseDateInput = (value?: string | null) => {
   if (!value) {
     return null;
   }
@@ -486,7 +486,7 @@ const formatCompletionOffset = (diffMs: number) => {
 const buildCompletionNote = (
   status: Task["status"] | undefined,
   dueValue?: string,
-  completedValue?: string,
+  completedValue?: string | null,
 ) => {
   if (status !== "Выполнена") {
     return null;


### PR DESCRIPTION
## Summary
- allow task column date helpers to accept null completion timestamps without type errors
- normalize completed_at payloads in task service before delegating to queries so TypeScript accepts TaskDocument payloads

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_68da7a64754083209a091ac45c4a7627