### PR TITLE
feat: sync telegram status history

### DIFF
--- a/apps/api/src/tasks/taskHistory.service.ts
+++ b/apps/api/src/tasks/taskHistory.service.ts
@@ -1,0 +1,135 @@
+// Назначение: формирование текста истории задач для Telegram
+// Основные модули: db/model, db/queries, shared, utils/userLink
+import { PROJECT_TIMEZONE, PROJECT_TIMEZONE_LABEL } from 'shared';
+import { Task, type HistoryEntry } from '../db/model';
+import { getUsersMap } from '../db/queries';
+import userLink from '../utils/userLink';
+
+const historyFormatter = new Intl.DateTimeFormat('ru-RU', {
+  day: '2-digit',
+  month: '2-digit',
+  year: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+  timeZone: PROJECT_TIMEZONE,
+});
+
+type UsersMap = Record<
+  number,
+  {
+    name?: string | null;
+    username?: string | null;
+  }
+>;
+
+const emptyObject = Object.freeze({}) as Record<string, unknown>;
+
+function mdEscape(str: unknown): string {
+  // eslint-disable-next-line no-useless-escape
+  return String(str).replace(/[\\_*\[\]()~`>#+\-=|{}.!]/g, '\\$&');
+}
+
+function resolveAuthor(entry: HistoryEntry, users: UsersMap): string {
+  const id = Number(entry.changed_by);
+  if (Number.isFinite(id) && id !== 0) {
+    const user = users[id];
+    const display = user?.name || user?.username || undefined;
+    return userLink(id, display);
+  }
+  return mdEscape('Система');
+}
+
+function describeAction(entry: HistoryEntry): string | null {
+  const changes = entry.changes?.to || emptyObject;
+  const hasChanges =
+    changes && typeof changes === 'object' && Object.keys(changes).length > 0;
+  if (!hasChanges) {
+    const prev = entry.changes?.from || emptyObject;
+    if (prev && Object.keys(prev).length === 0) {
+      return 'задача создана';
+    }
+    return null;
+  }
+  const status = (changes as Record<string, unknown>).status;
+  if (typeof status === 'string' && status.trim()) {
+    return `статус изменён на «${mdEscape(status.trim())}»`;
+  }
+  const fields = Object.keys(changes as Record<string, unknown>);
+  if (!fields.length) return null;
+  const formatted = fields
+    .map((field) => `«${mdEscape(field)}»`)
+    .join(', ');
+  return `изменены поля ${formatted}`;
+}
+
+function formatHistoryEntry(entry: HistoryEntry, users: UsersMap): string | null {
+  const action = describeAction(entry);
+  if (!action) return null;
+  const at = entry.changed_at ? new Date(entry.changed_at) : new Date();
+  if (Number.isNaN(at.getTime())) return null;
+  const formatted = historyFormatter.format(at).replace(', ', ' ');
+  const timeWithZone = `${mdEscape(formatted)} \\(${mdEscape(
+    PROJECT_TIMEZONE_LABEL,
+  )}\\)`;
+  const author = resolveAuthor(entry, users);
+  return `• ${timeWithZone} — ${action} — ${author}`;
+}
+
+export interface TaskHistoryMessage {
+  taskId: string;
+  messageId: number | null;
+  topicId?: number;
+  text: string;
+}
+
+export async function getTaskHistoryMessage(
+  taskId: string,
+): Promise<TaskHistoryMessage | null> {
+  if (!taskId) return null;
+  const task = await Task.findById(taskId).lean();
+  if (!task) return null;
+  const messageId =
+    typeof task.telegram_status_message_id === 'number'
+      ? task.telegram_status_message_id
+      : null;
+  const topicId =
+    typeof task.telegram_topic_id === 'number'
+      ? task.telegram_topic_id
+      : undefined;
+  const history = Array.isArray(task.history) ? task.history : [];
+  const userIds = new Set<number>();
+  history.forEach((entry) => {
+    const id = Number(entry.changed_by);
+    if (Number.isFinite(id) && id !== 0) {
+      userIds.add(id);
+    }
+  });
+  const usersRaw = userIds.size
+    ? await getUsersMap(Array.from(userIds))
+    : {};
+  const users: UsersMap = {};
+  Object.entries(usersRaw).forEach(([key, value]) => {
+    const id = Number(key);
+    if (Number.isFinite(id)) {
+      users[id] = { name: value.name, username: value.username };
+    }
+  });
+  const lines = history
+    .map((entry) => formatHistoryEntry(entry, users))
+    .filter((line): line is string => Boolean(line));
+  const header = '*История изменений*';
+  const body = lines.length ? lines.join('\n') : mdEscape('Записей нет');
+  const text = lines.length ? `${header}\n${lines.join('\n')}` : `${header}\n_${body}_`;
+  return { taskId, messageId, topicId, text };
+}
+
+export async function updateTaskStatusMessageId(
+  taskId: string,
+  messageId: number,
+): Promise<void> {
+  if (!taskId || !Number.isFinite(messageId)) return;
+  await Task.findByIdAndUpdate(taskId, {
+    telegram_status_message_id: messageId,
+  }).exec();
+}

--- a/tests/bot.status-history.spec.ts
+++ b/tests/bot.status-history.spec.ts
@@ -1,0 +1,138 @@
+// Назначение: проверка обновления истории статусов через Telegram-бота
+// Основные модули: jest, bot, taskHistory.service
+const editMessageTextMock = jest.fn();
+const sendMessageMock = jest.fn();
+
+process.env.NODE_ENV = 'test';
+
+jest.mock('../apps/api/src/config', () => ({
+  botToken: 'test-token',
+  chatId: -1001234567890,
+}));
+
+jest.mock('telegraf', () => {
+  const keyboard = jest.fn(() => ({ resize: jest.fn(() => ({})) }));
+  class MockTelegraf {
+    telegram = {
+      editMessageText: editMessageTextMock,
+      sendMessage: sendMessageMock,
+      deleteWebhook: jest.fn(),
+    };
+    launch = jest.fn();
+    start = jest.fn();
+    command = jest.fn();
+    hears = jest.fn();
+    action = jest.fn();
+    on = jest.fn();
+    use = jest.fn();
+    stop = jest.fn();
+  }
+  return {
+    Telegraf: MockTelegraf,
+    Markup: { keyboard },
+    Context: class {},
+  };
+});
+
+const updateTaskStatusMock = jest.fn();
+
+jest.mock('../apps/api/src/services/service', () => ({
+  updateTaskStatus: (...args: unknown[]) => updateTaskStatusMock(...args),
+  createUser: jest.fn(),
+  getUser: jest.fn(),
+}));
+
+const getTaskHistoryMessageMock = jest.fn();
+const updateTaskStatusMessageIdMock = jest.fn();
+
+jest.mock('../apps/api/src/tasks/taskHistory.service', () => ({
+  getTaskHistoryMessage: (...args: unknown[]) => getTaskHistoryMessageMock(...args),
+  updateTaskStatusMessageId: (...args: unknown[]) =>
+    updateTaskStatusMessageIdMock(...args),
+}));
+
+jest.mock('../apps/api/src/services/scheduler', () => ({
+  startScheduler: jest.fn(),
+}));
+
+jest.mock('../apps/api/src/services/keyRotation', () => ({
+  startKeyRotation: jest.fn(),
+}));
+
+jest.mock('../apps/api/src/messages', () => ({
+  taskAccepted: 'Принято',
+  taskCompleted: 'Сделано',
+  menuPrompt: 'Меню',
+  accessOnlyGroup: 'Только группа',
+  accessError: 'Ошибка',
+  welcomeBack: 'Привет',
+  registrationSuccess: 'Успешно',
+  ermLink: 'https://erm',
+  noVehicles: 'Нет транспорта',
+  vehiclesError: 'Ошибка транспорта',
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { processStatusAction } = require('../apps/api/src/bot/bot');
+
+function createContext(data: string) {
+  return {
+    callbackQuery: { data },
+    from: { id: 42 },
+    answerCbQuery: jest.fn(),
+  } as unknown;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('редактирует существующее сообщение истории', async () => {
+  updateTaskStatusMock.mockResolvedValue({ _id: 'task123' });
+  getTaskHistoryMessageMock.mockResolvedValue({
+    taskId: 'task123',
+    messageId: 777,
+    text: '*История изменений*\n• событие',
+  });
+  const ctx = createContext('task_done:task123') as Parameters<
+    typeof processStatusAction
+  >[0];
+
+  await processStatusAction(ctx, 'Выполнена', 'Готово');
+
+  expect(updateTaskStatusMock).toHaveBeenCalledWith('task123', 'Выполнена', 42);
+  expect(getTaskHistoryMessageMock).toHaveBeenCalledWith('task123');
+  expect(editMessageTextMock).toHaveBeenCalledWith(
+    -1001234567890,
+    777,
+    undefined,
+    '*История изменений*\n• событие',
+    { parse_mode: 'MarkdownV2' },
+  );
+  expect(sendMessageMock).not.toHaveBeenCalled();
+  expect(updateTaskStatusMessageIdMock).not.toHaveBeenCalled();
+});
+
+test('создаёт новое сообщение истории и сохраняет идентификатор', async () => {
+  updateTaskStatusMock.mockResolvedValue({ _id: 'task999' });
+  getTaskHistoryMessageMock.mockResolvedValue({
+    taskId: 'task999',
+    messageId: null,
+    topicId: 55,
+    text: '*История изменений*\n• новое событие',
+  });
+  sendMessageMock.mockResolvedValue({ message_id: 31337 });
+  const ctx = createContext('task_accept:task999') as Parameters<
+    typeof processStatusAction
+  >[0];
+
+  await processStatusAction(ctx, 'В работе', 'Принято');
+
+  expect(sendMessageMock).toHaveBeenCalledWith(
+    -1001234567890,
+    '*История изменений*\n• новое событие',
+    { parse_mode: 'MarkdownV2', message_thread_id: 55 },
+  );
+  expect(updateTaskStatusMessageIdMock).toHaveBeenCalledWith('task999', 31337);
+  expect(editMessageTextMock).not.toHaveBeenCalled();
+});

--- a/tests/taskHistory.service.spec.ts
+++ b/tests/taskHistory.service.spec.ts
@@ -1,0 +1,59 @@
+// Назначение: проверка форматирования истории задачи для Telegram
+// Основные модули: jest, taskHistory.service, db/model
+import { getTaskHistoryMessage } from '../apps/api/src/tasks/taskHistory.service';
+
+jest.mock('../apps/api/src/db/model', () => ({
+  Task: {
+    findById: jest.fn(),
+    findByIdAndUpdate: jest.fn(),
+  },
+}));
+
+jest.mock('../apps/api/src/db/queries', () => ({
+  getUsersMap: jest.fn(),
+}));
+
+const { Task } = require('../apps/api/src/db/model');
+const { getUsersMap } = require('../apps/api/src/db/queries');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('возвращает сообщение истории со временем, действием и автором', async () => {
+  const lean = jest.fn().mockResolvedValue({
+    telegram_status_message_id: 555,
+    telegram_topic_id: 42,
+    history: [
+      {
+        changed_at: new Date('2024-03-12T10:15:00Z'),
+        changed_by: 77,
+        changes: {
+          from: { status: 'Новая' },
+          to: { status: 'Выполнена' },
+        },
+      },
+    ],
+  });
+  (Task.findById as jest.Mock).mockReturnValue({ lean });
+  (getUsersMap as jest.Mock).mockResolvedValue({
+    77: { name: 'Имя', username: 'user77' },
+  });
+
+  const result = await getTaskHistoryMessage('abc123');
+
+  expect(Task.findById).toHaveBeenCalledWith('abc123');
+  expect(getUsersMap).toHaveBeenCalledWith([77]);
+  expect(result).toEqual(
+    expect.objectContaining({
+      taskId: 'abc123',
+      messageId: 555,
+      topicId: 42,
+    }),
+  );
+  expect(result?.text).toContain('*История изменений*');
+  const normalized = result?.text.replace(/\\/g, '');
+  expect(normalized).toContain(
+    '12.03.2024 12:15 (GMT+3) — статус изменён на «Выполнена» — [Имя](tg://user?id=77)',
+  );
+});


### PR DESCRIPTION
## Summary
- add a reusable formatter that builds Telegram-friendly task history blocks and persists status message ids
- refresh bot inline status updates to edit or recreate the shared history message instead of replying with plain text
- keep API task updates in sync with Telegram history and cover the flow with focused Jest tests

## Testing
- `pnpm lint`
- `pnpm test`

## Checklist
- [x] Tests are green
- [x] Lint is clean
- [x] Build scripts succeed (covered by `pnpm test` presteps)
- [x] No breaking changes introduced

## Self-check
- Verified MarkdownV2 escaping for history lines
- Confirmed new service handles missing message ids gracefully
- Ensured controller uses the shared formatter after updates
- Added regression tests for both bot integration and service formatting

------
https://chatgpt.com/codex/tasks/task_b_68dba1484c84832098ba6976fc592a7f