### PR TITLE
feat: send local inline preview images as attachments

### DIFF
--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -236,21 +236,24 @@ export default class TasksController {
       });
     }
     const previewImage = previewPool.length ? previewPool[0] : null;
-    const extrasWithoutPreview = previewImage
-      ? (() => {
-          let removed = false;
-          return extras.filter((attachment) => {
-            if (attachment.kind !== 'image') {
+    const shouldKeepPreviewInExtras =
+      !!previewImage && this.extractLocalFileId(previewImage.url) !== null;
+    const extrasWithoutPreview =
+      previewImage && !shouldKeepPreviewInExtras
+        ? (() => {
+            let removed = false;
+            return extras.filter((attachment) => {
+              if (attachment.kind !== 'image') {
+                return true;
+              }
+              if (!removed && attachment === previewImage) {
+                removed = true;
+                return false;
+              }
               return true;
-            }
-            if (!removed && attachment === previewImage) {
-              removed = true;
-              return false;
-            }
-            return true;
-          });
-        })()
-      : extras;
+            });
+          })()
+        : extras;
     return {
       previewImage,
       extras: extrasWithoutPreview,


### PR DESCRIPTION
## Что сделано
- сохранил локальное превью из `/api/v1/files/:id` в списке отправляемых вложений.
- добавил юнит-тест, который проверяет отправку единственного локального inline-изображения.

## Почему
- без локального изображения в `extras` бот не отправлял фото, поэтому карточка задачи в Telegram оставалась без вложения.

## Чек-лист
- [x] `pnpm test:unit -- tasks.notifyAttachments`

## Логи
```
pnpm test:unit -- tasks.notifyAttachments
```

## Самопроверка
- локальные пути определяются по регулярному выражению `/api/v1/files/:id`.
- новые тесты создают временный файл и удаляют его после выполнения.
- существующие сценарии с другими вложениями не изменились.


------
https://chatgpt.com/codex/tasks/task_b_68de893eb3c48320a021d47ff0632d15