### PR TITLE
fix: stabilize mongo index tests

### DIFF
--- a/apps/api/tests/mongoIndexes.test.ts
+++ b/apps/api/tests/mongoIndexes.test.ts
@@ -24,87 +24,102 @@ function planHasStage(plan: Plan | undefined, stage: string): boolean {
   return false;
 }
 
-describe('индексы задач', () => {
+describe('индексы MongoDB', () => {
   let mongod: MongoMemoryServer;
+
+  const cleanDatabase = async () => {
+    if (mongoose.connection.readyState !== 1) return;
+    try {
+      await mongoose.connection.db.dropDatabase();
+    } catch (error) {
+      const maybe = error as { codeName?: string; message?: string };
+      if (maybe?.codeName !== 'NamespaceNotFound' && !maybe?.message?.includes('ns not found')) {
+        throw error;
+      }
+    }
+  };
 
   beforeAll(async () => {
     mongod = await MongoMemoryServer.create();
     await mongoose.connect(mongod.getUri());
-    await mongoose.connection.db.collection('tasks').insertOne({
-      assigneeId: 1,
-      status: 'Новая',
-      dueAt: new Date(),
-      createdAt: new Date(),
+  });
+
+  afterAll(async () => {
+    await cleanDatabase();
+    await mongoose.disconnect();
+    await mongod.stop();
+  });
+
+  describe('индексы задач', () => {
+    beforeEach(async () => {
+      await cleanDatabase();
+      await mongoose.connection.db.collection('tasks').insertOne({
+        assigneeId: 1,
+        status: 'Новая',
+        dueAt: new Date(),
+        createdAt: new Date(),
+      });
+      await ensureTaskIndexes(mongoose.connection);
+    });
+
+    afterAll(async () => {
+      await cleanDatabase();
+    });
+
+    test('запрос по исполнителю и статусу использует композитный индекс', async () => {
+      const cursor = mongoose.connection.db
+        .collection('tasks')
+        .find({ assigneeId: 1, status: 'Новая', dueAt: { $gte: new Date(0) } })
+        .sort({ dueAt: 1 });
+      const exp = await cursor.explain('queryPlanner');
+      expect(planHasStage(exp.queryPlanner.winningPlan, 'IXSCAN')).toBe(true);
+    });
+
+    test('сортировка по дате создания использует индекс', async () => {
+      const cursor = mongoose.connection.db
+        .collection('tasks')
+        .find()
+        .sort({ createdAt: -1 });
+      const exp = await cursor.explain('queryPlanner');
+      expect(planHasStage(exp.queryPlanner.winningPlan, 'IXSCAN')).toBe(true);
     });
   });
 
-  afterAll(async () => {
-    await mongoose.disconnect();
-    await mongod.stop();
+  describe('индексы загрузок', () => {
+    beforeEach(async () => {
+      await cleanDatabase();
+      await ensureUploadIndexes(mongoose.connection);
+    });
+
+    test('создаются индексы ключа и владельца', async () => {
+      const indexes = await mongoose.connection.db
+        .collection('uploads')
+        .indexes();
+      expect(indexes.some((i) => i.name === 'key_unique')).toBe(true);
+      expect(indexes.some((i) => i.name === 'owner_idx')).toBe(true);
+    });
+
+    afterAll(async () => {
+      await cleanDatabase();
+    });
   });
 
-  test('запрос по исполнителю и статусу использует композитный индекс', async () => {
-    await ensureTaskIndexes(mongoose.connection);
-    const cursor = mongoose.connection.db
-      .collection('tasks')
-      .find({ assigneeId: 1, status: 'Новая', dueAt: { $gte: new Date(0) } })
-      .sort({ dueAt: 1 });
-    const exp = await cursor.explain('queryPlanner');
-    expect(planHasStage(exp.queryPlanner.winningPlan, 'IXSCAN')).toBe(true);
-  });
+  describe('индексы коллекции', () => {
+    beforeEach(async () => {
+      await cleanDatabase();
+      await ensureCollectionItemIndexes(mongoose.connection);
+    });
 
-  test('сортировка по дате создания использует индекс', async () => {
-    const cursor = mongoose.connection.db
-      .collection('tasks')
-      .find()
-      .sort({ createdAt: -1 });
-    const exp = await cursor.explain('queryPlanner');
-    expect(planHasStage(exp.queryPlanner.winningPlan, 'IXSCAN')).toBe(true);
-  });
-});
+    test('создаются уникальный и текстовый индексы', async () => {
+      const indexes = await mongoose.connection.db
+        .collection('collectionitems')
+        .indexes();
+      expect(indexes.some((i) => i.name === 'type_name_unique')).toBe(true);
+      expect(indexes.some((i) => i.name === 'search_text')).toBe(true);
+    });
 
-describe('индексы загрузок', () => {
-  let mongod: MongoMemoryServer;
-
-  beforeAll(async () => {
-    mongod = await MongoMemoryServer.create();
-    await mongoose.connect(mongod.getUri());
-  });
-
-  afterAll(async () => {
-    await mongoose.disconnect();
-    await mongod.stop();
-  });
-
-  test('создаются индексы ключа и владельца', async () => {
-    await ensureUploadIndexes(mongoose.connection);
-    const indexes = await mongoose.connection.db
-      .collection('uploads')
-      .indexes();
-    expect(indexes.some((i) => i.name === 'key_unique')).toBe(true);
-    expect(indexes.some((i) => i.name === 'owner_idx')).toBe(true);
-  });
-});
-
-describe('индексы коллекции', () => {
-  let mongod: MongoMemoryServer;
-
-  beforeAll(async () => {
-    mongod = await MongoMemoryServer.create();
-    await mongoose.connect(mongod.getUri());
-  });
-
-  afterAll(async () => {
-    await mongoose.disconnect();
-    await mongod.stop();
-  });
-
-  test('создаются уникальный и текстовый индексы', async () => {
-    await ensureCollectionItemIndexes(mongoose.connection);
-    const indexes = await mongoose.connection.db
-      .collection('collectionitems')
-      .indexes();
-    expect(indexes.some((i) => i.name === 'type_name_unique')).toBe(true);
-    expect(indexes.some((i) => i.name === 'search_text')).toBe(true);
+    afterAll(async () => {
+      await cleanDatabase();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- reuse a single MongoMemoryServer instance for the Mongo index specs to avoid concurrent binary lock conflicts
- add a guarded cleanDatabase helper and per-suite setup so each group rebuilds its indexes deterministically

## Testing
- `pnpm --dir apps/api test -- tests/mongoIndexes.test.ts`

## Checklist
- [x] Tests
- [ ] Lint (not run)
- [ ] Build (not run)

## Logs
- `pnpm --dir apps/api test -- tests/mongoIndexes.test.ts`

## Self-check
- [x] Tests isolated and repeatable
- [x] No persistent MongoMemoryServer artifacts left behind
- [x] Index verifications still cover all target collections


------
https://chatgpt.com/codex/tasks/task_b_68dfd27933008320b54adcc2fccf69aa