### PR TITLE
feat: enrich task history change descriptions

### DIFF
--- a/apps/api/tests/taskHistory.service.test.ts
+++ b/apps/api/tests/taskHistory.service.test.ts
@@ -1,0 +1,38 @@
+// Назначение: автотесты. Модули: jest.
+const { describeAction } = require('../src/tasks/taskHistory.service.ts');
+
+describe('describeAction', () => {
+  test('форматирует изменение статуса', () => {
+    const entry = {
+      changes: {
+        from: { status: 'Назначена' },
+        to: { status: 'В работе' },
+      },
+    };
+    expect(describeAction(entry)).toBe('статус: «Назначена» → «В работе»');
+  });
+
+  test('форматирует изменение даты', () => {
+    const entry = {
+      changes: {
+        from: { deadline: '2023-11-01T10:00:00.000Z' },
+        to: { deadline: '2023-11-02T12:30:00.000Z' },
+      },
+    };
+    expect(describeAction(entry)).toBe(
+      'срок: «01.11.2023 13:00» → «02.11.2023 15:30»',
+    );
+  });
+
+  test('форматирует изменение текстового поля', () => {
+    const entry = {
+      changes: {
+        from: { description: '  старое _значение_' },
+        to: { description: 'новое значение' },
+      },
+    };
+    expect(describeAction(entry)).toBe(
+      'описание: «старое \\_значение\\_» → «новое значение»',
+    );
+  });
+});

--- a/tests/taskHistory.service.spec.ts
+++ b/tests/taskHistory.service.spec.ts
@@ -54,6 +54,6 @@ test('возвращает сообщение истории со времене
   expect(result?.text).toContain('*История изменений*');
   const normalized = result?.text.replace(/\\/g, '');
   expect(normalized).toContain(
-    '12.03.2024 12:15 (GMT+3) — статус изменён на «Выполнена» — [Имя](tg://user?id=77)',
+    '12.03.2024 12:15 (GMT+3) — статус: «Новая» → «Выполнена» — [Имя](tg://user?id=77)',
   );
 });


### PR DESCRIPTION
## Summary
- format task history changes as field diffs with friendly formatting for text, dates, numbers and arrays
- cover describeAction with focused unit tests and update history message expectations

## Testing
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_b_68dc250c0f9c8320a4b2332f01a3afa1