### PR TITLE
fix(web): normalize task identifiers in dialog flows

### DIFF
--- a/apps/web/src/components/TaskDialog.tsx
+++ b/apps/web/src/components/TaskDialog.tsx
@@ -1,5 +1,5 @@
 // Общая форма создания и редактирования задач
-// Модули: React, DOMPurify, контексты, сервисы задач, shared, EmployeeLink и логов
+// Модули: React, DOMPurify, контексты, сервисы задач, shared, EmployeeLink, логирование, coerceTaskId
 import React from "react";
 import DOMPurify from "dompurify";
 import { buttonVariants } from "@/components/ui/button-variants";
@@ -35,6 +35,7 @@ import type { Attachment, HistoryItem, UserBrief } from "../types/task";
 import type { Task } from "shared";
 import EmployeeLink from "./EmployeeLink";
 import useDueDateOffset from "../hooks/useDueDateOffset";
+import coerceTaskId from "../utils/coerceTaskId";
 
 interface Props {
   onClose: () => void;
@@ -261,26 +262,6 @@ const hasDimensionValues = (
   );
 
 const START_OFFSET_MS = 60 * 60 * 1000;
-
-const coerceTaskId = (value: unknown): string | null => {
-  if (value === null || value === undefined) {
-    return null;
-  }
-  if (typeof value === "string" || typeof value === "number") {
-    const str = String(value).trim();
-    return str ? str : null;
-  }
-  if (
-    typeof value === "object" &&
-    value !== null &&
-    "toString" in value &&
-    typeof (value as { toString(): unknown }).toString === "function"
-  ) {
-    const str = String((value as { toString(): unknown }).toString()).trim();
-    return str ? str : null;
-  }
-  return null;
-};
 
 export default function TaskDialog({ onClose, onSave, id }: Props) {
   const [resolvedTaskId, setResolvedTaskId] = React.useState<string | null>(

--- a/apps/web/src/components/TaskDialogRoute.tsx
+++ b/apps/web/src/components/TaskDialogRoute.tsx
@@ -1,9 +1,10 @@
 // Назначение файла: показ TaskDialog поверх текущей страницы
-// Отображает TaskDialog при наличии query-параметров
+// Основные модули: React, react-router-dom, useTasks, Modal, coerceTaskId
 import React, { Suspense } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import useTasks from "../context/useTasks";
 import Modal from "./Modal";
+import coerceTaskId from "../utils/coerceTaskId";
 
 const TaskDialogLazy = React.lazy(() => import("./TaskDialog"));
 
@@ -11,7 +12,7 @@ export default function TaskDialogRoute() {
   const [params] = useSearchParams();
   const navigate = useNavigate();
   const { refresh } = useTasks();
-  const id = params.get("task");
+  const id = coerceTaskId(params.get("task"));
   const create = params.get("newTask");
   if (!id && !create) return null;
   const close = () => {

--- a/apps/web/src/components/TaskTable.tsx
+++ b/apps/web/src/components/TaskTable.tsx
@@ -1,9 +1,10 @@
 // Назначение файла: таблица задач на основе DataTable
-// Основные модули: React, DataTable (лениво), taskColumns, useTasks
+// Основные модули: React, DataTable (лениво), taskColumns, useTasks, coerceTaskId
 import React, { lazy, Suspense } from "react";
 const DataTable = lazy(() => import("./DataTable"));
 import taskColumns, { TaskRow } from "../columns/taskColumns";
 import useTasks from "../context/useTasks";
+import coerceTaskId from "../utils/coerceTaskId";
 
 interface TaskTableProps {
   tasks: TaskRow[];
@@ -39,7 +40,7 @@ export default function TaskTable({
 
   return (
     <Suspense fallback={<div>Загрузка таблицы...</div>}>
-      <DataTable
+      <DataTable<TaskRow>
         columns={columns}
         data={tasks.filter((t) => {
           if (
@@ -65,7 +66,14 @@ export default function TaskTable({
         pageSize={25}
         pageCount={pageCount}
         onPageChange={onPageChange}
-        onRowClick={(row) => onRowClick?.((row as TaskRow)._id)}
+        onRowClick={(row) => {
+          const original = row as TaskRow & Record<string, unknown>;
+          const normalizedId =
+            coerceTaskId(original._id) || coerceTaskId(original.id);
+          if (normalizedId) {
+            onRowClick?.(normalizedId);
+          }
+        }}
         toolbarChildren={
           <>
             {typeof onMineChange === "function" && (

--- a/apps/web/src/utils/coerceTaskId.test.ts
+++ b/apps/web/src/utils/coerceTaskId.test.ts
@@ -1,0 +1,21 @@
+// Назначение файла: проверка нормализации идентификаторов задач.
+// Основные модули: coerceTaskId.
+import coerceTaskId from "./coerceTaskId";
+
+describe("coerceTaskId", () => {
+  it("возвращает строку для ObjectId", () => {
+    expect(coerceTaskId({ $oid: "507f1f77bcf86cd799439011" })).toBe(
+      "507f1f77bcf86cd799439011",
+    );
+  });
+
+  it("отбрасывает некорректные значения", () => {
+    expect(coerceTaskId("[object Object]")).toBeNull();
+    expect(coerceTaskId(undefined)).toBeNull();
+  });
+
+  it("использует toString для объектов", () => {
+    const value = { toString: () => "64e4e99d0b705d4df86f7d3a" };
+    expect(coerceTaskId(value)).toBe("64e4e99d0b705d4df86f7d3a");
+  });
+});

--- a/apps/web/src/utils/coerceTaskId.ts
+++ b/apps/web/src/utils/coerceTaskId.ts
@@ -1,0 +1,32 @@
+// Назначение: нормализация идентификаторов задач в строковое представление
+// Основные модули: отсутствуют
+export function coerceTaskId(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === "string" || typeof value === "number") {
+    const normalized = String(value).trim();
+    if (!normalized) return null;
+    if (normalized === "[object Object]" || normalized === "undefined") {
+      return null;
+    }
+    return normalized;
+  }
+  if (typeof value === "object") {
+    if (
+      "$oid" in (value as Record<string, unknown>) &&
+      typeof (value as { $oid?: unknown }).$oid === "string"
+    ) {
+      return coerceTaskId((value as { $oid: string }).$oid);
+    }
+    if (
+      "toString" in (value as Record<string, unknown>) &&
+      typeof (value as { toString?: () => unknown }).toString === "function"
+    ) {
+      return coerceTaskId((value as { toString: () => unknown }).toString());
+    }
+  }
+  return null;
+}
+
+export default coerceTaskId;


### PR DESCRIPTION
## Что сделано
- добавил `coerceTaskId` и покрывающие тесты, чтобы приводить идентификаторы задач к строке и отфильтровывать некорректные значения
- переиспользовал нормализацию идентификаторов в таблице задач, роуте диалога и самом диалоге, чтобы исключить `[object Object]`

## Зачем
- правки устраняют 404 при сохранении задачи, когда в форму попадал некорректный идентификатор из таблицы

## Чек-лист
- [x] pnpm test:unit
- [x] pnpm lint
- [x] сборка не проверялась (изменения только в веб-клиенте)
- [x] обратная совместимость сохранена

## Логи
- `pnpm test:unit`
- `pnpm lint`

## Самопроверка
- [x] убедился, что TaskDialogRoute не открывает диалог без валидного id
- [x] проверил, что таблица задач передает нормализованный идентификатор
- [x] убедился, что TaskDialog сохраняет id после загрузки данных

------
https://chatgpt.com/codex/tasks/task_b_68e10ca159308320ac35a301107c15d6