### PR TITLE
fix: уточнить типизацию расширения Schema

### DIFF
--- a/apps/api/src/types/mongoose.d.ts
+++ b/apps/api/src/types/mongoose.d.ts
@@ -1,12 +1,13 @@
 // Назначение: дополняет типы mongoose для серверного кода
 // Основные модули: mongoose
+import type { HydratedDocument } from 'mongoose';
 import 'mongoose';
 
 declare module 'mongoose' {
-  interface Schema<TRawDocType = any> {
-    pre<TDoc = TRawDocType>(
+  interface Schema<TRawDocType = unknown> {
+    pre(
       event: string,
-      fn: (...args: unknown[]) => unknown,
+      fn: (this: HydratedDocument<TRawDocType>, ...args: unknown[]) => unknown,
     ): this;
     index(
       fields: Record<string, unknown>,


### PR DESCRIPTION
## Что изменилось
- добавил импорт `HydratedDocument` для точного контекста `this` в хуках mongoose
- заменил значение типа по умолчанию на `unknown`, чтобы избежать неявного `any`

## Почему
- линтер падал из-за `no-explicit-any` и неиспользуемого дженерика в модуле расширения типов

## Чек-лист
- [x] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm run dev`

## Логи
- `pnpm lint`

## Самопроверка
- [x] проверил, что сигнатура `pre` сохраняет совместимость с текущим кодом
- [x] убедился, что линтеры выполняются без ошибок


------
https://chatgpt.com/codex/tasks/task_b_68e4a55f36488320a0bad85df51713bc