### PR TITLE
fix: allow task edits without manager role

### DIFF
--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -561,8 +561,6 @@ router.patch(
   upload.any(),
   processUploads,
   normalizeArrays,
-  Roles(ACCESS_MANAGER) as unknown as RequestHandler,
-  rolesGuard as unknown as RequestHandler,
   param('id').isMongoId(),
   checkTaskAccess as unknown as RequestHandler,
   ...(validateDto(UpdateTaskDto) as RequestHandler[]),

--- a/apps/api/src/utils/formatTask.ts
+++ b/apps/api/src/utils/formatTask.ts
@@ -198,7 +198,7 @@ const preserveConsecutiveSpaces = (value: string): string =>
     if (!prev || !next || /\s/.test(prev) || /\s/.test(next)) {
       return ' ';
     }
-    return ` ${' '.repeat(match.length - 1)}`;
+    return ` ${'\u00a0'.repeat(match.length - 1)}`;
   });
 
 const renderNodes = (nodes: DomNode[] | undefined, context: RenderContext): string => {
@@ -224,9 +224,9 @@ const renderNode = (node: DomNode, context: RenderContext): string => {
     const normalized = preserveConsecutiveSpaces(
       data.replace(/\r\n?/g, ' ').replace(/\t/g, ' '),
     );
-    const compact = normalized.replace(/ /g, ' ').trim();
+    const compact = normalized.replace(/\u00a0/g, ' ').trim();
     if (!compact) {
-      return normalized.includes(' ') ? normalized : ' ';
+      return normalized.includes('\u00a0') ? normalized : ' ';
     }
     return mdEscape(normalized);
   }

--- a/apps/api/tests/tasks.test.ts
+++ b/apps/api/tests/tasks.test.ts
@@ -144,6 +144,15 @@ test('обновление задачи', async () => {
   expect(res.body.status).toBe('Выполнена');
 });
 
+test('обновление задачи доступно назначенному пользователю без прав менеджера', async () => {
+  const res = await request(app)
+    .patch(`/api/v1/tasks/${id}`)
+    .set('x-access', String(1))
+    .send({ title: 'Обновлённая задача' });
+  expect(res.status).toBe(200);
+  expect(res.body.title).toBe('Обновлённая задача');
+});
+
 test('обновление с очисткой габаритов проходит валидацию', async () => {
   const res = await request(app)
     .patch(`/api/v1/tasks/${id}`)

--- a/apps/web/src/components/CKEditorPopup.tsx
+++ b/apps/web/src/components/CKEditorPopup.tsx
@@ -226,11 +226,11 @@ export default function CKEditorPopup({ value, onChange, readOnly }: Props) {
             </p>
           )}
         </div>
-        <div className="flex items-center justify-between gap-3 border-t border-slate-200 bg-slate-50 px-3 py-2">
-          <span className="text-xs text-slate-500">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-slate-200 bg-slate-50 px-3 py-2">
+          <span className="hidden text-xs text-slate-500 sm:block">
             Поддерживает списки, таблицы, изображения и ссылки.
           </span>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2 sm:flex-nowrap">
             {value && (
               <Button
                 type="button"
@@ -294,30 +294,24 @@ export default function CKEditorPopup({ value, onChange, readOnly }: Props) {
                 onChange={(_event, editor) => setDraft(editor.getData())}
               />
             </React.Suspense>
-            <div className="flex items-center justify-between gap-2">
-              <p className="text-xs text-slate-500">
-                Перетащите изображение в редактор или вставьте его из буфера
-                обмена.
-              </p>
-              <div className="flex gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setOpen(false)}
-                >
-                  Отмена
-                </Button>
-                <Button
-                  type="button"
-                  variant="default"
-                  onClick={() => {
-                    onChange?.(draft);
-                    setOpen(false);
-                  }}
-                >
-                  Сохранить
-                </Button>
-              </div>
+            <div className="flex flex-wrap justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setOpen(false)}
+              >
+                Отмена
+              </Button>
+              <Button
+                type="button"
+                variant="default"
+                onClick={() => {
+                  onChange?.(draft);
+                  setOpen(false);
+                }}
+              >
+                Сохранить
+              </Button>
             </div>
           </div>
         </Modal>


### PR DESCRIPTION
## Summary
- replace literal non-breaking spaces in task formatter with explicit unicode escapes to satisfy the linter
- let task updates rely on task access checks instead of manager role and cover the scenario with a regression test
- adjust the CKEditor card and modal footer so buttons stay visible on mobile by removing extra helper copy

## Testing
- pnpm lint
- pnpm --dir apps/api test -- tasks.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68e0dd8bc0288320a3404a6d7a0c0db8