### PR TITLE
refactor: isolate bot runtime entrypoint

### DIFF
--- a/Procfile.railway
+++ b/Procfile.railway
@@ -1,4 +1,4 @@
 # Назначение файла: запуск API и бота на Railway отдельными процессами.
 release: pnpm build
 api: node apps/api/dist/server.js
-bot: ./scripts/set_bot_commands.sh && node apps/api/dist/bot/bot.js
+bot: ./scripts/set_bot_commands.sh && node apps/api/dist/bot/runtime.js

--- a/apps/api/ecosystem.config.cjs
+++ b/apps/api/ecosystem.config.cjs
@@ -17,7 +17,7 @@ module.exports = {
     },
     {
       name: 'bot',
-      script: 'dist/bot/bot.js',
+      script: 'dist/bot/runtime.js',
       cwd: __dirname,
       instances: 1,
       exec_mode: 'fork',

--- a/apps/api/ecosystem.config.ts
+++ b/apps/api/ecosystem.config.ts
@@ -22,7 +22,7 @@ export default {
     },
     {
       name: 'bot',
-      script: 'dist/bot/bot.js',
+      script: 'dist/bot/runtime.js',
       cwd: __dirname,
       instances: 1,
       exec_mode: 'fork',

--- a/apps/api/src/bot/bot.ts
+++ b/apps/api/src/bot/bot.ts
@@ -10,8 +10,6 @@ import {
   getUser,
   updateTaskStatus,
 } from '../services/service';
-import { startScheduler } from '../services/scheduler';
-import { startKeyRotation } from '../services/keyRotation';
 import '../db/model';
 import { FleetVehicle, type FleetVehicleAttrs } from '../db/models/fleet';
 import {
@@ -345,13 +343,6 @@ export async function startBot(retry = 0): Promise<void> {
   console.log(
     `Окружение: ${process.env.NODE_ENV || 'development'}, Node ${process.version}`,
   );
-}
-
-if (process.env.NODE_ENV !== 'test') {
-  startBot().then(() => {
-    startScheduler();
-    startKeyRotation();
-  });
 }
 
 process.once('SIGINT', () => bot.stop('SIGINT'));

--- a/apps/api/src/bot/runtime.ts
+++ b/apps/api/src/bot/runtime.ts
@@ -1,0 +1,17 @@
+// Назначение файла: точка входа для процесса Telegram-бота.
+// Основные модули: bot, scheduler, keyRotation
+import { startBot } from './bot';
+import { startScheduler } from '../services/scheduler';
+import { startKeyRotation } from '../services/keyRotation';
+
+if (process.env.NODE_ENV !== 'test') {
+  startBot()
+    .then(() => {
+      startScheduler();
+      startKeyRotation();
+    })
+    .catch((error) => {
+      console.error('Критическая ошибка запуска процесса бота', error);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Что сделано
- вынес запуск Telegram-бота и служебных задач в отдельный runtime-файл
- обновил конфигурации pm2 и Railway, чтобы использовать новый entrypoint без повторного запуска бота из API

## Почему
- импорт бота в API вызывал повторный `startBot`, что приводило к конфликту Telegram 409 на продакшене; отдельная точка входа исключает дублирование запросов `getUpdates`

## Чек-лист
- [x] `./scripts/setup_and_test.sh`

## Логи ключевых команд
- `./scripts/setup_and_test.sh`

## Самопроверка
- [x] Изменения не нарушают совместимость API
- [x] Конфигурации деплоя обновлены
- [x] Логика повторного запуска бота осталась без регрессий
- [x] Добавлены новые импорты только там, где они нужны

------
https://chatgpt.com/codex/tasks/task_b_68dc416f0c308320ad8bcf8fdaf8ad48