### PR TITLE
feat: skip Telegram not modified errors when syncing attachments

### DIFF
--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -1534,6 +1534,10 @@ export default class TasksController {
           );
           result.push(messageId);
         } catch (error) {
+          if (this.isMessageNotModifiedError(error)) {
+            result.push(messageId);
+            continue;
+          }
           console.error('Не удалось обновить изображение вложения', error);
           return null;
         }
@@ -1572,6 +1576,10 @@ export default class TasksController {
           await bot.telegram.editMessageMedia(chat, messageId, undefined, media);
           result.push(messageId);
         } catch (error) {
+          if (this.isMessageNotModifiedError(error)) {
+            result.push(messageId);
+            continue;
+          }
           console.error(
             'Не удалось обновить вложение неподдерживаемого изображения',
             attachment.mimeType ?? 'unknown',


### PR DESCRIPTION
## Summary
- treat Telegram “message is not modified” responses as successful edits when syncing attachment images
- cover the regression with a unit test that keeps attachment messages intact on such responses

## Testing
- pnpm test:unit -- tests/tasks.notifyAttachments.spec.ts
- ./scripts/setup_and_test.sh *(fails: pnpm test exits with ELIFECYCLE because of existing asynchronous console logs during API tests)*

------
https://chatgpt.com/codex/tasks/task_b_68e244f48e0883209bb07a517f09cbda