### PR TITLE
fix: корректное форматирование дат в истории задач

### DIFF
--- a/apps/api/src/tasks/taskHistory.service.ts
+++ b/apps/api/src/tasks/taskHistory.service.ts
@@ -195,7 +195,8 @@ function formatFieldName(field: string): string {
 
 function formatFieldValue(value: unknown): string {
   const primitive = formatPrimitiveValue(value);
-  return mdEscape(primitive);
+  const escaped = mdEscape(primitive);
+  return escaped.replace(/\\\./g, '.');
 }
 
 export function describeAction(entry: HistoryEntry): string | null {


### PR DESCRIPTION
## Что сделано
- снял экранирование точек в значениях истории задач после markdown-экранирования
- сохранил экранирование остальных специальных символов

## Почему
- Telegram отображал даты в истории задач с лишними обратными слешами, что приводило к падению тестов

## Логи
- `pnpm test`
- `pnpm lint`

## Чек-лист
- [x] `pnpm test`
- [x] `pnpm lint`
- [x] `pnpm build` (в рамках `pnpm test`)

## Самопроверка
- проверил, что даты в действиях выводятся без обратных слешей
- убедился, что остальные спецсимволы продолжают экранироваться
- просмотрел тесты, покрывающие форматирование истории задач

------
https://chatgpt.com/codex/tasks/task_b_68dcf4f7eee8832082d4ec79605c5fff