### PR TITLE
feat: embed task preview image in main message

### DIFF
--- a/apps/api/src/types/domhandler.d.ts
+++ b/apps/api/src/types/domhandler.d.ts
@@ -1,0 +1,26 @@
+// Назначение: заглушки типов для пакета domhandler в среде тестирования.
+// Основные модули: domhandler.
+declare module 'domhandler' {
+  export interface DomNode {
+    type: string;
+    parent?: DomNode | null;
+    prev?: DomNode | null;
+    next?: DomNode | null;
+    startIndex?: number | null;
+    endIndex?: number | null;
+    children?: DomNode[];
+    attribs?: Record<string, string | undefined>;
+    [key: string]: unknown;
+  }
+
+  export interface DataNode extends DomNode {
+    data: string;
+  }
+
+  export interface Element extends DomNode {
+    name: string;
+    children: DomNode[];
+  }
+
+  export type Node = DomNode;
+}

--- a/apps/api/src/types/htmlparser2.d.ts
+++ b/apps/api/src/types/htmlparser2.d.ts
@@ -1,0 +1,18 @@
+// Назначение: заглушки типов для htmlparser2 в тестовой среде.
+// Основные модули: htmlparser2.
+declare module 'htmlparser2' {
+  import type { DomNode } from 'domhandler';
+
+  export interface ParserOptions {
+    decodeEntities?: boolean;
+  }
+
+  export interface Document {
+    children: DomNode[];
+  }
+
+  export function parseDocument(
+    data: string,
+    options?: ParserOptions,
+  ): Document;
+}


### PR DESCRIPTION
## Summary
- send task preview media through `sendPhoto`, falling back to text when Telegram rejects the image
- reuse cached photo descriptors when syncing attachments and skip duplicating preview images in extra messages
- provide type stubs and adjust attachment notification tests to reflect inline photo delivery

## Testing
- pnpm test:unit -- tests/tasks.notifyAttachments.spec.ts

------
https://chatgpt.com/codex/tasks/task_b_68e0304950088320b5444a216499e2e3