### PR TITLE
fix: корректировка теста завершения задачи

### DIFF
--- a/tests/bot.status-history.spec.ts
+++ b/tests/bot.status-history.spec.ts
@@ -388,7 +388,7 @@ describe('обработка завершения задачи', () => {
 
     await fn(ctx);
 
-    expect(taskStatusKeyboardMock).toHaveBeenCalledWith('task555', undefined);
+    expect(taskStatusKeyboardMock).toHaveBeenCalledWith('task555', 'Выполнена');
     expect(updateTaskStatusMock).toHaveBeenCalledWith('task555', 'Выполнена', 42);
     expect(ctx.answerCbQuery).toHaveBeenLastCalledWith('Сделано');
   });


### PR DESCRIPTION
## Что сделано
- обновил проверку вызова `taskStatusKeyboard` в тесте подтверждения завершения задачи

## Зачем
- фактическая реализация передаёт новый статус в клавиатуру, тест ожидал `undefined` и падал в CI

## Проверки
- [x] `pnpm test`
- [x] `pnpm lint`

## Логи
- `pnpm test`: см. консольный вывод в рабочей ветке
- `pnpm lint`: см. консольный вывод в рабочей ветке

## Самопроверка
- [x] изменения касаются только тестов
- [x] все временные файлы очищены
- [x] инструкции из AGENTS.md учтены

------
https://chatgpt.com/codex/tasks/task_b_68e3846b94b48320808cbd072d2bd377