### PR TITLE
fix: stabilize Mongo memory server setup in tests

### DIFF
--- a/tests/setupEnv.ts
+++ b/tests/setupEnv.ts
@@ -1,7 +1,10 @@
 /**
  * Назначение файла: настройка переменных окружения и полифиллов для юнит-тестов.
- * Основные модули: process, util.
+ * Основные модули: process, util, mongoose.
  */
+
+import type { Mongoose } from 'mongoose';
+import { TextDecoder, TextEncoder } from 'util';
 
 process.env.NODE_ENV = 'test';
 process.env.BOT_TOKEN ||= 'test-bot-token';
@@ -13,13 +16,22 @@ process.env.MONGO_DATABASE_URL ||=
 process.env.RETRY_ATTEMPTS ||= '0';
 process.env.SUPPRESS_LOGS ||= '1';
 
-// Увеличиваем тайм-аут буфера операций, чтобы дождаться запуска MongoMemoryServer в CI
-void import('mongoose')
-  .then(({ default: mongoose }) => {
-    mongoose.set('bufferTimeoutMS', 30000);
-  })
-  .catch(() => undefined);
+// Увеличиваем тайм-аут буфера операций синхронно, чтобы дождаться запуска MongoMemoryServer в CI
+const applyBufferTimeout = (mongoose: Mongoose): void => {
+  mongoose.set('bufferTimeoutMS', 60000);
+};
 
-import { TextDecoder, TextEncoder } from 'util';
+if (process.env.JEST_WORKER_ID) {
+  void import('mongoose')
+    .then(({ default: mongoose }) => {
+      applyBufferTimeout(mongoose);
+    })
+    .catch(() => undefined);
+} else {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+  const mongoose: Mongoose = require('mongoose');
+  applyBufferTimeout(mongoose);
+}
+
 (global as any).TextEncoder = TextEncoder;
 (global as any).TextDecoder = TextDecoder as any;


### PR DESCRIPTION
## Summary
- set the mongoose buffer timeout to 60 seconds for API tests to avoid premature insert timeouts on CI
- load mongoose synchronously under Mocha while keeping Jest compatible lazy loading

## Testing
- pnpm test:unit
- pnpm test:api

------
https://chatgpt.com/codex/tasks/task_b_68e4bf802f94832086a380a2591d773a