### PR TITLE
feat: group Telegram attachments and show badge colors

### DIFF
--- a/tests/formatTask.spec.ts
+++ b/tests/formatTask.spec.ts
@@ -47,6 +47,12 @@ describe('formatTask', () => {
 
     expect(text).toContain(expectedLink);
     expect(text).toContain('🧾 *Информация*');
+    expect(text).toContain(
+      '⚡️ Приоритет: _Срочно_ — заливка \\#F43F5E · 20%; контур \\#F43F5E · 40%',
+    );
+    expect(text).toContain(
+      '🛠 Статус: _Новая_ — заливка \\#465FFF · 70%; контур \\#2563EB · 30%',
+    );
     expect(text).toContain('🧭 *Логистика*');
     expect(text).toContain('🚚 *Груз*');
     expect(text).toContain('🤝 *Участники*');


### PR DESCRIPTION
## Что сделано
- сгруппировал фото-вложения задач в отправку медиа-группами Telegram с откатом на одиночные сообщения при ошибках
- добавил описание цветов бейджей приоритета и статуса в форматировании сообщений для чата
- обновил модульные и интеграционные тесты под новое поведение медиа-групп и цветовых подсказок

## Почему
- альбомы в Telegram визуально объединяют вложенные изображения и делают просмотр удобнее
- менеджерам важно видеть цветовую кодировку статусов/приоритетов даже в чате, чтобы сохранить一致ность UX

## Чек-лист
- [x] `pnpm test`
- [x] `pnpm test:api`
- [x] `pnpm test:e2e`

## Логи
- `pnpm test`
- `pnpm test:api`
- `pnpm test:e2e`

## Самопроверка
- проверил, что sendMediaGroup заполняет reply_parameters и отдаёт ID в верном порядке
- убедился, что fallback на sendPhoto/sendDocument работает при ошибках Telegram
- пересмотрел formatTask на экранирование MarkdownV2 для строк с цветами
- прогнал jest/mocha/playwright после чистки build-артефактов

------
https://chatgpt.com/codex/tasks/task_b_68e14225aaf48320a48662f9f5bfda39