### PR TITLE
fix: экранирование точек в ссылках YouTube

### DIFF
--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -43,7 +43,9 @@ const taskEventFormatter = new Intl.DateTimeFormat('ru-RU', {
 });
 
 const escapeMarkdownV2 = (value: unknown): string =>
-  String(value).replace(/[[\\]_()*~`>#+=|{}.!-]/g, '\\$&');
+  String(value)
+    .replace(/\\/g, '\\\\')
+    .replace(/([_*\[\]()~`>#+\-=|{}.!])/g, '\\$1');
 
 const HTTP_URL_REGEXP = /^https?:\/\//i;
 const YOUTUBE_URL_REGEXP =


### PR DESCRIPTION
## Что сделано
- скорректировал экранирование MarkdownV2, добавив обработку обратных слешей и спецсимволов по документации Telegram.

## Зачем
- unit-тест `notifyTaskCreated вложения` ожидает экранированную точку в ссылке на YouTube; прежняя реализация пропускала символ.

## Чек-лист
- [x] tests: `pnpm test:unit -- tests/tasks.notifyAttachments.spec.ts`
- [ ] lint: `pnpm lint` (не запускалось)
- [ ] build: `pnpm build` (не запускалось)

## Логи
- `pnpm test:unit -- tests/tasks.notifyAttachments.spec.ts`

## Самопроверка
- [x] новая функция экранирования не ломает существующий шаблон сообщения
- [x] тест на порядок отправки вложений проходит
- [x] код соответствует требованиям MarkdownV2 для Telegram

------
https://chatgpt.com/codex/tasks/task_b_68dbb705cd4c8320b0535174dbcc2966