### PR TITLE
Fix task edit start date validation and dedupe attachments

### DIFF
--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -299,9 +299,18 @@ export default class TasksController {
     const previewPool: NormalizedImage[] = [];
     const extras: NormalizedAttachment[] = [];
     const collageCandidates: NormalizedImage[] = [];
+    const extrasSeen = new Set<string>();
+    const registerExtra = (attachment: NormalizedAttachment) => {
+      const key = `${attachment.kind}:${attachment.url}`;
+      if (extrasSeen.has(key)) {
+        return;
+      }
+      extrasSeen.add(key);
+      extras.push(attachment);
+    };
     const registerImage = (image: NormalizedImage) => {
       previewPool.push(image);
-      extras.push(image);
+      registerExtra(image);
       if (this.extractLocalFileId(image.url)) {
         collageCandidates.push(image);
       }
@@ -317,7 +326,7 @@ export default class TasksController {
             typeof attachment.name === 'string' && attachment.name.trim()
               ? attachment.name.trim()
               : undefined;
-          extras.push({ kind: 'youtube', url, title });
+          registerExtra({ kind: 'youtube', url, title });
           return;
         }
         const type =
@@ -340,7 +349,7 @@ export default class TasksController {
           if (size !== undefined && size > MAX_PHOTO_SIZE_BYTES) {
             const localId = this.extractLocalFileId(absolute);
             if (!localId) {
-              extras.push({
+              registerExtra({
                 kind: 'unsupported-image',
                 url: absolute,
                 mimeType,
@@ -355,7 +364,7 @@ export default class TasksController {
           registerImage({ kind: 'image', url: absolute });
           return;
         }
-        extras.push({
+        registerExtra({
           kind: 'unsupported-image',
           url: absolute,
           mimeType,

--- a/apps/web/src/components/TaskDialog.tsx
+++ b/apps/web/src/components/TaskDialog.tsx
@@ -960,12 +960,16 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
       const creationDate = parseIsoDate(created);
       if (formData.startDate && creationDate) {
         const parsedStart = parseIsoDate(formData.startDate);
-        if (parsedStart && parsedStart.getTime() < creationDate.getTime()) {
+        if (parsedStart) {
+          const startMinutes = Math.floor(parsedStart.getTime() / 60000);
+          const createdMinutes = Math.floor(creationDate.getTime() / 60000);
+          if (startMinutes < createdMinutes) {
           setError("startDate", {
             type: "validate",
             message: t("startBeforeCreated"),
           });
           return;
+        }
         }
       }
       const initialValues = initialRef.current;


### PR DESCRIPTION
## Summary
- allow TaskDialog to compare the task start date against the creation time with minute precision so edits are not blocked by second-level differences
- extend the TaskDialog tests to wait for hydrated values and cover the regression where creation timestamps contain extra seconds
- deduplicate Telegram attachment payloads by URL when syncing updates to avoid sending duplicate images

## Testing
- pnpm test:unit -- TaskDialog
- pnpm test:api -- tests/api/tasks.patch.dates.spec.ts

------
https://chatgpt.com/codex/tasks/task_b_68e21f5facc48320af31d81d06fd0ab9