### PR TITLE
fix: assign creator when executors absent

### DIFF
--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -457,6 +457,30 @@ router.post(
 );
 export const normalizeArrays: RequestHandler = (req, _res, next) => {
   const body = req.body as Record<string, unknown>;
+  const requestUserId = (req as RequestWithUser).user?.id;
+  const hasAssignedUserId =
+    body.assigned_user_id !== undefined ||
+    (body as Record<string, unknown>).assignedUserId !== undefined;
+  const hasAssignees = body.assignees !== undefined;
+
+  const normalizedId =
+    typeof requestUserId === 'string'
+      ? requestUserId.trim()
+      : typeof requestUserId === 'number' && Number.isFinite(requestUserId)
+        ? String(requestUserId)
+        : undefined;
+
+  if (
+    req.method === 'POST' &&
+    !hasAssignedUserId &&
+    !hasAssignees &&
+    normalizedId &&
+    normalizedId.length > 0
+  ) {
+    body.assigned_user_id = normalizedId;
+    body.assignees = [normalizedId];
+  }
+
   const assignedRaw =
     body.assigned_user_id ?? (body as Record<string, unknown>).assignedUserId;
   if (assignedRaw !== undefined) {


### PR DESCRIPTION
## Что сделано
- автоматически добавил ID текущего пользователя в поля `assigned_user_id` и `assignees`, если менеджер создаёт задачу без явного исполнителя.

## Зачем
- вернуть успешное прохождение сценария loginTasksFlow, где менеджер создаёт задачу сразу после логина без выбора исполнителя.

## Чек-лист
- [x] ./scripts/setup_and_test.sh
- [x] pnpm --filter telegram-task-bot test -- loginTasksFlow.test.ts

## Логи
- `./scripts/setup_and_test.sh`
- `pnpm --filter telegram-task-bot test -- loginTasksFlow.test.ts`

## Самопроверка
- [x] Назначение исполнителя добавляется только для POST и при полном отсутствии полей исполнителей.
- [x] Значение приводится к строке и очищается от пробелов.
- [x] Обновление задач (PATCH) не затронуто.
- [x] Валидаторы `CreateTaskDto` и `taskFormValidators` получают заполненные поля.
- [x] Локальные тесты зелёные.


------
https://chatgpt.com/codex/tasks/task_b_68e26b9942408320a0a328306edabef5