### PR TITLE
feat: disable telegram link previews

### DIFF
--- a/apps/api/src/bot/bot.ts
+++ b/apps/api/src/bot/bot.ts
@@ -184,11 +184,12 @@ async function processStatusAction(
               messageId,
               undefined,
               text,
-              { parse_mode: 'MarkdownV2' },
+              { parse_mode: 'MarkdownV2', disable_web_page_preview: true },
             );
           } else {
             const options: Parameters<typeof bot.telegram.sendMessage>[2] = {
               parse_mode: 'MarkdownV2',
+              disable_web_page_preview: true,
             };
             if (typeof topicId === 'number') {
               options.message_thread_id = topicId;

--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -242,6 +242,7 @@ export default class TasksController {
     const messageOptionsBase = () => {
       const options: Parameters<typeof bot.telegram.sendMessage>[2] = {
         parse_mode: 'MarkdownV2',
+        disable_web_page_preview: true,
       };
       if (typeof topicId === 'number') {
         options.message_thread_id = topicId;
@@ -349,12 +350,13 @@ export default class TasksController {
           messageId,
           undefined,
           text,
-          { parse_mode: 'MarkdownV2' },
+          { parse_mode: 'MarkdownV2', disable_web_page_preview: true },
         );
         return;
       }
       const options: Parameters<typeof bot.telegram.sendMessage>[2] = {
         parse_mode: 'MarkdownV2',
+        disable_web_page_preview: true,
       };
       if (typeof topicId === 'number') {
         options.message_thread_id = topicId;
@@ -573,6 +575,7 @@ export default class TasksController {
             : undefined;
         const groupOptions: Parameters<typeof bot.telegram.sendMessage>[2] = {
           parse_mode: 'MarkdownV2',
+          disable_web_page_preview: true,
           ...mainKeyboard,
         };
         if (typeof topicId === 'number') {
@@ -605,7 +608,9 @@ export default class TasksController {
             (plain as { createdAt?: string | Date }).createdAt ?? Date.now(),
           ),
         );
-        const statusOptions: Parameters<typeof bot.telegram.sendMessage>[2] = {};
+        const statusOptions: Parameters<typeof bot.telegram.sendMessage>[2] = {
+          disable_web_page_preview: true,
+        };
         if (typeof topicId === 'number') {
           statusOptions.message_thread_id = topicId;
         }
@@ -631,6 +636,7 @@ export default class TasksController {
       const dmOptions: Parameters<typeof bot.telegram.sendMessage>[2] = {
         ...taskStatusKeyboard(docId),
         parse_mode: 'HTML',
+        disable_web_page_preview: true,
       };
       await Promise.allSettled(
         Array.from(assignees).map((userId) =>


### PR DESCRIPTION
## Summary
- add disable_web_page_preview to every bot.telegram.sendMessage and editMessageText usage in task notifications
- ensure personal notifications inherit the flag to avoid unwanted previews

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68dc1acdadfc8320b8483a40f074dfc4