### PR TITLE
fix: refresh task presentation status after updates

### DIFF
--- a/apps/api/src/bot/bot.ts
+++ b/apps/api/src/bot/bot.ts
@@ -724,9 +724,14 @@ async function processStatusAction(
         : (task as unknown);
     const override = overrideRaw as TaskPresentation;
     const presentation = await syncTaskPresentation(docId, override);
-    const appliedStatus =
-      (presentation.plain?.status as SharedTask['status'] | undefined) ?? status;
-    const plainForView = presentation.plain ?? override;
+    const appliedStatus = (
+      (presentation.plain?.status as SharedTask['status'] | undefined) ?? status
+    ) as SharedTask['status'];
+    const plainForView = {
+      ...override,
+      ...(presentation.plain ?? {}),
+      status: appliedStatus,
+    } as TaskPresentation;
     const messageId = toNumericId(plainForView?.telegram_message_id ?? null);
     const link = buildChatMessageLink(chatId, messageId ?? undefined);
     if (ctx.chat?.type === 'private') {


### PR DESCRIPTION
## Что сделано и зачем
- Сохранил итоговый статус задачи при синхронизации данных, чтобы уведомления и клавиатуры использовали актуальное значение.
- Убрал предупреждение линтера об неиспользуемой переменной и заодно унифицировал подготовку данных для сообщений.

## Чек-лист
- [x] Линтер `pnpm lint`
- [ ] Тесты `pnpm test`
- [ ] Сборка `pnpm build`
- [ ] Разработка `pnpm run dev`

## Логи команд
```bash
pnpm lint
```

## Самопроверка
- Изменение не затрагивает хранение данных.
- Новое поведение не ломает приватные и групповые чаты.
- Линтер проходит без ошибок.
- Документация не требует обновления.

## Риски и откат
- Возможные регрессии в форматировании уведомлений: откатить коммит.

------
https://chatgpt.com/codex/tasks/task_b_68e37fe6f46c8320b794da2b4f561134