### PR TITLE
feat: inline task previews and history logging

### DIFF
--- a/apps/api/src/utils/formatTask.ts
+++ b/apps/api/src/utils/formatTask.ts
@@ -322,8 +322,7 @@ export default function formatTask(
           ? image.alt.trim()
           : `Изображение ${index + 1}`;
         const label = mdEscape(labelBase);
-        const link = mdEscape(image.url);
-        lines.push(`• [${label}](${link})`);
+        lines.push(`• ${label}`);
       });
     }
     if (lines.length) {

--- a/tests/formatTask.spec.ts
+++ b/tests/formatTask.spec.ts
@@ -74,9 +74,7 @@ describe('formatTask', () => {
     expect(text).toContain('📝 *Описание*');
     expect(text).toContain(escapeMarkdownV2('Основной текст.'));
     expect(text).toContain('🖼 *Изображение*');
-    expect(text).toContain(
-      `[${escapeMarkdownV2('Схема')}](${escapeMarkdownV2(inlineUrl)})`,
-    );
+    expect(text).toContain(`• ${escapeMarkdownV2('Схема')}`);
     expect(text).not.toContain('<img');
   });
 
@@ -101,16 +99,15 @@ describe('formatTask', () => {
     expect(text).not.toContain(textSpecial);
     const attachmentLine = text
       .split('\n')
-      .find((line) => line.startsWith('• ['));
+      .find((line) => line.startsWith('• '));
     expect(attachmentLine).toBeDefined();
-    const match = attachmentLine?.match(/^• \[(.+)\]\((.+)\)$/);
+    const match = attachmentLine?.match(/^• (.+)$/);
     expect(match).toBeTruthy();
-    const [, labelEncoded, urlEncoded] = match as RegExpMatchArray;
+    const [, labelEncoded] = match as RegExpMatchArray;
     const decode = (value: string) =>
       value.replace(/\\([\\_*\[\]()~`>#+\-=|{}.!])/g, '$1');
     expect(labelEncoded).toBe(escapeMarkdownV2(altSpecial));
     expect(decode(labelEncoded)).toBe(altSpecial);
-    expect(urlEncoded).toBe(escapeMarkdownV2(inlineUrl));
     expect(inlineImages).toEqual([
       {
         alt: altSpecial,


### PR DESCRIPTION
## Summary
- use the first available image as the Telegram link preview and remove Markdown links from the task text
- keep editing the existing status message while appending a running history log of changes
- update attachment handling plus the related unit tests for tasks and formatting

## Testing
- pnpm exec jest --runInBand tests/tasks.notifyAttachments.spec.ts tests/formatTask.spec.ts

------
https://chatgpt.com/codex/tasks/task_b_68de719074548320ba123385d7fdea91