### PR TITLE
fix: resolve web lint issues

### DIFF
--- a/apps/web/src/columns/__tests__/taskColumns.test.tsx
+++ b/apps/web/src/columns/__tests__/taskColumns.test.tsx
@@ -40,9 +40,7 @@ describe("taskColumns", () => {
     } as any);
 
     const tooltip = "Александр Александров, ivanov";
-    const { container } = render(
-      <MemoryRouter>{cell as React.ReactElement}</MemoryRouter>,
-    );
+    render(<MemoryRouter>{cell as React.ReactElement}</MemoryRouter>);
 
     const wrapper = screen.getByTitle(tooltip);
     expect(wrapper).toHaveClass("flex-wrap");
@@ -81,9 +79,7 @@ describe("taskColumns", () => {
       row: { original: row },
     } as any);
 
-    const { container } = render(
-      <MemoryRouter>{cell as React.ReactElement}</MemoryRouter>,
-    );
+    render(<MemoryRouter>{cell as React.ReactElement}</MemoryRouter>);
 
     const datePart = screen.getByText("05.03.2024");
     expect(datePart.closest("time")).toHaveAttribute("dateTime", row.due_date);
@@ -124,9 +120,7 @@ describe("taskColumns", () => {
       row: { original: row },
     } as any);
 
-    const { container } = render(
-      <MemoryRouter>{cell as React.ReactElement}</MemoryRouter>,
-    );
+    render(<MemoryRouter>{cell as React.ReactElement}</MemoryRouter>);
 
     const datePart = screen.getByText("05.03.2024");
     expect(datePart.closest("time")).toHaveAttribute("dateTime", row.due_date);

--- a/apps/web/src/components/TaskDialog.tsx
+++ b/apps/web/src/components/TaskDialog.tsx
@@ -347,7 +347,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
       );
       return { start, due };
     },
-    [formatInputDate],
+    [formatInputDate, DEFAULT_DUE_OFFSET_MS],
   );
 
   const startDateValue = watch("startDate");


### PR DESCRIPTION
## Что сделано
- Удалил неиспользуемые ссылки на `container` в тестах колонок задач, чтобы удовлетворить `@typescript-eslint/no-unused-vars`.
- Добавил `DEFAULT_DUE_OFFSET_MS` в зависимости `computeDefaultDates`, устранив предупреждение `react-hooks/exhaustive-deps`.

## Зачем
- Линтер падал в CI из-за указанных замечаний и блокировал слияние.

## Чек-лист
- [x] Линтер (`pnpm lint`)
- [ ] Тесты (`pnpm test`) — не запускал, затронуты только вспомогательные функции и тестовый код.
- [ ] Сборка (`pnpm build`) — скрипт зависает на `ensureDefaults`, требуется разбор отдельно.

## Логи
- `pnpm lint`

## Самопроверка
- [x] Убедился, что eslint-предупреждения об отсутствующих зависимостях закрыты.
- [x] Проверил, что тесты продолжают рендерить компоненты без использования `container`.
- [ ] Полный цикл сборки прерван из-за зависания, отметил риск в чек-листе.


------
https://chatgpt.com/codex/tasks/task_b_68dacd621d348320bb394445157d92fe