### PR TITLE
test: align attachment inline keyboard expectation

### DIFF
--- a/tests/tasks.notifyAttachments.spec.ts
+++ b/tests/tasks.notifyAttachments.spec.ts
@@ -1238,7 +1238,9 @@ describe('syncTelegramTaskMessage вложения', () => {
     expect(mainChat).toBe(process.env.CHAT_ID);
     expect(mainMessageId).toBe(1001);
     expect(mainMedia).toMatchObject({ type: 'photo', media: 'https://cdn.example.com/new.jpg' });
-    expect(mainExtra).toMatchObject({ inline_keyboard: [] });
+    expect(mainExtra).toMatchObject({
+      reply_markup: { inline_keyboard: [] },
+    });
     expect(deleteMessageMock).toHaveBeenCalledTimes(1);
     expect(deleteMessageMock.mock.calls[0][1]).toBe(404);
     expect(sendMessageMock).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- update the expectation in `tasks.notifyAttachments.spec.ts` to match the reply markup shape returned by Telegram mocks

## Testing
- pnpm test:unit -- tests/tasks.notifyAttachments.spec.ts
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68e18e67a8a4832098916fc6f2f66b0f