### PR TITLE
feat: add completion note to Telegram task formatter

### DIFF
--- a/tests/formatTask.spec.ts
+++ b/tests/formatTask.spec.ts
@@ -115,5 +115,23 @@ describe('formatTask', () => {
       },
     ]);
   });
+
+  it('добавляет заметку о сроках выполнения для завершённой задачи', () => {
+    const task = {
+      _id: '507f1f77bcf86cd799439099',
+      task_number: 'FIN-99',
+      title: 'Контроль сдачи отчёта',
+      status: 'Выполнена',
+      due_date: '2024-04-01T10:00:00Z',
+      completed_at: '2024-04-03T12:00:00Z',
+    };
+
+    const { text } = formatTask(task as any, {});
+    const [headerSection] = text.split('\n\n━━━━━━━━━━━━\n\n');
+    const headerLines = headerSection.split('\n');
+
+    expect(headerLines[1]).toBe('Выполнена с опозданием на 2 дня 2 часа');
+    expect(headerSection).toContain('Выполнена с опозданием на 2 дня 2 часа');
+  });
 });
 


### PR DESCRIPTION
## Что сделано
- добавлен расчёт комментария о соблюдении срока в formatTask с логикой, аналогичной веб-клиенту
- строка с результатом вставляется в заголовок задачи после идентификатора/названия и экранируется через mdEscape
- обновлены unit-тесты formatTask с кейсом завершённой задачи и ожидаемой фразой «Выполнена …»

## Почему
- синхронизируем отображение информации о соблюдении сроков между веб-клиентом и Telegram-форматом, чтобы пользователи видели статус выполнения

## Чек-лист
- [x] Тесты проходят локально
- [ ] Линтер запущен
- [ ] Сборка выполнена
- [ ] Ручное тестирование проведено
- [x] Обратная совместимость сохранена

## Логи
- `pnpm test:unit -- --runTestsByPath tests/formatTask.spec.ts`

## Самопроверка
- [x] Логика helper совпадает с реализацией на фронтенде (порог 60_000 мс и два блока времени)
- [x] Учтён fallback при отсутствии валидных дат
- [x] Заголовок формируется с экранированием MarkdownV2

------
https://chatgpt.com/codex/tasks/task_b_68e0024c9d448320bbac35eb7c32981e