### PR TITLE
fix: extend collections aggregator test timeout

### DIFF
--- a/apps/api/tests/collectionsAggregator.test.ts
+++ b/apps/api/tests/collectionsAggregator.test.ts
@@ -7,6 +7,8 @@ process.env.JWT_SECRET = 's';
 process.env.MONGO_DATABASE_URL = 'mongodb://localhost/db';
 process.env.APP_URL = 'https://localhost';
 
+jest.setTimeout(30000);
+
 import express from 'express';
 import request from 'supertest';
 import mongoose from 'mongoose';
@@ -53,7 +55,9 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await mongoose.disconnect();
-  await mongod.stop();
+  if (mongod) {
+    await mongod.stop();
+  }
 });
 
 describe('Агрегация коллекций', () => {


### PR DESCRIPTION
## Summary
- increase the Jest timeout for the collections aggregator suite to accommodate MongoDB binary startup
- stop the in-memory MongoDB server only when it has been created

## Testing
- pnpm --dir apps/api test -- collectionsAggregator.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68dd477c68a083208170f52d8f43755f