### PR TITLE
fix: restore collage helpers

### DIFF
--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { randomBytes } from 'node:crypto';
 import { createReadStream } from 'node:fs';
-import { access, mkdir, stat, writeFile } from 'node:fs/promises';
+import { access, mkdir, stat, unlink, writeFile } from 'node:fs/promises';
 import { Request, Response } from 'express';
 import { injectable, inject } from 'tsyringe';
 import { handleValidation } from '../utils/validate';
@@ -113,6 +113,49 @@ type TaskMedia = {
   previewImage: NormalizedImage | null;
   extras: NormalizedAttachment[];
   collageCandidates: NormalizedImage[];
+};
+
+type CollageCell = {
+  width: number;
+  height: number;
+  left: number;
+  top: number;
+};
+
+type CollageLayout = {
+  width: number;
+  height: number;
+  cells: CollageCell[];
+};
+
+const COLLAGE_LAYOUTS: Record<number, CollageLayout> = {
+  2: {
+    width: 1200,
+    height: 900,
+    cells: [
+      { width: 600, height: 900, left: 0, top: 0 },
+      { width: 600, height: 900, left: 600, top: 0 },
+    ],
+  },
+  3: {
+    width: 1200,
+    height: 900,
+    cells: [
+      { width: 600, height: 900, left: 0, top: 0 },
+      { width: 600, height: 450, left: 600, top: 0 },
+      { width: 600, height: 450, left: 600, top: 450 },
+    ],
+  },
+  4: {
+    width: 1200,
+    height: 900,
+    cells: [
+      { width: 600, height: 450, left: 0, top: 0 },
+      { width: 600, height: 450, left: 600, top: 0 },
+      { width: 600, height: 450, left: 0, top: 450 },
+      { width: 600, height: 450, left: 600, top: 450 },
+    ],
+  },
 };
 
 type SendMessageOptions = NonNullable<


### PR DESCRIPTION
## Что сделано
- добавил типы `CollageCell` и `CollageLayout` вместе с преднастроенными схемами на 2–4 изображения
- подключил `unlink` из `node:fs/promises` для корректной очистки временных файлов коллажа

## Зачем
- сборка и тесты падали из-за отсутствующих типов и констант коллажа при обработке вложений задач

## Чек-лист
- [x] Линтер `pnpm lint`
- [x] Юнит-тесты, связанные с вложениями задач
- [ ] E2E-тесты (потребуется отдельный прогон)
- [x] Сборка `pnpm build`
- [x] Обратная совместимость сохранена

## Логи
- `pnpm lint`
- `pnpm test:unit -- tests/tasks.notifyAttachments.spec.ts`
- `pnpm test:unit -- tests/tasks.upload.spec.ts tests/tasks.attachments.merge.spec.ts tests/attachments.normalize.spec.ts tests/normalizeArrays.spec.ts`
- `pnpm build`

## Самопроверка
- [x] Код и импорты оформлены по принятому стилю
- [x] Новые сущности названы понятно и отражают назначение
- [x] Отсутствуют временные файлы и каталоги, попавшие в git


------
https://chatgpt.com/codex/tasks/task_b_68e17c3370308320b6ddd529c864d029