### PR TITLE
fix: восстановить алиасы ui-компонентов в jest

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -14,6 +14,11 @@ const config: Config = {
     '<rootDir>/tests/playwright/',
     '<rootDir>/apps/web/src/types/',
   ],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/apps/web/src/$1',
+    '^shared$': '<rootDir>/packages/shared/src',
+    '^shared/(.*)$': '<rootDir>/packages/shared/src/$1',
+  },
   setupFiles: [
     '<rootDir>/tests/setupMongoMemoryServer.ts',
     '<rootDir>/tests/setupEnv.ts',

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -8,6 +8,12 @@
     "jsx": "react-jsx",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
+    "baseUrl": "..",
+    "paths": {
+      "@/*": ["apps/web/src/*"],
+      "shared": ["packages/shared/src"],
+      "shared/*": ["packages/shared/src/*"]
+    },
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
## Что сделано
- добавлены мапперы модулей в конфигурацию Jest для путей `@/*` и `shared`
- настроен `tests/tsconfig.json` для поддержки `baseUrl` и `paths`, совпадающих с веб-клиентом

## Почему
Jest не понимал алиасы веб-клиента, из-за чего падали модульные тесты в CI. Обновления синхронизируют конфигурацию тестов с Vite.

## Чек-лист
- [x] `pnpm test`
- [x] `pnpm lint`
- [ ] `pnpm build` (выполняется в `pnpm test` через `scripts/build_with_tmp.sh`)
- [x] Обратная совместимость сохранена

## Логи
- `pnpm test`
- `pnpm lint`

## Самопроверка
1. Алиасы `@/*` и `shared` доступны при выполнении Jest-тестов.
2. Конфигурации TypeScript и Jest синхронизированы с веб-клиентом.
3. Лишние сборочные артефакты не попадают в репозиторий.

## Риски и откат
- Риск: появление новых алиасов без обновления конфигурации тестов; страховка — добавить проверки в CI.
- Откат: `git revert` данного коммита.


------
https://chatgpt.com/codex/tasks/task_b_68db916e097c8320bad90a57436caa95