### PR TITLE
feat: track Telegram message cleanup metadata

### DIFF
--- a/apps/api/src/db/model.ts
+++ b/apps/api/src/db/model.ts
@@ -244,6 +244,15 @@ export interface TaskAttrs {
   telegram_summary_message_id?: number;
   telegram_preview_message_ids?: number[];
   telegram_attachments_message_ids?: number[];
+  telegram_message_cleanup?: {
+    chat_id: string | number;
+    message_id: number;
+    topic_id?: number;
+    attempted_topic_id?: number;
+    new_message_id?: number;
+    reason?: string;
+    attempted_at?: Date | string;
+  };
   deadline_reminder_sent_at?: Date;
   time_spent?: number;
   // Произвольные поля задачи
@@ -356,6 +365,7 @@ const taskSchema = new Schema<TaskDocument>(
     telegram_summary_message_id: Number,
     telegram_preview_message_ids: [Number],
     telegram_attachments_message_ids: [Number],
+    telegram_message_cleanup: Schema.Types.Mixed,
     deadline_reminder_sent_at: Date,
     time_spent: { type: Number, default: 0 },
     // Произвольные поля хранятся как объект


### PR DESCRIPTION
## Summary
- persist cleanup metadata when Telegram deleteMessage fails so resend keeps the latest message identifiers
- extend the task schema and controller to store cleanup details and warn about manual follow-up
- cover resend failure with a unit test that ensures attachments and message id are updated without duplication

## Testing
- pnpm test:unit -- tests/tasks.notifyAttachments.spec.ts
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68e2af2ed3d08320b04e9d3efcc10282