### PR TITLE
feat: preserve start date when editing tasks

### DIFF
--- a/apps/web/src/components/TaskDialog.test.tsx
+++ b/apps/web/src/components/TaskDialog.test.tsx
@@ -118,6 +118,24 @@ describe("TaskDialog", () => {
     expect(await screen.findByText("taskCreatedBy")).toBeTruthy();
   });
 
+  it("не меняет дату начала при сохранении без правок", async () => {
+    render(
+      <MemoryRouter>
+        <TaskDialog onClose={() => {}} id="1" />
+      </MemoryRouter>,
+    );
+
+    const startInput = (await screen.findByLabelText("startDate")) as HTMLInputElement;
+    const initialStart = startInput.value;
+
+    fireEvent.click(screen.getByText("save"));
+
+    await waitFor(() => expect(updateTaskMock).toHaveBeenCalled());
+    expect(updateTaskMock.mock.calls[0][1]).toMatchObject({
+      start_date: initialStart,
+    });
+  });
+
   it("передаёт выбранный срок при создании задачи", async () => {
     createTaskMock.mockResolvedValue({ _id: "new-task" });
     render(

--- a/apps/web/src/components/TaskDialog.tsx
+++ b/apps/web/src/components/TaskDialog.tsx
@@ -847,27 +847,41 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
       }
       const defaults = computeDefaultDates(creationDate ?? undefined);
       const initialValues = initialRef.current;
-      let startInputValue = formData.startDate || defaults.start;
-      let dueInputValue = formData.dueDate || defaults.due;
-      const initialStart = initialValues?.startDate || '';
-      const initialDue = initialValues?.dueDate || '';
-      const startUnchanged =
-        (!formData.startDate && !initialStart) ||
-        (formData.startDate && formData.startDate === initialStart);
-      if (startUnchanged) {
+      const initialStart = initialValues?.startDate || "";
+      const initialDue = initialValues?.dueDate || "";
+      const startValue = formData.startDate || "";
+      const dueValue = formData.dueDate || "";
+      const isNewTask = !isEdit;
+      const startMatchesInitial =
+        Boolean(startValue) && Boolean(initialStart) && startValue === initialStart;
+      const startCleared = !startValue && Boolean(initialStart) && !isNewTask;
+      let startInputValue = startValue || defaults.start;
+      if (isNewTask) {
+        if (startMatchesInitial || (!startValue && !initialStart)) {
+          startInputValue = formatInputDate(new Date());
+        }
+      } else if (startMatchesInitial) {
+        startInputValue = initialStart;
+      } else if (startCleared) {
         startInputValue = formatInputDate(new Date());
       }
-      const dueUnchanged =
-        (!formData.dueDate && !initialDue) ||
-        (formData.dueDate && formData.dueDate === initialDue);
-      if (dueUnchanged) {
-        const startMs = new Date(startInputValue).getTime();
-        const offset =
-          initialStart && initialDue
-            ? new Date(initialDue).getTime() - new Date(initialStart).getTime()
-            : DEFAULT_DUE_OFFSET_MS;
-        if (Number.isFinite(startMs)) {
-          dueInputValue = formatInputDate(new Date(startMs + offset));
+      let dueInputValue = dueValue || defaults.due;
+      const dueMatchesInitial =
+        Boolean(dueValue) && Boolean(initialDue) && dueValue === initialDue;
+      const dueEmpty = !dueValue;
+      if (!isNewTask && startMatchesInitial && (dueMatchesInitial || (dueEmpty && Boolean(initialDue)))) {
+        dueInputValue = initialDue || dueInputValue;
+      } else {
+        const dueUnchanged = (!dueValue && !initialDue) || dueMatchesInitial;
+        if (dueUnchanged) {
+          const startMs = new Date(startInputValue).getTime();
+          const offset =
+            initialStart && initialDue
+              ? new Date(initialDue).getTime() - new Date(initialStart).getTime()
+              : DEFAULT_DUE_OFFSET_MS;
+          if (Number.isFinite(startMs)) {
+            dueInputValue = formatInputDate(new Date(startMs + offset));
+          }
         }
       }
       const startMs = new Date(startInputValue).getTime();


### PR DESCRIPTION
## Что сделано
- скорректировал вычисление дат начала и срока в TaskDialog, чтобы при редактировании без изменений сохранялось исходное значение
- учёл новое поведение при расчёте срока и оставил изначальный dueDate, когда пользователь не меняет даты
- добавил модульный тест TaskDialog, подтверждающий, что startDate не переписывается при сохранении без правок

## Почему
- пользователи теряли исходную дату начала при сохранении задачи без редактирования поля, что приводило к неверным срокам

## Чек-лист
- [x] unit-тесты зелёные (`pnpm test:unit -- TaskDialog`)
- [ ] api-тесты
- [ ] e2e-тесты
- [ ] линтер
- [ ] сборка

## Логи
- `pnpm test:unit -- TaskDialog`

## Самопроверка
- [x] логика дат учитывает новое условие для создания и редактирования
- [x] срок не сдвигается при неизменённых полях
- [x] есть покрытие тестом для сохранения startDate


------
https://chatgpt.com/codex/tasks/task_b_68dbf8f3bdcc8320888f47f2b812a0cc