### PR TITLE
fix: adjust Markdown escape regex for lint compliance

### DIFF
--- a/apps/api/src/utils/mdEscape.ts
+++ b/apps/api/src/utils/mdEscape.ts
@@ -1,7 +1,7 @@
 // Назначение: экранирование текста для MarkdownV2
 // Основные модули: отсутствуют
 
-const MARKDOWN_V2_ESCAPE_REGEXP = /[\\_*\[\]()~`>#+\-=|{}.!]/g;
+const MARKDOWN_V2_ESCAPE_REGEXP = /[[\\\]_*()~`>#+\-=|{}.!]/g;
 
 export function escapeMarkdownV2(value: unknown): string {
   return String(value).replace(MARKDOWN_V2_ESCAPE_REGEXP, '\\$&');


### PR DESCRIPTION
## Summary
- обновил регулярное выражение экранирования MarkdownV2, чтобы убрать лишний escape
- сохранил поддерживаемые символы для экранирования Markdown сообщений

## Testing
- pnpm lint

## Checklist
- [x] Линтеры зелёные
- [ ] Тесты (не запускались)
- [ ] Сборка (не запускалась)
- [ ] Dev-сервер (не запускался)

## Self-check
- [x] Изменения соответствуют требованиям задачи
- [x] Нет регрессий по логике
- [x] Соблюдены договорённости по код-стайлу
- [ ] Документацию обновлять не требовалось
- [x] Проверил вывод ключевых команд

## Risks & Rollback
- Риск: возможны пропущенные спецсимволы Markdown
- Откат: вернуть предыдущее выражение из истории git

------
https://chatgpt.com/codex/tasks/task_b_68de37eb54e083208265525bd082557c