### PR TITLE
fix: summarize inline images in formatted tasks

### DIFF
--- a/apps/api/src/utils/formatTask.ts
+++ b/apps/api/src/utils/formatTask.ts
@@ -574,6 +574,17 @@ export default function formatTask(
     if (lines.length) {
       sections.push(`📝 *Описание*\n${lines.join('\n')}`);
     }
+    if (images.length) {
+      const title = images.length === 1 ? 'Изображение' : 'Изображения';
+      const attachmentLines = images.map((image, index) => {
+        const rawLabel = image.alt?.trim();
+        const label = rawLabel && rawLabel.length
+          ? rawLabel
+          : `Вложение ${index + 1}`;
+        return `• ${mdEscape(label)}`;
+      });
+      sections.push([`🖼 *${title}*`, ...attachmentLines].join('\n'));
+    }
   }
 
   return { text: sections.join('\n\n━━━━━━━━━━━━\n\n'), inlineImages };


### PR DESCRIPTION
## Что сделано
- Добавил секцию «Изображение» в форматировании задач Telegram с перечислением подписей вложений.
- Ввёл запасные подписи и экранирование MarkdownV2 для названий inline-файлов.

## Зачем
- Чтобы бот выдавал человекочитаемые ссылки на встроенные изображения и проходили unit-тесты форматирования.

## Чек-лист
- [x] `pnpm exec jest tests/formatTask.spec.ts`
- [x] `pnpm lint`
- [ ] `pnpm build` (не запускал: правка вспомогательного форматтера)

## Логи
- `pnpm exec jest tests/formatTask.spec.ts`
- `pnpm lint`

## Самопроверка
- [x] Убедился, что секция вложений появляется только при наличии изображений.
- [x] Проверил, что подписи экранируются корректно.


------
https://chatgpt.com/codex/tasks/task_b_68e0c8056ee883208d8fdd2c968d0f41