### PR TITLE
fix: normalize request user id in task auto assignment

### DIFF
--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -455,6 +455,17 @@ router.post(
   inlineUpload,
   handleInlineUpload,
 );
+function normalizeUserId(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  return undefined;
+}
+
 export const normalizeArrays: RequestHandler = (req, _res, next) => {
   const body = req.body as Record<string, unknown>;
   const requestUserId = (req as RequestWithUser).user?.id;
@@ -463,12 +474,7 @@ export const normalizeArrays: RequestHandler = (req, _res, next) => {
     (body as Record<string, unknown>).assignedUserId !== undefined;
   const hasAssignees = body.assignees !== undefined;
 
-  const normalizedId =
-    typeof requestUserId === 'string'
-      ? requestUserId.trim()
-      : typeof requestUserId === 'number' && Number.isFinite(requestUserId)
-        ? String(requestUserId)
-        : undefined;
+  const normalizedId = normalizeUserId(requestUserId);
 
   if (
     req.method === 'POST' &&


### PR DESCRIPTION
## Что сделано и зачем
- вынес нормализацию идентификатора пользователя в отдельную функцию, чтобы корректно обрабатывать строки и числа
- устранил падение компиляции TypeScript при автоприсвоении исполнителя из request.user

## Проверки
- [x] pnpm exec jest tests/normalizeArrays.spec.ts
- [x] pnpm lint
- [x] pnpm build
- [ ] pnpm test *(падает на e2e-чанках в локальной среде, см. лог)*

## Логи
- `pnpm exec jest tests/normalizeArrays.spec.ts`
- `pnpm lint`
- `pnpm build`
- `pnpm test`

## Самопроверка
- [x] Код компилируется без ошибок TypeScript
- [x] Автозаполнение исполнителя не ломает существующую нормализацию массивов
- [x] Потенциальные побочные эффекты описаны в комментарии к проверкам
- [ ] Все автоматические тесты прошли локально

------
https://chatgpt.com/codex/tasks/task_b_68e2721b81b483209fc8066c32f106bd