### PR TITLE
fix: guard task dialog creation date parsing

### DIFF
--- a/apps/web/src/components/TaskDialog.tsx
+++ b/apps/web/src/components/TaskDialog.tsx
@@ -730,7 +730,19 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
             return list;
           });
           setRequestId(t.task_number || t.request_id);
-          setCreated(new Date(t.createdAt).toISOString());
+          const createdSource =
+            ((t as Record<string, unknown>).createdAt as unknown) ??
+            ((t as Record<string, unknown>).created_at as unknown) ??
+            null;
+          const createdIso = toIsoString(createdSource);
+          const createdDate = parseIsoDateMemo(createdIso);
+          if (createdDate) {
+            setCreated(createdDate.toISOString());
+          } else if (createdIso) {
+            setCreated(createdIso);
+          } else {
+            setCreated((prev) => prev || new Date().toISOString());
+          }
           setHistory(normalizeHistory(t.history));
           setResolvedTaskId((prev) => prev ?? coerceTaskId(t._id));
           setStartDateNotice(null);
@@ -810,6 +822,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
     DEFAULT_STATUS,
     DEFAULT_DUE_OFFSET_MS,
     computeDefaultDates,
+    parseIsoDateMemo,
     reset,
     setDueOffset,
   ]);


### PR DESCRIPTION
## Summary
- avoid crashing TaskDialog when the fetched task has no createdAt timestamp
- reuse existing ISO parsing helper and fallback to the previous value so the dialog stays usable

## Testing
- pnpm test -- TaskDialog *(fails: unrelated suites expect htmlparser2/domhandler dependencies in API tests)*

------
https://chatgpt.com/codex/tasks/task_b_68e026a9012883209cf6e9e8fd6d344c