### PR TITLE
feat: simplify task assignee selection

### DIFF
--- a/apps/api/src/dto/tasks.dto.ts
+++ b/apps/api/src/dto/tasks.dto.ts
@@ -30,6 +30,10 @@ export class CreateTaskDto {
       body('completed_at')
         .optional({ nullable: true })
         .isISO8601(),
+      body('assigned_user_id')
+        .customSanitizer(normalizeEmptyNumeric)
+        .optional({ nullable: true })
+        .isNumeric(),
       body('start_date').optional().isISO8601(),
       body('assignees').optional().isArray(),
       optionalFloatField('cargo_length_m'),
@@ -51,6 +55,10 @@ export class UpdateTaskDto {
       body('completed_at')
         .optional({ nullable: true })
         .isISO8601(),
+      body('assigned_user_id')
+        .customSanitizer(normalizeEmptyNumeric)
+        .optional({ nullable: true })
+        .isNumeric(),
       optionalFloatField('cargo_length_m'),
       optionalFloatField('cargo_width_m'),
       optionalFloatField('cargo_height_m'),

--- a/apps/web/src/components/MultiUserSelect.tsx
+++ b/apps/web/src/components/MultiUserSelect.tsx
@@ -1,4 +1,4 @@
-// Назначение файла: компонент выбора нескольких пользователей.
+// Назначение файла: компонент выбора одного пользователя.
 // Модули: React, react-select
 import { useMemo } from "react";
 import Select from "react-select";
@@ -11,8 +11,8 @@ interface Props {
     username?: string;
     telegram_username?: string | null;
   }[];
-  value: string[];
-  onChange: (v: string[]) => void;
+  value: string | null;
+  onChange: (v: string | null) => void;
   disabled?: boolean;
 }
 
@@ -31,17 +31,23 @@ export default function MultiUserSelect({
       })),
     [users],
   );
-  const selected = options.filter((o) => value.includes(o.value));
+  const selected = options.find((o) => o.value === value) ?? null;
   return (
     <div>
       <label className="block text-sm font-medium">{label}</label>
       <Select
-        isMulti
         isDisabled={disabled}
         options={options}
         value={selected}
         placeholder="Выбрать"
-        onChange={(vals) => onChange((vals as any[]).map((v) => v.value))}
+        onChange={(val) => {
+          if (!val) {
+            onChange(null);
+            return;
+          }
+          const item = val as { value?: string } | null;
+          onChange(item?.value ?? null);
+        }}
         className="mt-1"
         classNamePrefix="select"
       />

--- a/apps/web/src/components/TaskDialog.test.tsx
+++ b/apps/web/src/components/TaskDialog.test.tsx
@@ -38,6 +38,7 @@ const taskData = {
   title: "Task",
   task_description: "",
   assignees: [1],
+  assigned_user_id: 1,
   start_date: "2024-01-01T00:00:00Z",
   due_date: "2024-01-02T00:00:00Z",
   created_by: 99,
@@ -109,7 +110,7 @@ describe("TaskDialog", () => {
     await waitFor(() =>
       expect(updateTaskMock).toHaveBeenCalledWith(
         "1",
-        expect.objectContaining({ assignees: ["1"] }),
+        expect.objectContaining({ assigned_user_id: "1" }),
       ),
     );
 

--- a/apps/web/src/services/buildTaskFormData.test.ts
+++ b/apps/web/src/services/buildTaskFormData.test.ts
@@ -18,10 +18,12 @@ describe("buildTaskFormData", () => {
     const formData = buildTaskFormData({
       attachments,
       assignees: [1, 2],
+      assigned_user_id: "15",
       metadata: { flag: true },
     });
     expect(formData.get("formVersion")).toBe("1");
     expect(formData.getAll("assignees")).toEqual(["1", "2"]);
+    expect(formData.get("assigned_user_id")).toBe("15");
     expect(formData.get("attachments")).toBe(JSON.stringify(attachments));
     expect(formData.get("metadata")).toBe(JSON.stringify({ flag: true }));
   });

--- a/tests/normalizeArrays.spec.ts
+++ b/tests/normalizeArrays.spec.ts
@@ -49,4 +49,22 @@ describe('normalizeArrays', () => {
     expect(attachments?.[0]).toMatchObject({ name: 'файл', url: '/api/v1/files/2' });
     expect(next).toHaveBeenCalledTimes(1);
   });
+
+  it('нормализует assigned_user_id и приводит его к массиву assignees', () => {
+    const req = createReq({ assigned_user_id: ' 42 ' });
+    const next = jest.fn() as unknown as NextFunction;
+    normalizeArrays(req, res, next);
+    expect((req.body as { assigned_user_id: unknown }).assigned_user_id).toBe('42');
+    expect((req.body as { assignees: unknown[] }).assignees).toEqual(['42']);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('очищает назначение при пустом assigned_user_id', () => {
+    const req = createReq({ assigned_user_id: '' });
+    const next = jest.fn() as unknown as NextFunction;
+    normalizeArrays(req, res, next);
+    expect((req.body as { assigned_user_id: unknown }).assigned_user_id).toBeNull();
+    expect((req.body as { assignees: unknown[] }).assignees).toEqual([]);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary
- переключил `MultiUserSelect` на выбор одного пользователя и перевёл TaskDialog на поле `assigneeId`, отправляя `assigned_user_id`
- адаптировал middleware `normalizeArrays` и DTO задач для нового поля с обратной совместимостью массива `assignees`
- обновил модульные тесты TaskDialog, buildTaskFormData и normalizeArrays под новый контракт

## Testing
- `pnpm test:unit -- TaskDialog.test.tsx normalizeArrays.spec.ts`
- `pnpm lint`

## Logs
```text
pnpm test:unit -- TaskDialog.test.tsx normalizeArrays.spec.ts
pnpm lint
```

## Checklist
- [x] Тесты
- [x] Линт
- [ ] Сборка
- [ ] Dev сервер

## Self-check
- TaskDialog не использует массив исполнителей
- assigned_user_id очищается при снятии выбора
- normalizeArrays покрыт тестами на новые ветки
- DTO пропускают пустые значения назначенного исполнителя
- UI-тесты TaskDialog отражают новый контракт

------
https://chatgpt.com/codex/tasks/task_b_68dcfde815648320810957f6385ce8ba