### PR TITLE
fix: refresh sharp stubs and collage stream handling

### DIFF
--- a/apps/api/src/types/sharp.d.ts
+++ b/apps/api/src/types/sharp.d.ts
@@ -1,11 +1,66 @@
 // Назначение: заглушка типов для sharp в тестах
 declare module 'sharp' {
-  type SharpInstance = {
-    jpeg(options?: unknown): SharpInstance;
-    toFile(path: string): Promise<void>;
+  type SharpColor = string | { r: number; g: number; b: number; alpha?: number };
+
+  type ResizeOptions = {
+    width?: number;
+    height?: number;
+    fit?:
+      | 'cover'
+      | 'contain'
+      | 'fill'
+      | 'inside'
+      | 'outside';
+    position?: string | number;
+    withoutEnlargement?: boolean;
   };
 
-  function sharp(input?: unknown): SharpInstance;
+  type FlattenOptions = {
+    background?: SharpColor;
+  };
+
+  type JpegOptions = {
+    quality?: number;
+    progressive?: boolean;
+  };
+
+  type CompositeInput = {
+    input: Buffer | string;
+    left?: number;
+    top?: number;
+  };
+
+  type CreateOptions = {
+    create: {
+      width: number;
+      height: number;
+      channels?: number;
+      background?: SharpColor;
+    };
+  };
+
+  type Metadata = {
+    width?: number;
+    height?: number;
+    hasAlpha?: boolean;
+  };
+
+  type SharpInput = string | Buffer | CreateOptions;
+
+  interface SharpInstance {
+    metadata(): Promise<Metadata>;
+    resize(options: ResizeOptions): SharpInstance;
+    resize(width: number, height: number, options?: ResizeOptions): SharpInstance;
+    flatten(options?: FlattenOptions): SharpInstance;
+    jpeg(options?: JpegOptions): SharpInstance;
+    composite(images: CompositeInput[]): SharpInstance;
+    toFile(path: string): Promise<void>;
+    toBuffer(): Promise<Buffer>;
+  }
+
+  function sharp(input?: SharpInput): SharpInstance;
+
+  export type Sharp = SharpInstance;
 
   export default sharp;
 }


### PR DESCRIPTION
## Что сделано
- расширил заглушку типов sharp, добавив используемые методы и опции, чтобы tsc видел методы обработки изображений;
- обновил создание коллажа, генерируя буфер и сохраняя его через writeFile, что избавляет от обращения к несуществующему файлу;
- дождался открытия потока перед отдачей локального файла в Telegram, чтобы не получать ENOENT в тестовом окружении.

## Почему
- TypeScript падал из-за устаревшей заглушки sharp, а тесты рушились, когда поток удалял временный файл до открытия.

## Чек-лист
- [x] `pnpm test:unit -- tests/tasks.notifyAttachments.spec.ts`
- [x] `pnpm --filter telegram-task-bot build`

## Логи
- `pnpm test:unit -- tests/tasks.notifyAttachments.spec.ts`
- `pnpm --filter telegram-task-bot build`

## Самопроверка
1. Типы sharp покрывают используемые методы.
2. Коллаж создаётся и сохраняется до чтения.
3. Потоки открываются до начала отправки.


------
https://chatgpt.com/codex/tasks/task_b_68e15de4e6008320b51453c3da834df0