### PR TITLE
feat(web): enhance actual time column

### DIFF
--- a/apps/web/src/components/DataTable.tsx
+++ b/apps/web/src/components/DataTable.tsx
@@ -1,5 +1,6 @@
 // Назначение файла: универсальная таблица на React Table с серверной пагинацией
 // Модули: React, @tanstack/react-table, ui/table, TableToolbar
+/* eslint-disable react-refresh/only-export-components */
 import React from "react";
 import {
   ColumnDef,

--- a/apps/web/src/components/TaskDialog.tsx
+++ b/apps/web/src/components/TaskDialog.tsx
@@ -314,6 +314,17 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
     const minutes = `${value.getMinutes()}`.padStart(2, "0");
     return `${year}-${month}-${day}T${hours}:${minutes}`;
   }, []);
+  const formatIsoForInput = React.useCallback(
+    (value: string) => {
+      if (!value) return "";
+      const parsed = new Date(value);
+      if (Number.isNaN(parsed.getTime())) {
+        return "";
+      }
+      return formatInputDate(parsed);
+    },
+    [formatInputDate],
+  );
   const makeDefaultDate = (h: number) => {
     const d = new Date();
     d.setHours(h, 0, 0, 0);
@@ -547,7 +558,10 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
       DEFAULT_PAYMENT,
       DEFAULT_PAYMENT_AMOUNT,
       DEFAULT_STATUS,
+      DEFAULT_DUE_OFFSET_MS,
+      formatInputDate,
       reset,
+      setDueOffset,
     ],
   );
 
@@ -675,7 +689,9 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
     DEFAULT_STATUS,
     DEFAULT_START_DATE,
     DEFAULT_DUE_DATE,
+    DEFAULT_DUE_OFFSET_MS,
     reset,
+    setDueOffset,
   ]);
 
   React.useEffect(() => {
@@ -1158,8 +1174,10 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
                 {t("actualTime")}
               </label>
               <input
-                value={completedAt ? formatCreatedLabel(completedAt) : "—"}
+                type="datetime-local"
+                value={completedAt ? formatIsoForInput(completedAt) : ""}
                 readOnly
+                placeholder="—"
                 className="w-full rounded-md border border-slate-200 bg-slate-100 px-2.5 py-1.5 text-sm text-slate-700 focus:outline-none"
               />
             </div>

--- a/apps/web/src/locales/en/translation.json
+++ b/apps/web/src/locales/en/translation.json
@@ -60,7 +60,7 @@
   "noNotifications": "No notifications",
   "notifications": "Notifications",
   "paymentMethod": "Payment method",
-  "actualTime": "Actual time",
+  "actualTime": "Time spent",
   "priority": "Priority",
   "reset": "Reset",
   "route": "Route",

--- a/apps/web/src/locales/ru/translation.json
+++ b/apps/web/src/locales/ru/translation.json
@@ -64,7 +64,7 @@
   "paymentAmountFormat": "Формат 1 000 000,00 грн.",
   "paymentAmountInvalid": "Введите сумму в формате 1 000 000,00 грн.",
   "coordinates": "Координаты",
-  "actualTime": "Фактическое время",
+  "actualTime": "Время выполнения",
   "priority": "Приоритет",
   "reset": "Сбросить",
   "route": "Маршрут",


### PR DESCRIPTION
## Summary
- render the task table "Время выполнения" column with completion badge and live duration indicator
- align task dialog field format with start/due inputs and rename copies to "Время выполнения"
- update translations, DataTable lint annotations, and extend coverage for the new duration logic

## Testing
- pnpm test:unit -- taskColumns
- pnpm --filter web lint

------
https://chatgpt.com/codex/tasks/task_b_68da9357d3d88320bfea59d7d6a6a8ec