### PR TITLE
fix: preserve markdown escapes in task history

### DIFF
--- a/apps/api/src/tasks/taskHistory.service.ts
+++ b/apps/api/src/tasks/taskHistory.service.ts
@@ -195,10 +195,6 @@ function formatFieldValue(value: unknown): string {
   const primitive = formatPrimitiveValue(value);
   const escaped = mdEscape(primitive);
 
-  if (/^\d{2}\.\d{2}\.\d{4}/.test(primitive)) {
-    return escaped.replace(/\\\.(?=\d{4}(?:\D|$))/g, '.');
-  }
-
   return escaped;
 }
 


### PR DESCRIPTION
## Что изменено и зачем
- убран постобработчик, который снимал экранирование точек в истории задач для Telegram Markdown V2
- добавлен вспомогательный валидатор escape-последовательностей и тест на случай 03.10.2025 15:35, чтобы защититься от ошибок Telegram
- обновлены существующие проверки истории, чтобы фиксировать ожидаемые escape-последовательности вместо неустойчивых подстрок

## Чек-лист
- [ ] `pnpm test --filter=taskHistory` (падает из-за MongoMemoryServer: connect ENETUNREACH 66.33.22.231:43551)
- [x] `pnpm test:unit tests/taskHistory.service.spec.ts`

## Логи
- `pnpm test --filter=taskHistory`
  - ❌ Instance failed to start within 10000ms (MongoMemoryServer, ENETUNREACH)
- `pnpm test:unit tests/taskHistory.service.spec.ts`
  - ✅ Test Suites: 1 passed, Tests: 6 passed

## Самопроверка
1. Проверил, что даты в истории остаются экранированными и не содержат сырых точек.
2. Убедился, что новая проверка ловит некорректные escape-последовательности.
3. Подтвердил на тестах, что формат «03.10.2025 15:35» отображается без Markdown-ошибок.


------
https://chatgpt.com/codex/tasks/task_b_68df8315a4988320b2758eeff838d95f