### PR TITLE
feat: add confirmation flow for task status updates

### DIFF
--- a/apps/api/src/utils/taskButtons.ts
+++ b/apps/api/src/utils/taskButtons.ts
@@ -2,11 +2,20 @@
 // Модули: telegraf Markup
 import { Markup } from 'telegraf';
 
+export function taskAcceptConfirmKeyboard(
+  id: string,
+): ReturnType<typeof Markup.inlineKeyboard> {
+  return Markup.inlineKeyboard([
+    Markup.button.callback('Подтвердить', `task_accept_confirm:${id}`),
+    Markup.button.callback('Отмена', `task_accept_cancel:${id}`),
+  ]);
+}
+
 export default function taskStatusKeyboard(
   id: string,
 ): ReturnType<typeof Markup.inlineKeyboard> {
   return Markup.inlineKeyboard([
-    Markup.button.callback('В работу', `task_accept:${id}`),
+    Markup.button.callback('В работу', `task_accept_prompt:${id}`),
     Markup.button.callback('Выполнена', `task_done:${id}`),
   ]);
 }

--- a/tests/api/task.status.spec.ts
+++ b/tests/api/task.status.spec.ts
@@ -79,4 +79,21 @@ describe('updateTaskStatus', function () {
     assert.equal(reopenedBulk?.status, 'Новая');
     assert.equal(reopenedBulk?.completed_at, null);
   });
+
+  it('запрещает обновление статуса пользователю без назначений', async () => {
+    const task = await Task.create({
+      title: 'restricted',
+      created_by: 1,
+      request_id: 'ERM_TEST',
+      task_number: 'ERM_TEST',
+      assigned_user_id: 77,
+      assignees: [77],
+    });
+    const id = (task._id as Types.ObjectId).toHexString();
+
+    await assert.rejects(
+      () => updateTaskStatus(id, 'В работе', 42),
+      /Нет прав на изменение статуса задачи/,
+    );
+  });
 });

--- a/tests/bot.status-history.spec.ts
+++ b/tests/bot.status-history.spec.ts
@@ -35,11 +35,13 @@ jest.mock('telegraf', () => {
 });
 
 const updateTaskStatusMock = jest.fn();
+const getTaskMock = jest.fn();
 
 jest.mock('../apps/api/src/services/service', () => ({
   updateTaskStatus: (...args: unknown[]) => updateTaskStatusMock(...args),
   createUser: jest.fn(),
   getUser: jest.fn(),
+  getTask: (...args: unknown[]) => getTaskMock(...args),
 }));
 
 const getTaskHistoryMessageMock = jest.fn();
@@ -57,6 +59,12 @@ jest.mock('../apps/api/src/services/scheduler', () => ({
 
 jest.mock('../apps/api/src/services/keyRotation', () => ({
   startKeyRotation: jest.fn(),
+}));
+
+jest.mock('../apps/api/src/utils/taskButtons', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ reply_markup: {} })),
+  taskAcceptConfirmKeyboard: jest.fn(() => ({ reply_markup: {} })),
 }));
 
 jest.mock('../apps/api/src/messages', () => ({
@@ -122,7 +130,7 @@ test('создаёт новое сообщение истории и сохра�
     text: '*История изменений*\n• новое событие',
   });
   sendMessageMock.mockResolvedValue({ message_id: 31337 });
-  const ctx = createContext('task_accept:task999') as Parameters<
+  const ctx = createContext('task_accept_confirm:task999') as Parameters<
     typeof processStatusAction
   >[0];
 


### PR DESCRIPTION
## Summary
- add a confirmation keyboard for taking a task in work and wire new prompt/confirm/cancel handlers in the bot
- restrict status updates to assigned executors and guard at both bot and database layers
- extend task status tests to cover the new permission checks and adapt bot history tests

## Testing
- `pnpm test:unit -- tests/bot.status-history.spec.ts`
- `pnpm test:api -- tests/api/task.status.spec.ts`

## Checklist
- [x] Tests
- [ ] Lint
- [ ] Build
- [ ] Dev Server

## Risk Notes
- Bot UI now edits inline keyboards before confirmation; monitor for Telegram API edit errors. Roll back to single-step callbacks if unexpected edit failures occur.


------
https://chatgpt.com/codex/tasks/task_b_68dc1436a64c8320adbe06d27e1ee207