### PR TITLE
feat: add web link in task notifications

### DIFF
--- a/apps/api/src/tasks/taskMessages.ts
+++ b/apps/api/src/tasks/taskMessages.ts
@@ -92,7 +92,10 @@ const resolveHistoryAction = (entry: HistoryEntry | undefined): string | null =>
   if (toStatus && toStatus !== fromStatus) {
     return `переведена в статус «${toStatus}»`;
   }
-  return 'обновлена';
+  if (!toStatus && fromStatus && fromStatus !== toStatus) {
+    return 'переведена в статус «без статуса»';
+  }
+  return null;
 };
 
 export async function buildLatestHistorySummary(

--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -23,7 +23,12 @@ import {
 import { sendProblem } from '../utils/problem';
 import { sendCached } from '../utils/sendCached';
 import { type Task as SharedTask } from 'shared';
-import { bot, buildDirectTaskKeyboard, buildDirectTaskMessage } from '../bot/bot';
+import {
+  bot,
+  buildTaskAppLink,
+  buildDirectTaskKeyboard,
+  buildDirectTaskMessage,
+} from '../bot/bot';
 import { chatId as groupChatId, appUrl as baseAppUrl } from '../config';
 import taskStatusKeyboard from '../utils/taskButtons';
 import formatTask, { type InlineImage } from '../utils/formatTask';
@@ -2033,12 +2038,14 @@ export default class TasksController {
     const assignees = this.collectAssignees(plain);
     assignees.delete(creatorId);
     if (assignees.size) {
+      const appLink = buildTaskAppLink(plain);
       const dmText = buildDirectTaskMessage(
         plain,
         messageLink,
         users,
+        appLink,
       );
-      const dmKeyboard = buildDirectTaskKeyboard(messageLink);
+      const dmKeyboard = buildDirectTaskKeyboard(messageLink, appLink ?? undefined);
       const dmOptions: SendMessageOptions = {
         parse_mode: 'HTML',
         link_preview_options: { is_disabled: true },

--- a/tests/buildDirectTaskMessage.spec.ts
+++ b/tests/buildDirectTaskMessage.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * Назначение файла: проверка формирования личного сообщения о задаче.
+ * Основные модули: buildDirectTaskMessage.
+ */
+import { buildDirectTaskMessage } from '../apps/api/src/bot/bot';
+
+describe('buildDirectTaskMessage', () => {
+  it('добавляет ссылку на веб-версию при наличии ссылки приложения', () => {
+    const task = {
+      _id: '507f1f77bcf86cd799439011',
+      task_number: 'ERM_000002',
+      title: 'Тестовая задача',
+      status: 'Новая',
+      assignees: [101],
+    } as const;
+    const users = {
+      101: { name: 'Исполнитель Тестов', username: 'tester' },
+    };
+    const appLink =
+      'https://example.com/tasks?task=507f1f77bcf86cd799439011';
+
+    const text = buildDirectTaskMessage(task as any, null, users, appLink);
+
+    expect(text).toContain(
+      'Веб-версия: <a href="https://example.com/tasks?task=507f1f77bcf86cd799439011">Открыть задачу</a>',
+    );
+  });
+});

--- a/tests/taskMessages.spec.ts
+++ b/tests/taskMessages.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * Назначение файла: проверка формирования текста истории задач.
+ * Основные модули: buildHistorySummaryLog.
+ */
+import { buildHistorySummaryLog } from '../apps/api/src/tasks/taskMessages';
+
+jest.mock('../apps/api/src/db/queries', () => ({
+  getUsersMap: jest.fn(async () => ({
+    '101': { name: 'Семенович В.И.', username: 'semenovich' },
+    '102': { name: 'Диденко Денис', username: 'didenko' },
+  })),
+}));
+
+describe('buildHistorySummaryLog', () => {
+  it('игнорирует элементы истории без изменения статуса', async () => {
+    const history = [
+      {
+        changed_at: '2025-10-06T16:59:00Z',
+        changed_by: 101,
+        changes: { from: { status: 'Новая' }, to: { status: 'В работе' } },
+      },
+      {
+        changed_at: '2025-10-06T17:06:00Z',
+        changed_by: 102,
+        changes: {
+          from: { task_type: 'Построить' },
+          to: { task_type: 'Проверить' },
+        },
+      },
+    ];
+    const task = {
+      request_id: 'ERM_000002',
+      history,
+    };
+
+    const summary = await buildHistorySummaryLog(task as any);
+
+    expect(summary).toContain('переведена в статус «В работе»');
+    expect(summary).not.toContain('обновлена');
+  });
+});

--- a/tests/tasks.notifyAttachments.spec.ts
+++ b/tests/tasks.notifyAttachments.spec.ts
@@ -30,6 +30,7 @@ jest.mock('../apps/api/src/bot/bot', () => {
         deleteMessage: deleteMessageMock,
       },
     },
+    buildTaskAppLink: jest.fn(() => 'https://example.com/tasks?task=507f1f77bcf86cd799439011'),
     buildDirectTaskKeyboard: jest.fn(),
     buildDirectTaskMessage: jest.fn(() => ''),
     __sendMessageMock: sendMessageMock,


### PR DESCRIPTION
## Summary
- add reusable helper to build links to the task dialog in the web interface and reuse it in bot notifications
- extend direct Telegram messages with a web-version button and link while keeping chat jump support
- ignore non-status entries in history summaries to avoid redundant updates and cover the changes with unit tests

## Testing
- `npx jest tests/buildDirectTaskMessage.spec.ts`
- `npx jest tests/taskMessages.spec.ts`


------
https://chatgpt.com/codex/tasks/task_b_68e3f8c760748320a81f393063c64169