### PR TITLE
Fix inline history escape and reuse Telegram attachments

### DIFF
--- a/apps/api/src/tasks/taskHistory.service.ts
+++ b/apps/api/src/tasks/taskHistory.service.ts
@@ -198,7 +198,7 @@ function formatFieldName(field: string): string {
 function formatFieldValue(value: unknown): string {
   const primitive = formatPrimitiveValue(value);
   const escaped = mdEscape(primitive);
-  return escaped.replace(/\\\./g, '.');
+  return escaped;
 }
 
 export function describeAction(entry: HistoryEntry): string | null {

--- a/tests/taskHistory.service.spec.ts
+++ b/tests/taskHistory.service.spec.ts
@@ -66,8 +66,8 @@ test('экранирует точки в датах и другие специа
         changed_at: new Date('2025-09-30T20:44:00Z'),
         changed_by: 0,
         changes: {
-          from: { comment: 'Старая *версия* #A' },
-          to: { comment: 'Новая версия + улучшения' },
+          from: { title: 'Старая *версия* #A' },
+          to: { title: 'Новая версия + улучшения' },
         },
       },
     ],
@@ -80,7 +80,8 @@ test('экранирует точки в датах и другие специа
   expect(result).not.toBeNull();
   expect(result?.text).toContain('30\\.09\\.2025 23:44');
   expect(result?.text).not.toContain('30.09.2025 23:44');
-  expect(result?.text).toContain('задачу обновил Система');
-  expect(result?.text).not.toContain('Старая \\*версия\\* \\#A');
-  expect(result?.text).not.toContain('Новая версия \\+ улучшения');
+  expect(result?.text).toContain('— Система');
+  expect(result?.text).toContain(
+    'название: «Старая \\*версия\\* \\#A» → «Новая версия \\+ улучшения»',
+  );
 });


### PR DESCRIPTION
## Summary
- ensure task history values keep MarkdownV2 escaping so edits no longer fail with 400 errors
- reuse and update existing Telegram attachment messages instead of sending new ones for inline images
- extend unit coverage for history formatting and attachment synchronisation flows

## Testing
- pnpm test:unit -- taskHistory.service.spec.ts
- pnpm test:unit -- tasks.notifyAttachments.spec.ts

------
https://chatgpt.com/codex/tasks/task_b_68dd351196bc8320af41fcedb3dbcc3c