### PR TITLE
fix: escape dots in task history markdown

### DIFF
--- a/apps/api/src/tasks/taskHistory.service.ts
+++ b/apps/api/src/tasks/taskHistory.service.ts
@@ -194,9 +194,6 @@ function formatFieldName(field: string): string {
 function formatFieldValue(value: unknown, field?: string): string {
   const primitive = formatPrimitiveValue(value);
   const escaped = mdEscape(primitive);
-  if (field && (field === 'deadline' || field === 'due' || field === 'completed_at')) {
-    return escaped.replace(/\\\.(?=\d{4}\b)/g, '.');
-  }
   return escaped;
 }
 

--- a/tests/taskHistory.service.spec.ts
+++ b/tests/taskHistory.service.spec.ts
@@ -112,3 +112,30 @@ test('не снимает экранирование точек в значен�
     'in progress at: «—» → «01\\.10\\.2025 19:48»',
   );
 });
+
+test('экранирует точки в поле выполнено', async () => {
+  const lean = jest.fn().mockResolvedValue({
+    telegram_status_message_id: null,
+    history: [
+      {
+        changed_at: new Date('2025-10-02T15:09:00Z'),
+        changed_by: 321,
+        changes: {
+          from: { completed_at: null, status: 'В работе' },
+          to: { completed_at: '2025-10-02T15:09:00Z', status: 'Выполнена' },
+        },
+      },
+    ],
+  });
+  (Task.findById as jest.Mock).mockReturnValue({ lean });
+  (getUsersMap as jest.Mock).mockResolvedValue({
+    321: { name: 'Ответственный', username: 'user321' },
+  });
+
+  const result = await getTaskHistoryMessage('completed-at');
+
+  expect(result).not.toBeNull();
+  expect(result?.text).toContain(
+    'выполнено: «—» → «02\\.10\\.2025 18:09»',
+  );
+});


### PR DESCRIPTION
## Summary
- prevent Markdown unescaping for task history values so completed_at dates stay valid
- cover completed_at formatting with a regression test

## Testing
- pnpm test


------
https://chatgpt.com/codex/tasks/task_b_68df60fe6b80832098cd80ede422693c