### PR TITLE
fix: escape ordered list markers for telegram

### DIFF
--- a/apps/api/src/utils/formatTask.ts
+++ b/apps/api/src/utils/formatTask.ts
@@ -307,7 +307,7 @@ const renderNode = (node: DomNode, context: RenderContext): string => {
       const indent = '  '.repeat(Math.max(stack.length - 1, 0));
       const marker =
         current && current.type === 'ol'
-          ? `${current.index}. `
+          ? `${current.index}\\. `
           : '• ';
       const lines = body.split(/\n+/);
       const firstLine = `${indent}${marker}${lines[0].trimStart()}`;

--- a/tests/formatTask.spec.ts
+++ b/tests/formatTask.spec.ts
@@ -152,5 +152,19 @@ describe('formatTask', () => {
     expect(descriptionSection).toContain('• Подготовить отчёт');
     expect(descriptionSection).toContain('• _Согласовать_ детали');
   });
+
+  it('экранирует маркер нумерованного списка, предотвращая ошибку 400 Telegram', () => {
+    const task = {
+      _id: '507f1f77bcf86cd799439077',
+      task_number: 'OL-01',
+      task_description: '<ol><li>Первое действие</li><li>Второе действие</li></ol>',
+    };
+
+    const { text } = formatTask(task as any, {});
+    const descriptionSection = text.split('📝 *Описание*')[1];
+
+    expect(descriptionSection).toContain('1\\. Первое действие');
+    expect(descriptionSection).toContain('2\\. Второе действие');
+  });
 });
 


### PR DESCRIPTION
## Что сделано
- Экранирован маркер нумерованного списка, чтобы MarkdownV2 не ломал сообщения.
- Добавлен регрессионный тест с `<ol><li>` на конвертацию описания задачи.

## Почему
- Telegram отклоняет сообщения с `1. ` без экранирования точки, поэтому нужно использовать безопасный маркер.

## Проверки
- [x] `pnpm test:unit -- tests/formatTask.spec.ts`
- [ ] `pnpm test`
- [ ] `pnpm test:api`
- [ ] `pnpm test:e2e`

## Логи
- `pnpm test:unit -- tests/formatTask.spec.ts`

## Самопроверка
- [x] Экранирование маркера проверено.
- [x] Тест падает без фикса.
- [ ] Ручная проверка в Telegram невозможна в текущей среде.


------
https://chatgpt.com/codex/tasks/task_b_68e0f03284d08320b157e9001d8d18b9