### PR TITLE
fix: remove redundant try/catch in preview media preparation

### DIFF
--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -787,12 +787,8 @@ export default class TasksController {
       return null;
     }
     const sourceUrl = preview.url;
-    try {
-      const photo = await this.resolvePhotoInputWithCache(sourceUrl, cache);
-      return { photo, sourceUrl };
-    } catch (error) {
-      throw error;
-    }
+    const photo = await this.resolvePhotoInputWithCache(sourceUrl, cache);
+    return { photo, sourceUrl };
   }
 
   private createPreviewOptions(


### PR DESCRIPTION
## Summary
- remove the unnecessary try/catch wrapper when resolving preview media inputs

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68e1786452a883209e6c8dc796bd2d25