### PR TITLE
feat: align buttons with editor style

### DIFF
--- a/apps/web/src/components/CKEditorPopup.tsx
+++ b/apps/web/src/components/CKEditorPopup.tsx
@@ -7,6 +7,7 @@ import { ensureWebpackNonce } from "../utils/ensureWebpackNonce";
 import authFetch from "../utils/authFetch";
 import { showToast } from "../utils/toast";
 import { PhotoIcon, SparklesIcon } from "@heroicons/react/24/outline";
+import "@ckeditor/ckeditor5-build-classic/build/translations/ru";
 
 ensureWebpackNonce();
 
@@ -113,6 +114,10 @@ export default function CKEditorPopup({ value, onChange, readOnly }: Props) {
   );
   const editorConfig = useMemo(
     () => ({
+      language: {
+        ui: "ru",
+        content: "ru",
+      },
       toolbar: [
         "undo",
         "redo",

--- a/apps/web/src/components/ui/button-variants.ts
+++ b/apps/web/src/components/ui/button-variants.ts
@@ -4,27 +4,27 @@
 import { cva } from "class-variance-authority";
 
 export const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md border border-transparent text-sm font-semibold shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+          "bg-indigo-600 text-white hover:bg-indigo-700 focus-visible:ring-indigo-200",
         destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "bg-rose-600 text-white hover:bg-rose-700 focus-visible:ring-rose-200",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "border-slate-200 bg-white text-slate-600 hover:bg-slate-100 focus-visible:ring-slate-200",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+          "bg-slate-100 text-slate-700 hover:bg-slate-200 focus-visible:ring-slate-200",
         ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+          "bg-transparent text-slate-600 hover:bg-slate-100 focus-visible:ring-slate-200",
+        link: "text-indigo-600 underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
+        default: "px-4 py-2 has-[>svg]:px-3",
+        sm: "px-3 py-1.5 has-[>svg]:px-2.5 text-sm",
+        lg: "px-5 py-2.5 has-[>svg]:px-4 text-base",
+        icon: "p-2 rounded-full",
       },
     },
     defaultVariants: {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -290,19 +290,19 @@
   }
 
   .btn {
-    @apply rounded-lg px-4 py-2 text-sm font-medium transition-colors;
+    @apply inline-flex items-center justify-center gap-2 rounded-md border border-transparent px-4 py-2 text-sm font-semibold shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60;
   }
   .btn-blue {
-    @apply bg-brand-500 hover:bg-brand-600 text-white;
+    @apply bg-indigo-600 text-white hover:bg-indigo-700 focus-visible:ring-indigo-200;
   }
   .btn-gray {
-    @apply bg-gray-100 text-gray-700 hover:bg-gray-200;
+    @apply border-slate-200 bg-white text-slate-600 hover:bg-slate-100 focus-visible:ring-slate-200;
   }
   .btn-green {
-    @apply bg-success-500 hover:bg-success-600 text-white;
+    @apply bg-emerald-600 text-white hover:bg-emerald-700 focus-visible:ring-emerald-200;
   }
   .btn-red {
-    @apply bg-error-500 text-white hover:bg-red-600;
+    @apply bg-rose-600 text-white hover:bg-rose-700 focus-visible:ring-rose-200;
   }
 }
 
@@ -948,12 +948,12 @@ span.flatpickr-weekday,
     @apply bg-white;
   }
   .btn {
-    @apply inline-flex items-center justify-center rounded-lg border border-transparent px-4 py-2 font-medium shadow-sm;
+    @apply inline-flex items-center justify-center gap-2 rounded-md border border-transparent px-4 py-2 text-sm font-semibold shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60;
   }
   .btn-ghost {
-    @apply inline-flex items-center justify-center rounded-lg border border-transparent px-4 py-2 font-medium shadow-sm hover:bg-gray-100;
+    @apply inline-flex items-center justify-center gap-2 rounded-md border border-transparent px-4 py-2 text-sm font-semibold shadow-sm transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-slate-200;
   }
   .btn-primary {
-    @apply inline-flex items-center justify-center rounded-lg border border-transparent bg-blue-600 px-4 py-2 font-medium text-white shadow-sm hover:bg-blue-700 focus:ring-2 focus:ring-blue-300 focus:outline-none;
+    @apply inline-flex items-center justify-center gap-2 rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200 focus-visible:ring-offset-2;
   }
 }


### PR DESCRIPTION
## Что сделано
- Уединил базовые классы `.btn` и варианты компонента `Button` под оформление редактора: насыщенный индиго, мягкие тени и фокус-ринги.
- Перевёл UI CKEditor 5 на русский, подключив штатную локализацию.

## Почему
- Чтобы все кнопки выглядели как любимые кнопки в текстовом редакторе.
- Чтобы меню редактора было целиком на русском.

## Проверки
- [x] `pnpm lint`
- [x] `pnpm test`

## Логи
- `pnpm lint`
- `pnpm test`

## Самопроверка
- [x] Чужих артефактов сборки в git-истории нет.
- [x] Стиль кнопок повторяет шаблон из редактора.
- [x] Панель инструментов редактора переведена на русский.

------
https://chatgpt.com/codex/tasks/task_b_68db6a0e5dd883208398cb689d365997