### PR TITLE
fix: корректная обработка callback и карта пользователей

### DIFF
--- a/apps/api/src/bot/bot.ts
+++ b/apps/api/src/bot/bot.ts
@@ -15,7 +15,7 @@ if (process.env.NODE_ENV !== 'production') {
   console.log('BOT_TOKEN загружен');
 }
 
-export const bot = new Telegraf(botToken!);
+export const bot: Telegraf<Context> = new Telegraf(botToken!);
 
 process.on('unhandledRejection', (err) => {
   console.error('Unhandled rejection in bot:', err);
@@ -133,13 +133,21 @@ function buildTaskEventMessage(task: TaskDocument, action: string): string {
   return `Задача ${identifier} ${action} ${time}`;
 }
 
+const getCallbackData = (
+  callback: Context['callbackQuery'],
+): string | null => {
+  if (!callback) return null;
+  if ('data' in callback && typeof callback.data === 'string') return callback.data;
+  return null;
+};
+
 async function processStatusAction(
   ctx: Context,
   status: 'В работе' | 'Выполнена',
   actionText: string,
   responseMessage: string,
 ) {
-  const data = ctx.callbackQuery?.data;
+  const data = getCallbackData(ctx.callbackQuery);
   const taskId = data?.split(':')[1];
   if (!taskId) {
     await ctx.answerCbQuery('Некорректный идентификатор задачи', {

--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -53,10 +53,11 @@ export default class TasksController {
     const recipients = this.collectNotificationTargets(plain, creatorId);
     const usersRaw = await getUsersMap(Array.from(recipients));
     const users = Object.fromEntries(
-      Object.entries(usersRaw).map(([key, value]) => [
-        Number(key),
-        { name: value.name, username: value.username },
-      ]),
+      Object.entries(usersRaw).map(([key, value]) => {
+        const name = value.name ?? value.username ?? '';
+        const username = value.username ?? '';
+        return [Number(key), { name, username }];
+      }),
     );
     const keyboard = taskStatusKeyboard(id);
     const options: Parameters<typeof bot.telegram.sendMessage>[2] = {

--- a/apps/api/tests/startBotRetry.test.ts
+++ b/apps/api/tests/startBotRetry.test.ts
@@ -13,6 +13,7 @@ jest.mock('telegraf', () => {
     start = jest.fn();
     command = jest.fn();
     hears = jest.fn();
+    action = jest.fn();
     stop = jest.fn();
   }
   return {


### PR DESCRIPTION
## Описание
- добавил заглушку `action` в мок Telegraf для unit-теста повторного запуска бота
- нормализовал карту пользователей при уведомлениях о задаче, чтобы в ней всегда были строки `name` и `username`
- ввёл безопасный парсинг callback-запросов и явную типизацию экземпляра Telegraf

## Почему
- тест `startBot` падал из-за отсутствующего метода `action` в моке
- TypeScript-типизация ломала сборку и jest из-за необязательных полей и широкого типа `callbackQuery`

## Логи
- `pnpm test:unit` — см. вывод в логе `dce8d4`
- `pnpm lint` — см. `3ebeb7`
- `pnpm build` — см. `053ff1`

## Чек-лист
- [x] Тесты проходят
- [x] Линтер без ошибок
- [x] Сборка успешна
- [x] Обратная совместимость сохранена

## Самопроверка
- [x] Убедился, что типы Telegraf не падают на `tsc -b`
- [x] Проверил, что уведомления формируют валидную карту пользователей даже при пустом username
- [x] Убедился, что retry-тест действительно проверяет экспоненциальную задержку

------
https://chatgpt.com/codex/tasks/task_b_68da8934a6e4832082f571117d2203b4