### PR TITLE
fix: skip duplicate keyboard updates for direct messages

### DIFF
--- a/apps/api/src/bot/bot.ts
+++ b/apps/api/src/bot/bot.ts
@@ -515,6 +515,10 @@ export const buildDirectTaskKeyboard = (
   if (!row.length) {
     return undefined;
   }
+  if (typeof Markup.inlineKeyboard !== 'function') {
+    console.warn('Пропущено построение inline-клавиатуры: отсутствует поддержка');
+    return undefined;
+  }
   return Markup.inlineKeyboard([row]);
 };
 
@@ -788,6 +792,9 @@ async function processStatusAction(
     if (ctx.chat?.type === 'private') {
       const keyboard = buildDirectTaskKeyboard(link, appLink ?? undefined);
       const inlineMarkup = keyboard?.reply_markup ?? undefined;
+      if (inlineMarkup) {
+        await updateMessageReplyMarkup(ctx, undefined);
+      }
       const dmText = buildDirectTaskMessage(
         plainForView,
         link,


### PR DESCRIPTION
## Summary
- guard direct task keyboard builder when Telegraf inline helper is missing
- reset confirmation keyboard before rendering private task updates to avoid redundant edits

## Testing
- pnpm lint
- pnpm test


------
https://chatgpt.com/codex/tasks/task_b_68e3ff590a5c8320a65349b414d5fcb2