### PR TITLE
feat: tighten typings for auth fetch and repair scripts

### DIFF
--- a/apps/web/src/types/mongodb.d.ts
+++ b/apps/web/src/types/mongodb.d.ts
@@ -1,0 +1,10 @@
+// Назначение: минимальные типы mongodb для unit-тестов и скриптов
+// Модули: mongodb
+
+declare module 'mongodb' {
+  export type AnyBulkWriteOperation<T> =
+    | { updateOne: { filter: Record<string, unknown>; update: Record<string, unknown> } }
+    | { deleteOne: { filter: Record<string, unknown> } }
+    | { deleteMany: { filter: Record<string, unknown> } }
+    | { insertOne: { document: T } };
+}

--- a/apps/web/src/types/mongoose.d.ts
+++ b/apps/web/src/types/mongoose.d.ts
@@ -1,0 +1,80 @@
+// Назначение: упрощённые типы mongoose для unit-тестов и скриптов
+// Модули: mongoose, mongodb
+
+declare module 'mongoose' {
+  import type { AnyBulkWriteOperation } from 'mongodb';
+
+  export interface ConnectOptions {
+    serverSelectionTimeoutMS?: number;
+  }
+
+  export interface AdminDb {
+    ping(): Promise<void>;
+  }
+
+  export interface DatabaseHandle {
+    admin(): AdminDb;
+  }
+
+  export interface Connection {
+    readyState: number;
+    db?: DatabaseHandle;
+  }
+
+  export namespace Types {
+    class ObjectId {
+      constructor(id?: string);
+      toHexString(): string;
+      static isValid(value: unknown): boolean;
+    }
+  }
+
+  export class Schema<T = unknown> {
+    constructor(definition?: Record<string, unknown>, options?: Record<string, unknown>);
+    static Types: {
+      Mixed: unknown;
+      ObjectId: typeof Types.ObjectId;
+    };
+  }
+
+  export interface UpdateResult {
+    upsertedCount?: number;
+    modifiedCount?: number;
+  }
+
+  export interface BulkWriteOptions {
+    ordered?: boolean;
+  }
+
+  export interface BulkWriteResult {
+    modifiedCount?: number;
+    upsertedCount?: number;
+  }
+
+  export interface Model<T> {
+    find(filter?: Record<string, unknown>): {
+      lean(): Promise<T[]>;
+      lean<U>(): Promise<U[]>;
+    };
+    updateOne(
+      filter: Record<string, unknown>,
+      update: Record<string, unknown>,
+      options?: Record<string, unknown>,
+    ): Promise<UpdateResult>;
+    bulkWrite(
+      operations: Array<AnyBulkWriteOperation<T>>,
+      options?: BulkWriteOptions,
+    ): Promise<BulkWriteResult>;
+    create(doc: Partial<T>): Promise<T & { toObject(): T }>;
+  }
+
+  export const models: Record<string, Model<unknown>>;
+
+  export function model<T>(name: string, schema: Schema<T>, collection?: string): Model<T>;
+
+  export function connect(uri: string, options?: ConnectOptions): Promise<void>;
+
+  export function disconnect(): Promise<void>;
+
+  export const connection: Connection;
+}


### PR DESCRIPTION
## Summary
- add local mongoose/mongodb typings for DB scripts and wire them up without using any
- refine task table row typing and adjust authFetch to sanitize XHR bodies without casts to any
- ensure repairCollections and ensureDefaults rely on typed models to satisfy ts-jest

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_b_68e405b274708320b6d0c3a8b240ceb4