### PR TITLE
feat: include author in task status messaging

### DIFF
--- a/tests/taskHistory.service.spec.ts
+++ b/tests/taskHistory.service.spec.ts
@@ -54,7 +54,7 @@ test('возвращает сообщение истории со времене
   expect(result?.text).toContain('*История изменений*');
   const normalized = result?.text.replace(/\\/g, '');
   expect(normalized).toContain(
-    '12.03.2024 12:15 (GMT+3) — статус: «Новая» → «Выполнена» — [Имя](tg://user?id=77)',
+    '• 12.03.2024 12:15 (GMT+3) — статус: «Новая» → «Выполнена» — [Имя](tg://user?id=77)',
   );
 });
 
@@ -80,7 +80,7 @@ test('экранирует точки в датах и другие специа
   expect(result).not.toBeNull();
   expect(result?.text).toContain('30\\.09\\.2025 23:44');
   expect(result?.text).not.toContain('30.09.2025 23:44');
-  expect(result?.text).toContain('Старая \\*версия\\* \\#A');
-  expect(result?.text).toContain('Новая версия \\+ улучшения');
-  expect(result?.text).toContain('— Система');
+  expect(result?.text).toContain('задачу обновил Система');
+  expect(result?.text).not.toContain('Старая \\*версия\\* \\#A');
+  expect(result?.text).not.toContain('Новая версия \\+ улучшения');
 });


### PR DESCRIPTION
## Что сделано и зачем
- Добавил в статусное сообщение задачи имя автора, чтобы уведомления в Telegram отражали источник изменений.
- Ограничил детализированное описание истории только статусными изменениями и переписал формат записи для остальных действий.
- Обновил unit-тесты истории, чтобы зафиксировать новое форматирование и отсутствие описаний для нестатусных обновлений.

## Проверки
- `pnpm test:unit -- taskHistory.service.spec.ts`

## Чек-лист
- [x] Тесты зелёные
- [ ] Линтер пройден
- [ ] Сборка выполнена
- [ ] Бот локально проверен
- [x] Обратная совместимость сохранена

## Самопроверка
- [x] Нет лишних файлов и мусора в коммите
- [x] Нейминг и формулировки соответствуют продуктовой терминологии
- [x] Просмотрел дифф глазами
- [x] Учёл комментарии инструкций AGENTS.md
- [ ] Проверил все связанные сценарии вручную

------
https://chatgpt.com/codex/tasks/task_b_68dd106d5e7883208c99f378f153518c