### PR TITLE
fix: preserve dots in task history action text

### DIFF
--- a/apps/api/src/tasks/taskHistory.service.ts
+++ b/apps/api/src/tasks/taskHistory.service.ts
@@ -198,7 +198,7 @@ function formatFieldName(field: string): string {
 function formatFieldValue(value: unknown): string {
   const primitive = formatPrimitiveValue(value);
   const escaped = mdEscape(primitive);
-  return escaped;
+  return escaped.replace(/\\\./g, '.');
 }
 
 export function describeAction(entry: HistoryEntry): string | null {


### PR DESCRIPTION
## Summary
- убрал экранирование точек при описании изменений задачи, чтобы сроки отображались в читаемом виде

## Testing
- pnpm lint
- pnpm test

## Checklist
- [x] Тесты green
- [x] Линтер чист
- [x] Сборка проходит
- [x] Обратная совместимость сохранена

## Risk
- Низкий: изменение затрагивает только текстовое описание истории задач; при необходимости достаточно откатить коммит.


------
https://chatgpt.com/codex/tasks/task_b_68dd406d1ba4832089300659470bb062