### PR TITLE
Fix Mongo memory server flakiness in tests

### DIFF
--- a/scripts/db/repairCollections.ts
+++ b/scripts/db/repairCollections.ts
@@ -35,8 +35,8 @@ const mongoose: MongooseModule = (() => {
 })();
 
 const { Schema, Types } = mongoose;
-type MongoObjectIdCtor = typeof import('mongodb').ObjectId;
-const ObjectIdCtor: MongoObjectIdCtor = Types.ObjectId as unknown as MongoObjectIdCtor;
+type MongoObjectIdCtor = typeof Types.ObjectId;
+const ObjectIdCtor: MongoObjectIdCtor = Types.ObjectId;
 
 type BulkUpdateOperation<T> = {
   updateOne: {

--- a/tests/setupEnv.ts
+++ b/tests/setupEnv.ts
@@ -13,6 +13,13 @@ process.env.MONGO_DATABASE_URL ||=
 process.env.RETRY_ATTEMPTS ||= '0';
 process.env.SUPPRESS_LOGS ||= '1';
 
+// Увеличиваем тайм-аут буфера операций, чтобы дождаться запуска MongoMemoryServer в CI
+void import('mongoose')
+  .then(({ default: mongoose }) => {
+    mongoose.set('bufferTimeoutMS', 30000);
+  })
+  .catch(() => undefined);
+
 import { TextDecoder, TextEncoder } from 'util';
 (global as any).TextEncoder = TextEncoder;
 (global as any).TextDecoder = TextDecoder as any;


### PR DESCRIPTION
## Summary
- increase the mongoose buffer timeout in the shared test setup so MongoMemoryServer can finish booting on CI
- rely on mongoose.Types.ObjectId inside repairCollections instead of importing mongodb types directly

## Testing
- pnpm test:unit --runInBand
- pnpm test:api --reporter spec

------
https://chatgpt.com/codex/tasks/task_b_68e4b4c5f1f48320b7f0799d0228f288