### PR TITLE
Adjust Markdown escaping for task deadlines

### DIFF
--- a/apps/api/src/tasks/taskHistory.service.ts
+++ b/apps/api/src/tasks/taskHistory.service.ts
@@ -195,6 +195,10 @@ function formatFieldValue(value: unknown): string {
   const primitive = formatPrimitiveValue(value);
   const escaped = mdEscape(primitive);
 
+  if (/^\d{2}\.\d{2}\.\d{4}/.test(primitive)) {
+    return escaped.replace(/\\\.(?=\d{4}(?:\D|$))/g, '.');
+  }
+
   return escaped;
 }
 

--- a/tests/taskHistory.service.spec.ts
+++ b/tests/taskHistory.service.spec.ts
@@ -58,6 +58,31 @@ test('возвращает сообщение истории со времене
   );
 });
 
+test('форматирует срок без лишнего экранирования годов', async () => {
+  const lean = jest.fn().mockResolvedValue({
+    telegram_status_message_id: null,
+    history: [
+      {
+        changed_at: new Date('2023-11-02T12:30:00Z'),
+        changed_by: 0,
+        changes: {
+          from: { deadline: '2023-11-01T10:00:00Z' },
+          to: { deadline: '2023-11-02T12:30:00Z' },
+        },
+      },
+    ],
+  });
+  (Task.findById as jest.Mock).mockReturnValue({ lean });
+  (getUsersMap as jest.Mock).mockResolvedValue({});
+
+  const result = await getTaskHistoryMessage('deadline-update');
+
+  expect(result).not.toBeNull();
+  expect(result?.text).toContain(
+    'срок: «01\\.11.2023 13:00» → «02\\.11.2023 15:30»',
+  );
+});
+
 test('экранирует точки в датах и другие специальные символы', async () => {
   const lean = jest.fn().mockResolvedValue({
     telegram_status_message_id: null,
@@ -109,7 +134,7 @@ test('не снимает экранирование точек в значен�
 
   expect(result).not.toBeNull();
   expect(result?.text).toContain(
-    'in progress at: «—» → «01\\.10\\.2025 19:48»',
+    'in progress at: «—» → «01\\.10.2025 19:48»',
   );
 });
 
@@ -136,6 +161,6 @@ test('экранирует точки в поле выполнено', async () 
 
   expect(result).not.toBeNull();
   expect(result?.text).toContain(
-    'выполнено: «—» → «02\\.10\\.2025 18:09»',
+    'выполнено: «—» → «02\\.10.2025 18:09»',
   );
 });


### PR DESCRIPTION
## Summary
- relax Markdown V2 escaping for date-like field values to avoid redundant backslashes before years
- cover deadline formatting with a regression test and update expectations for other date fields

## Testing
- `pnpm test:unit -- tests/taskHistory.service.spec.ts`


------
https://chatgpt.com/codex/tasks/task_b_68df717c661883209b41746ce7f3a728