### PR TITLE
fix: assert unchanged dates in task dialog tests

### DIFF
--- a/apps/web/src/components/TaskDialog.test.tsx
+++ b/apps/web/src/components/TaskDialog.test.tsx
@@ -128,12 +128,16 @@ describe("TaskDialog", () => {
 
     const startInput = (await screen.findByLabelText("startDate")) as HTMLInputElement;
     const initialStart = startInput.value;
+    const dueInput = screen.getByLabelText("dueDate") as HTMLInputElement;
+    const initialDue = dueInput.value;
 
     fireEvent.click(screen.getByText("save"));
 
     await waitFor(() => expect(updateTaskMock).toHaveBeenCalled());
     expect(updateTaskMock.mock.calls[0][1]).not.toHaveProperty("start_date");
     expect(updateTaskMock.mock.calls[0][1]).not.toHaveProperty("due_date");
+    expect(startInput.value).toBe(initialStart);
+    expect(dueInput.value).toBe(initialDue);
   });
 
   it("устанавливает срок на 5 часов позже даты начала по умолчанию", async () => {


### PR DESCRIPTION
## Summary
- ensure the task dialog test records both start and due input values
- assert that the UI keeps the initial dates untouched when saving without edits

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68e139835cb08320beed8d60f5afc1e2