### PR TITLE
Fix inline task attachments streaming for Telegram

### DIFF
--- a/apps/api/src/tasks/taskHistory.service.ts
+++ b/apps/api/src/tasks/taskHistory.service.ts
@@ -195,7 +195,7 @@ function formatFieldName(field: string): string {
 
 function formatFieldValue(value: unknown): string {
   const primitive = formatPrimitiveValue(value);
-  return mdEscape(primitive).replace(/\\\./g, '.');
+  return mdEscape(primitive);
 }
 
 export function describeAction(entry: HistoryEntry): string | null {


### PR DESCRIPTION
## Summary
- keep history field values fully escaped to satisfy MarkdownV2 parsing
- resolve inline `<img>` URLs through the local storage catalog and upload them as Telegram InputFiles
- extend attachment tests with coverage for local inline images

## Testing
- `pnpm lint`
- `pnpm test --filter tasks.notifyAttachments` *(fails: playwright test does not support --filter option; unit and API suites pass)*

------
https://chatgpt.com/codex/tasks/task_b_68dcee7a734883208500821fd84d88e8