### PR TITLE
feat: поддержка inline изображений в задачах

### DIFF
--- a/tests/formatTask.spec.ts
+++ b/tests/formatTask.spec.ts
@@ -41,21 +41,43 @@ describe('formatTask', () => {
       202: { name: 'Ольга Сидорова', username: 'olga' },
     };
 
-    const result = formatTask(task as any, users);
+    const { text } = formatTask(task as any, users);
 
     const configuredUrl = process.env.APP_URL || 'https://example.com';
     const baseUrl = escapeMd(configuredUrl.replace(/\/+$/, ''));
     const expectedLink = `📌 [${escapeMd('A-12')}](${baseUrl}/tasks/507f1f77bcf86cd799439011)`;
 
-    expect(result).toContain(expectedLink);
-    expect(result).toContain('🧾 *Информация*');
-    expect(result).toContain('🧭 *Логистика*');
-    expect(result).toContain('🚚 *Груз*');
-    expect(result).toContain('🤝 *Участники*');
-    expect(result).toContain('[Иван Петров](tg://user?id=101)');
-    expect(result).toContain('[Ольга Сидорова](tg://user?id=202)');
-    expect(result).toMatch(/━━━━━━━━━━━━/);
-    expect(result).toContain('📝 *Описание*');
+    expect(text).toContain(expectedLink);
+    expect(text).toContain('🧾 *Информация*');
+    expect(text).toContain('🧭 *Логистика*');
+    expect(text).toContain('🚚 *Груз*');
+    expect(text).toContain('🤝 *Участники*');
+    expect(text).toContain('[Иван Петров](tg://user?id=101)');
+    expect(text).toContain('[Ольга Сидорова](tg://user?id=202)');
+    expect(text).toMatch(/━━━━━━━━━━━━/);
+    expect(text).toContain('📝 *Описание*');
+  });
+
+  it('извлекает изображения из HTML и формирует список ссылок', () => {
+    const task = {
+      _id: '507f1f77bcf86cd799439011',
+      task_number: 'A-12',
+      task_description:
+        '<p>Основной текст.</p><img src="/api/v1/files/demo.png" alt="Схема" />',
+    };
+    const { text, inlineImages } = formatTask(task as any, {});
+
+    const configuredUrl = process.env.APP_URL || 'https://example.com';
+    const baseUrl = configuredUrl.replace(/\/+$/, '');
+    const expectedUrl = `${baseUrl}/api/v1/files/demo.png`;
+    const inlineUrl = `${expectedUrl}?mode=inline`;
+
+    expect(inlineImages).toEqual([{ url: inlineUrl, alt: 'Схема' }]);
+    expect(text).toContain('📝 *Описание*');
+    expect(text).toContain(escapeMd('Основной текст.'));
+    expect(text).toContain('🖼 *Изображение*');
+    expect(text).toContain(`[${escapeMd('Схема')}](${escapeMd(inlineUrl)})`);
+    expect(text).not.toContain('<img');
   });
 });
 


### PR DESCRIPTION
## Что сделано
- разобрал описание задач, выделяя изображения и список ссылок в MarkdownV2
- добавил отправку inline-изображений из описания через `sendTaskAttachments`
- дополнил юнит и интеграционные тесты сценариями с `<img>`

## Почему
- требуется пересылать изображения из HTML-описаний задач вместе с текстом уведомления

## Чек-лист
- [x] `pnpm test:unit --runInBand formatTask.spec.ts tasks.notifyAttachments.spec.ts`
- [ ] `pnpm lint`
- [ ] `pnpm build`
- [ ] `pnpm run dev`

## Самопроверка
- [x] описал изменения в коде и тестах
- [x] убедился, что inline-вложения передаются с `mode=inline`
- [x] проверил, что текст сообщения остаётся в формате MarkdownV2

## Риски и откат
- возможны необычные HTML-фрагменты с изображениями; откат — вернуть предыдущие версии `formatTask` и `sendTaskAttachments`.


------
https://chatgpt.com/codex/tasks/task_b_68dcd89b6c588320bfb84b2407db75d7