### PR TITLE
fix(web): add identifiers to form inputs

### DIFF
--- a/apps/web/src/components/DepartmentManager.tsx
+++ b/apps/web/src/components/DepartmentManager.tsx
@@ -32,6 +32,7 @@ const DepartmentManager: DepartmentManagerComponent = ({ onSubmit }) => {
       </label>
       <input
         id="department-name"
+        name="departmentName"
         data-testid="department-name"
         className="h-10 w-full rounded border px-3"
         value={name}

--- a/apps/web/src/components/EmployeeCardForm.tsx
+++ b/apps/web/src/components/EmployeeCardForm.tsx
@@ -355,6 +355,7 @@ export default function EmployeeCardForm({
             <label className="space-y-1">
               <span className="block text-sm font-medium">ID</span>
               <input
+                name="telegramId"
                 className="h-10 w-full rounded border px-3"
                 value={form.telegram_id ?? ""}
                 onChange={(e) =>
@@ -370,6 +371,7 @@ export default function EmployeeCardForm({
             <label className="space-y-1">
               <span className="block text-sm font-medium">Username</span>
               <input
+                name="username"
                 className="h-10 w-full rounded border px-3"
                 value={form.username || ""}
                 onChange={(e) => updateField("username", e.target.value)}
@@ -380,6 +382,7 @@ export default function EmployeeCardForm({
             <label className="space-y-1">
               <span className="block text-sm font-medium">Имя</span>
               <input
+                name="name"
                 className="h-10 w-full rounded border px-3"
                 value={form.name || ""}
                 onChange={(e) => updateField("name", e.target.value)}
@@ -389,6 +392,7 @@ export default function EmployeeCardForm({
             <label className="space-y-1">
               <span className="block text-sm font-medium">Телефон</span>
               <input
+                name="phone"
                 className="h-10 w-full rounded border px-3"
                 value={form.phone || ""}
                 onChange={(e) => updateField("phone", e.target.value)}
@@ -398,6 +402,7 @@ export default function EmployeeCardForm({
             <label className="space-y-1">
               <span className="block text-sm font-medium">Доп. телефон</span>
               <input
+                name="mobNumber"
                 className="h-10 w-full rounded border px-3"
                 value={form.mobNumber || ""}
                 onChange={(e) => updateField("mobNumber", e.target.value)}
@@ -407,6 +412,7 @@ export default function EmployeeCardForm({
             <label className="space-y-1">
               <span className="block text-sm font-medium">Email</span>
               <input
+                name="email"
                 className="h-10 w-full rounded border px-3"
                 value={form.email || ""}
                 onChange={(e) => updateField("email", e.target.value)}

--- a/apps/web/src/components/EmployeeManager.tsx
+++ b/apps/web/src/components/EmployeeManager.tsx
@@ -63,6 +63,7 @@ const EmployeeManager: EmployeeManagerComponent = ({ onSubmit }) => {
       </label>
       <input
         id="employee-name"
+        name="employeeName"
         data-testid="employee-name"
         className="h-10 w-full rounded border px-3"
         value={name}

--- a/apps/web/src/components/FileUploader.tsx
+++ b/apps/web/src/components/FileUploader.tsx
@@ -82,6 +82,7 @@ export default function FileUploader({
 }: Props) {
   const [items, setItems] = React.useState<UploadItem[]>([]);
   const { t } = useTranslation();
+  const fileInputId = React.useId();
 
   const handleFiles = (files: FileList | File[]) => {
     Array.from(files).forEach((file) => {
@@ -203,6 +204,8 @@ export default function FileUploader({
       >
         <p>{t("dragFilesOrSelect")}</p>
         <input
+          id={fileInputId}
+          name="attachments"
           type="file"
           multiple
           onChange={handleChange}

--- a/apps/web/src/components/FiltersPanel.tsx
+++ b/apps/web/src/components/FiltersPanel.tsx
@@ -15,6 +15,7 @@ export default function FiltersPanel({ filters, onChange }: Props) {
       <select
         className="rounded border p-1"
         aria-label="Уровень"
+        name="level"
         value={filters.level || ""}
         onChange={(e) => onChange({ ...filters, level: e.target.value })}
       >
@@ -29,6 +30,7 @@ export default function FiltersPanel({ filters, onChange }: Props) {
         className="rounded border p-1"
         placeholder="Метод"
         aria-label="Метод"
+        name="method"
         value={filters.method || ""}
         onChange={(e) => onChange({ ...filters, method: e.target.value })}
       />
@@ -36,6 +38,7 @@ export default function FiltersPanel({ filters, onChange }: Props) {
         className="rounded border p-1"
         placeholder="Endpoint"
         aria-label="Endpoint"
+        name="endpoint"
         value={filters.endpoint || ""}
         onChange={(e) => onChange({ ...filters, endpoint: e.target.value })}
       />
@@ -43,6 +46,7 @@ export default function FiltersPanel({ filters, onChange }: Props) {
         className="rounded border p-1"
         placeholder="Статус"
         aria-label="Статус"
+        name="status"
         value={filters.status || ""}
         onChange={(e) =>
           onChange({ ...filters, status: Number(e.target.value) || undefined })
@@ -52,6 +56,7 @@ export default function FiltersPanel({ filters, onChange }: Props) {
         className="rounded border p-1"
         placeholder="Содержит текст"
         aria-label="Содержит текст"
+        name="message"
         value={filters.message || ""}
         onChange={(e) => onChange({ ...filters, message: e.target.value })}
       />
@@ -59,6 +64,7 @@ export default function FiltersPanel({ filters, onChange }: Props) {
         type="date"
         className="rounded border p-1"
         aria-label="От"
+        name="from"
         value={filters.from || ""}
         onChange={(e) => onChange({ ...filters, from: e.target.value })}
       />
@@ -66,12 +72,14 @@ export default function FiltersPanel({ filters, onChange }: Props) {
         type="date"
         className="rounded border p-1"
         aria-label="До"
+        name="to"
         value={filters.to || ""}
         onChange={(e) => onChange({ ...filters, to: e.target.value })}
       />
       <div className="flex items-center gap-1 text-sm">
         <input
           id={noCsrfId}
+          name="noCsrf"
           type="checkbox"
           checked={filters.noCsrf || false}
           onChange={(e) => onChange({ ...filters, noCsrf: e.target.checked })}

--- a/apps/web/src/components/FleetManager.tsx
+++ b/apps/web/src/components/FleetManager.tsx
@@ -54,6 +54,7 @@ const FleetManager: FleetManagerComponent = ({ onSubmit }) => {
       </label>
       <input
         id="fleet-name"
+        name="fleetName"
         data-testid="fleet-name"
         className="h-10 w-full rounded border px-3"
         value={name}
@@ -66,6 +67,7 @@ const FleetManager: FleetManagerComponent = ({ onSubmit }) => {
       <div className="flex gap-2">
         <input
           id="fleet-token"
+          name="fleetToken"
           data-testid="fleet-token"
           className="h-10 w-full rounded border px-3"
           type={showToken ? "text" : "password"}

--- a/apps/web/src/components/LogViewer.tsx
+++ b/apps/web/src/components/LogViewer.tsx
@@ -26,8 +26,13 @@ export default function LogViewer() {
     <div className="space-y-4 rounded-lg bg-white p-4 shadow-sm">
       <div className="flex items-center justify-between">
         <h2 className="text-xl font-semibold">Логи</h2>
-        <label className="flex items-center gap-1 text-sm">
+        <label
+          className="flex items-center gap-1 text-sm"
+          htmlFor="log-live-toggle"
+        >
           <input
+            id="log-live-toggle"
+            name="liveUpdates"
             type="checkbox"
             checked={live}
             onChange={(e) => setLive(e.target.checked)}

--- a/apps/web/src/components/ReportFilterForm.tsx
+++ b/apps/web/src/components/ReportFilterForm.tsx
@@ -18,12 +18,16 @@ export default function ReportFilterForm({ onChange }: ReportFilterFormProps) {
     <form onSubmit={submit} className="flex flex-wrap items-end gap-2">
       <input
         type="date"
+        id="report-from"
+        name="reportFrom"
         value={from}
         onChange={(e) => setFrom(e.target.value)}
         className="focus:border-accentPrimary focus:ring-brand-200 rounded-lg border border-gray-300 bg-gray-100 px-3 py-2 text-sm text-gray-800 focus:ring focus:outline-none"
       />
       <input
         type="date"
+        id="report-to"
+        name="reportTo"
         value={to}
         onChange={(e) => setTo(e.target.value)}
         className="focus:border-accentPrimary focus:ring-brand-200 rounded-lg border border-gray-300 bg-gray-100 px-3 py-2 text-sm text-gray-800 focus:ring focus:outline-none"

--- a/apps/web/src/components/SearchFilters.tsx
+++ b/apps/web/src/components/SearchFilters.tsx
@@ -12,6 +12,16 @@ export default function SearchFilters({ inline = false }: Props) {
   const { filters, setFilters } = useTasks();
   const [local, setLocal] = React.useState(filters);
 
+  const toFieldId = React.useCallback(
+    (prefix: string, value: string) =>
+      `${prefix}-${value}`
+        .toLowerCase()
+        .replace(/[^a-z0-9а-яё]+/gi, "-")
+        .replace(/-+/g, "-")
+        .replace(/^-|-$/g, ""),
+    [],
+  );
+
   const toggle = (key: "status" | "priority", value: string) => {
     setLocal((prev) => {
       const arr = prev[key];
@@ -27,42 +37,62 @@ export default function SearchFilters({ inline = false }: Props) {
         <span className="block text-xs font-semibold uppercase tracking-wide text-gray-600">
           Статус
         </span>
-        {TASK_STATUSES.map((s) => (
-          <label key={s} className="flex items-center gap-1 text-[13px]">
-            <input
-              type="checkbox"
-              checked={local.status.includes(s)}
-              onChange={() => toggle("status", s)}
-            />
-            {s}
-          </label>
-        ))}
+        {TASK_STATUSES.map((s) => {
+          const fieldId = toFieldId("status", s);
+          return (
+            <label
+              key={s}
+              className="flex items-center gap-1 text-[13px]"
+              htmlFor={fieldId}
+            >
+              <input
+                id={fieldId}
+                name="status[]"
+                type="checkbox"
+                checked={local.status.includes(s)}
+                onChange={() => toggle("status", s)}
+              />
+              {s}
+            </label>
+          );
+        })}
       </div>
       <div>
         <span className="block text-xs font-semibold uppercase tracking-wide text-gray-600">
           Приоритет
         </span>
-        {PRIORITIES.map((p) => (
-          <label key={p} className="flex items-center gap-1 text-[13px]">
-            <input
-              type="checkbox"
-              checked={local.priority.includes(p)}
-              onChange={() => toggle("priority", p)}
-            />
-            {p}
-          </label>
-        ))}
+        {PRIORITIES.map((p) => {
+          const fieldId = toFieldId("priority", p);
+          return (
+            <label
+              key={p}
+              className="flex items-center gap-1 text-[13px]"
+              htmlFor={fieldId}
+            >
+              <input
+                id={fieldId}
+                name="priority[]"
+                type="checkbox"
+                checked={local.priority.includes(p)}
+                onChange={() => toggle("priority", p)}
+              />
+              {p}
+            </label>
+          );
+        })}
       </div>
       <div className="flex items-center gap-1.5">
         <input
           type="date"
           className="rounded border px-1.5 py-1 text-[13px]"
+          name="from"
           value={local.from}
           onChange={(e) => setLocal({ ...local, from: e.target.value })}
         />
         <input
           type="date"
           className="rounded border px-1.5 py-1 text-[13px]"
+          name="to"
           value={local.to}
           onChange={(e) => setLocal({ ...local, to: e.target.value })}
         />

--- a/apps/web/src/components/TableToolbar.tsx
+++ b/apps/web/src/components/TableToolbar.tsx
@@ -119,8 +119,13 @@ export default function TableToolbar<T>({
                   key={col.id}
                   className="flex items-center justify-between gap-1"
                 >
-                  <label className="flex items-center gap-1 text-xs font-medium sm:text-sm">
+                  <label
+                    className="flex items-center gap-1 text-xs font-medium sm:text-sm"
+                    htmlFor={`table-column-${col.id}`}
+                  >
                     <input
+                      id={`table-column-${col.id}`}
+                      name={`column-${col.id}`}
                       type="checkbox"
                       checked={col.getIsVisible()}
                       onChange={() => toggleColumn(col.id)}

--- a/apps/web/src/components/TaskDialog.tsx
+++ b/apps/web/src/components/TaskDialog.tsx
@@ -1514,11 +1514,16 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               </select>
             </div>
             <div>
-              <label className="block text-sm font-medium">
+              <label
+                className="block text-sm font-medium"
+                htmlFor="task-dialog-completed-at"
+              >
                 {t("actualTime")}
               </label>
               <input
                 type="datetime-local"
+                id="task-dialog-completed-at"
+                name="completedAtDisplay"
                 value={completedAt ? formatIsoForInput(completedAt) : ""}
                 readOnly
                 placeholder="—"
@@ -1552,7 +1557,10 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
           </div>
           <div className="grid gap-3 md:[grid-template-columns:repeat(auto-fit,minmax(220px,1fr))]">
             <div>
-              <label className="block text-sm font-medium">
+              <label
+                className="block text-sm font-medium"
+                htmlFor="task-start-link"
+              >
                 {t("startPoint")}
               </label>
               {startLink ? (
@@ -1568,6 +1576,8 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
                     </a>
                     {startCoordinates && (
                       <input
+                        id="task-start-coordinates"
+                        name="startCoordinatesDisplay"
                         value={formatCoords(startCoordinates)}
                         readOnly
                         className="w-full cursor-text rounded-md border border-dashed border-slate-300 bg-slate-50 px-2 py-1 text-xs text-slate-600 focus:outline-none focus:ring focus:ring-brand-200 focus:border-accentPrimary"
@@ -1589,6 +1599,8 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               ) : (
                 <div className="mt-1 flex gap-2">
                   <input
+                    id="task-start-link"
+                    name="startLink"
                     value={startLink}
                     onChange={(e) => handleStartLink(e.target.value)}
                     placeholder={t("googleMapsLink")}
@@ -1610,7 +1622,10 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               )}
             </div>
             <div>
-              <label className="block text-sm font-medium">
+              <label
+                className="block text-sm font-medium"
+                htmlFor="task-end-link"
+              >
                 {t("endPoint")}
               </label>
               {endLink ? (
@@ -1626,6 +1641,8 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
                     </a>
                     {finishCoordinates && (
                       <input
+                        id="task-end-coordinates"
+                        name="endCoordinatesDisplay"
                         value={formatCoords(finishCoordinates)}
                         readOnly
                         className="w-full cursor-text rounded-md border border-dashed border-slate-300 bg-slate-50 px-2 py-1 text-xs text-slate-600 focus:outline-none focus:ring focus:ring-brand-200 focus:border-accentPrimary"
@@ -1647,6 +1664,8 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               ) : (
                 <div className="mt-1 flex gap-2">
                   <input
+                    id="task-end-link"
+                    name="endLink"
                     value={endLink}
                     onChange={(e) => handleEndLink(e.target.value)}
                     placeholder={t("googleMapsLink")}
@@ -1704,7 +1723,10 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               </select>
             </div>
             <div>
-              <label className="block text-sm font-medium">
+              <label
+                className="block text-sm font-medium"
+                htmlFor="task-payment-amount"
+              >
                 {t("paymentAmount")}
               </label>
               <div
@@ -1713,6 +1735,8 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
                 }`}
               >
                 <input
+                  id="task-payment-amount"
+                  name="paymentAmount"
                   value={paymentAmount}
                   onChange={(e) => setPaymentAmount(e.target.value)}
                   onBlur={(e) =>
@@ -1736,6 +1760,8 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
             <label className="flex items-center gap-2 text-sm font-medium">
               <input
                 type="checkbox"
+                id="task-show-dimensions"
+                name="showDimensions"
                 className="h-4 w-4"
                 checked={showDimensions}
                 onChange={(e) => handleDimensionsToggle(e.target.checked)}
@@ -1747,10 +1773,15 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
               <div className="space-y-3">
                 <div className="grid gap-3 md:[grid-template-columns:repeat(auto-fit,minmax(220px,1fr))]">
                   <div>
-                    <label className="block text-sm font-medium">
+                    <label
+                      className="block text-sm font-medium"
+                      htmlFor="task-cargo-length"
+                    >
                       {t("cargoLength")}
                     </label>
                     <input
+                      id="task-cargo-length"
+                      name="cargoLength"
                       value={cargoLength}
                       onChange={(e) => setCargoLength(e.target.value)}
                       className="w-full rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1.5 text-sm focus:outline-none focus:ring focus:ring-brand-200 focus:border-accentPrimary"
@@ -1760,10 +1791,15 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
                     />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium">
+                    <label
+                      className="block text-sm font-medium"
+                      htmlFor="task-cargo-width"
+                    >
                       {t("cargoWidth")}
                     </label>
                     <input
+                      id="task-cargo-width"
+                      name="cargoWidth"
                       value={cargoWidth}
                       onChange={(e) => setCargoWidth(e.target.value)}
                       className="w-full rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1.5 text-sm focus:outline-none focus:ring focus:ring-brand-200 focus:border-accentPrimary"
@@ -1773,10 +1809,15 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
                     />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium">
+                    <label
+                      className="block text-sm font-medium"
+                      htmlFor="task-cargo-height"
+                    >
                       {t("cargoHeight")}
                     </label>
                     <input
+                      id="task-cargo-height"
+                      name="cargoHeight"
                       value={cargoHeight}
                       onChange={(e) => setCargoHeight(e.target.value)}
                       className="w-full rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1.5 text-sm focus:outline-none focus:ring focus:ring-brand-200 focus:border-accentPrimary"
@@ -1788,10 +1829,15 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
                 </div>
                 <div className="grid gap-3 md:[grid-template-columns:repeat(auto-fit,minmax(220px,1fr))]">
                   <div>
-                    <label className="block text-sm font-medium">
+                    <label
+                      className="block text-sm font-medium"
+                      htmlFor="task-cargo-volume"
+                    >
                       {t("cargoVolume")}
                     </label>
                     <input
+                      id="task-cargo-volume"
+                      name="cargoVolume"
                       value={cargoVolume}
                       readOnly
                       className="w-full rounded-md border bg-gray-100 px-2.5 py-1.5 text-sm focus:outline-none focus:ring focus:ring-brand-200 focus:border-accentPrimary"
@@ -1799,10 +1845,15 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
                     />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium">
+                    <label
+                      className="block text-sm font-medium"
+                      htmlFor="task-cargo-weight"
+                    >
                       {t("cargoWeight")}
                     </label>
                     <input
+                      id="task-cargo-weight"
+                      name="cargoWeight"
                       value={cargoWeight}
                       onChange={(e) => setCargoWeight(e.target.value)}
                       className="w-full rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1.5 text-sm focus:outline-none focus:ring focus:ring-brand-200 focus:border-accentPrimary"

--- a/apps/web/src/components/TaskFormModern.tsx
+++ b/apps/web/src/components/TaskFormModern.tsx
@@ -18,11 +18,14 @@ const renderField = (
   field: Field,
   value: string,
   setValue: (v: string) => void,
+  inputId: string,
 ) => {
   switch (field.type) {
     case "text":
       return (
         <input
+          id={inputId}
+          name={field.name}
           className="h-10 w-full rounded-md border border-slate-200 bg-slate-50 px-3"
           value={value}
           onChange={(e) => setValue(e.target.value)}
@@ -32,6 +35,8 @@ const renderField = (
     case "textarea":
       return (
         <textarea
+          id={inputId}
+          name={field.name}
           className="w-full rounded-md border border-slate-200 bg-slate-50 px-3 py-2"
           value={value}
           onChange={(e) => setValue(e.target.value)}
@@ -41,6 +46,8 @@ const renderField = (
       return (
         <input
           type="datetime-local"
+          id={inputId}
+          name={field.name}
           className="h-10 w-full rounded-md border border-slate-200 bg-slate-50 px-3"
           value={value}
           onChange={(e) => setValue(e.target.value)}
@@ -50,19 +57,31 @@ const renderField = (
     case "segment":
       return (
         <div className="flex gap-2">
-          {field.options?.map((opt) => (
-            <label key={opt.value} className="flex items-center gap-1">
-              <input
-                type="radio"
-                name={field.name}
-                value={opt.value}
-                checked={value === opt.value}
-                onChange={() => setValue(opt.value)}
-                required={field.required}
-              />
-              {opt.label}
-            </label>
-          ))}
+          {field.options?.map((opt) => {
+            const optionId = `${inputId}-${String(opt.value)
+              .toLowerCase()
+              .replace(/[^a-z0-9а-яё]+/gi, "-")
+              .replace(/-+/g, "-")
+              .replace(/^-|-$/g, "")}`;
+            return (
+              <label
+                key={opt.value}
+                className="flex items-center gap-1"
+                htmlFor={optionId}
+              >
+                <input
+                  type="radio"
+                  name={field.name}
+                  id={optionId}
+                  value={opt.value}
+                  checked={value === opt.value}
+                  onChange={() => setValue(opt.value)}
+                  required={field.required}
+                />
+                {opt.label}
+              </label>
+            );
+          })}
         </div>
       );
     default:
@@ -163,27 +182,39 @@ const TaskFormModern: React.FC<TaskFormModernProps> = ({
       {formSchema.sections.map((section) => (
         <div key={section.name} className="space-y-4">
           <h2 className="text-lg font-semibold">{section.label}</h2>
-          {section.fields.map((field) => (
-            <div key={field.name} className="space-y-1">
-              <label className="block text-sm font-medium">{field.label}</label>
-              {renderField(field, data[field.name] ?? "", (v) =>
-                setField(field.name, v),
-              )}
-            </div>
-          ))}
+          {section.fields.map((field) => {
+            const fieldId = `task-${field.name}`;
+            return (
+              <div key={field.name} className="space-y-1">
+                <label className="block text-sm font-medium" htmlFor={fieldId}>
+                  {field.label}
+                </label>
+                {renderField(field, data[field.name] ?? "", (v) =>
+                  setField(field.name, v),
+                  fieldId,
+                )}
+              </div>
+            );
+          })}
         </div>
       ))}
       {customFields.length > 0 && (
         <div className="space-y-4">
           <h2 className="text-lg font-semibold">Дополнительно</h2>
-          {customFields.map((field) => (
-            <div key={field.name} className="space-y-1">
-              <label className="block text-sm font-medium">{field.label}</label>
-              {renderField(field, data[field.name] ?? "", (v) =>
-                setField(field.name, v),
-              )}
-            </div>
-          ))}
+          {customFields.map((field) => {
+            const fieldId = `task-${field.name}`;
+            return (
+              <div key={field.name} className="space-y-1">
+                <label className="block text-sm font-medium" htmlFor={fieldId}>
+                  {field.label}
+                </label>
+                {renderField(field, data[field.name] ?? "", (v) =>
+                  setField(field.name, v),
+                  fieldId,
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
       <div className="flex flex-wrap gap-2">

--- a/apps/web/src/components/TaskTable.tsx
+++ b/apps/web/src/components/TaskTable.tsx
@@ -77,8 +77,13 @@ export default function TaskTable({
         toolbarChildren={
           <>
             {typeof onMineChange === "function" && (
-              <label className="flex items-center gap-1 text-sm">
+              <label
+                className="flex items-center gap-1 text-sm"
+                htmlFor="task-table-mine"
+              >
                 <input
+                  id="task-table-mine"
+                  name="mineTasks"
                   type="checkbox"
                   checked={mine}
                   onChange={(e) => onMineChange(e.target.checked)}

--- a/apps/web/src/components/ThemePanel.tsx
+++ b/apps/web/src/components/ThemePanel.tsx
@@ -23,6 +23,8 @@ export default function ThemePanel() {
         <span className="mr-2">Основной</span>
         <input
           type="color"
+          id="theme-primary"
+          name="themePrimary"
           value={local.primary}
           onChange={(e) => change("primary", e.target.value)}
         />
@@ -31,6 +33,8 @@ export default function ThemePanel() {
         <span className="mr-2">Фон</span>
         <input
           type="color"
+          id="theme-background"
+          name="themeBackground"
           value={local.background}
           onChange={(e) => change("background", e.target.value)}
         />

--- a/apps/web/src/components/a11y/TaskForm.tsx
+++ b/apps/web/src/components/a11y/TaskForm.tsx
@@ -52,16 +52,23 @@ export function TaskForm({ customFields = [] }: TaskFormProps) {
 }
 
 const renderField = (field: Field) => {
+  const fieldId = `task-form-${field.name}`;
   switch (field.type) {
     case "text":
       return (
-        <input className="input" name={field.name} required={field.required} />
+        <input
+          id={fieldId}
+          className="input"
+          name={field.name}
+          required={field.required}
+        />
       );
     case "datetime":
       return (
         <input
           type="datetime-local"
           className="input"
+          id={fieldId}
           name={field.name}
           required={field.required}
         />
@@ -70,6 +77,7 @@ const renderField = (field: Field) => {
       return (
         <select
           className="input select"
+          id={fieldId}
           name={field.name}
           required={field.required}
         >
@@ -81,7 +89,13 @@ const renderField = (field: Field) => {
         </select>
       );
     case "textarea":
-      return <textarea className="input min-h-[120px]" name={field.name} />;
+      return (
+        <textarea
+          className="input min-h-[120px]"
+          id={fieldId}
+          name={field.name}
+        />
+      );
     default:
       return null;
   }

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -9,17 +9,25 @@ import { cn } from "@/lib/utils";
 export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type = "text", ...props }, ref) => (
-    <input
-      type={type}
-      ref={ref}
-      className={cn(
-        "border-input bg-background placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 flex h-9 w-full rounded-md border px-4 py-2 text-sm shadow-xs transition-colors focus-visible:ring-[3px] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
-        className,
-      )}
-      {...props}
-    />
-  ),
+  ({ className, type = "text", id, name, ...props }, ref) => {
+    const autoId = React.useId();
+    const resolvedId = id ?? name ?? `input-${autoId}`;
+    const resolvedName = name ?? id ?? `input-${autoId}`;
+
+    return (
+      <input
+        type={type}
+        ref={ref}
+        id={resolvedId}
+        name={resolvedName}
+        className={cn(
+          "border-input bg-background placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 flex h-9 w-full rounded-md border px-4 py-2 text-sm shadow-xs transition-colors focus-visible:ring-[3px] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
 );
 Input.displayName = "Input";
 

--- a/apps/web/src/hooks/useDueDateOffset.test.tsx
+++ b/apps/web/src/hooks/useDueDateOffset.test.tsx
@@ -29,9 +29,14 @@ describe("useDueDateOffset", () => {
       });
       return (
         <form onSubmit={handleSubmit(submitSpy)}>
-          <input data-testid="start" {...register("startDate")} />
+          <input
+            data-testid="start"
+            id="test-start-date"
+            {...register("startDate")}
+          />
           <input
             data-testid="due"
+            id="test-due-date"
             {...register("dueDate", { onChange: handleDueDateChange })}
           />
           <button type="submit">Отправить</button>

--- a/apps/web/src/pages/CodeLogin.tsx
+++ b/apps/web/src/pages/CodeLogin.tsx
@@ -49,6 +49,8 @@ export default function CodeLogin() {
   return (
     <form className="flex flex-col gap-2 p-4" onSubmit={sent ? verify : send}>
       <input
+        id="code-login-telegram-id"
+        name="telegramId"
         className="border p-2"
         placeholder="Telegram ID"
         value={telegramId}
@@ -64,6 +66,8 @@ export default function CodeLogin() {
       </a>
       {sent && (
         <input
+          id="code-login-code"
+          name="verificationCode"
           className="border p-2"
           placeholder="Код"
           value={code}

--- a/apps/web/src/pages/Profile.tsx
+++ b/apps/web/src/pages/Profile.tsx
@@ -196,6 +196,7 @@ export default function Profile() {
             <label className="space-y-1 md:col-span-2">
               <span className="block text-sm font-medium">ФИО</span>
               <input
+                name="fullName"
                 className="h-10 w-full rounded border px-3"
                 value={form.name}
                 onChange={(e) => updateField("name", e.target.value)}
@@ -205,6 +206,7 @@ export default function Profile() {
             <label className="space-y-1">
               <span className="block text-sm font-medium">Телефон</span>
               <input
+                name="phone"
                 className="h-10 w-full rounded border px-3"
                 value={form.phone}
                 onChange={(e) => updateField("phone", e.target.value)}
@@ -215,6 +217,7 @@ export default function Profile() {
             <label className="space-y-1">
               <span className="block text-sm font-medium">Email</span>
               <input
+                name="email"
                 className="h-10 w-full rounded border px-3"
                 value={form.email}
                 onChange={(e) => updateField("email", e.target.value)}
@@ -225,6 +228,7 @@ export default function Profile() {
             <label className="space-y-1">
               <span className="block text-sm font-medium">Доп. телефон</span>
               <input
+                name="additionalPhone"
                 className="h-10 w-full rounded border bg-gray-100 px-3 text-gray-600"
                 value={additionalPhone}
                 readOnly
@@ -234,6 +238,7 @@ export default function Profile() {
             <label className="space-y-1">
               <span className="block text-sm font-medium">Telegram ID</span>
               <input
+                name="telegramId"
                 className="h-10 w-full rounded border bg-gray-100 px-3 text-gray-600"
                 value={telegramId}
                 readOnly
@@ -243,6 +248,7 @@ export default function Profile() {
             <label className="space-y-1">
               <span className="block text-sm font-medium">Username</span>
               <input
+                name="telegramUsername"
                 className="h-10 w-full rounded border bg-gray-100 px-3 text-gray-600"
                 value={telegramUsername}
                 readOnly
@@ -252,6 +258,7 @@ export default function Profile() {
             <label className="space-y-1">
               <span className="block text-sm font-medium">Роль</span>
               <input
+                name="role"
                 className="h-10 w-full rounded border bg-gray-100 px-3 text-gray-600"
                 value={roleLabel}
                 readOnly
@@ -261,6 +268,7 @@ export default function Profile() {
             <label className="space-y-1">
               <span className="block text-sm font-medium">Департамент</span>
               <input
+                name="department"
                 className="h-10 w-full rounded border bg-gray-100 px-3 text-gray-600"
                 value={departmentName || "—"}
                 readOnly
@@ -270,6 +278,7 @@ export default function Profile() {
             <label className="space-y-1">
               <span className="block text-sm font-medium">Отдел</span>
               <input
+                name="division"
                 className="h-10 w-full rounded border bg-gray-100 px-3 text-gray-600"
                 value={divisionName || "—"}
                 readOnly
@@ -279,6 +288,7 @@ export default function Profile() {
             <label className="space-y-1">
               <span className="block text-sm font-medium">Должность</span>
               <input
+                name="position"
                 className="h-10 w-full rounded border bg-gray-100 px-3 text-gray-600"
                 value={positionName || "—"}
                 readOnly

--- a/apps/web/src/pages/Routes.tsx
+++ b/apps/web/src/pages/Routes.tsx
@@ -395,8 +395,13 @@ export default function RoutesPage() {
             >
               {vehiclesLoading ? "Загрузка..." : "Обновить технику"}
             </Button>
-            <label className="flex items-center gap-1 text-sm">
+            <label
+              className="flex items-center gap-1 text-sm"
+              htmlFor="routes-with-track"
+            >
               <input
+                id="routes-with-track"
+                name="withTrack"
                 type="checkbox"
                 className="size-4"
                 checked={withTrack}
@@ -404,8 +409,13 @@ export default function RoutesPage() {
               />
               <span>Показывать трек (1 час)</span>
             </label>
-            <label className="flex items-center gap-1 text-sm">
+            <label
+              className="flex items-center gap-1 text-sm"
+              htmlFor="routes-auto-refresh"
+            >
               <input
+                id="routes-auto-refresh"
+                name="autoRefresh"
                 type="checkbox"
                 className="size-4"
                 checked={autoRefresh}

--- a/apps/web/src/pages/Settings/CollectionForm.tsx
+++ b/apps/web/src/pages/Settings/CollectionForm.tsx
@@ -52,6 +52,8 @@ export default function CollectionForm({
       <div>
         <label className="block text-sm font-medium">Имя</label>
         <input
+          id="collection-form-name"
+          name="collectionName"
           className="h-10 w-full rounded border px-3"
           value={form.name}
           onChange={(e) => onChange({ ...form, name: e.target.value })}
@@ -67,6 +69,8 @@ export default function CollectionForm({
           })
         ) : (
           <input
+            id="collection-form-value"
+            name="collectionValue"
             className="h-10 w-full rounded border px-3"
             value={form.value}
             onChange={(e) => onChange({ ...form, value: e.target.value })}

--- a/apps/web/src/pages/Settings/CollectionList.tsx
+++ b/apps/web/src/pages/Settings/CollectionList.tsx
@@ -30,6 +30,7 @@ export default function CollectionList({
   searchValue,
 }: Props) {
   const [search, setSearch] = React.useState(searchValue ?? "");
+  const searchInputId = React.useId();
 
   React.useEffect(() => {
     setSearch(searchValue ?? "");
@@ -47,6 +48,8 @@ export default function CollectionList({
         className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center"
       >
         <input
+          id={searchInputId}
+          name="collectionSearch"
           className="h-10 w-full rounded border px-3 sm:h-9 sm:flex-1"
           value={search}
           onChange={(e) => setSearch(e.target.value)}

--- a/apps/web/src/pages/Settings/CollectionsPage.test.tsx
+++ b/apps/web/src/pages/Settings/CollectionsPage.test.tsx
@@ -233,6 +233,8 @@ jest.mock("./CollectionForm", () => ({
     >
       <input
         data-testid="collection-name"
+        id="test-collection-name"
+        name="collectionName"
         value={form?.name ?? ""}
         onChange={(event) =>
           onChange({ ...(form ?? { name: "", value: "" }), name: event.target.value })
@@ -241,6 +243,8 @@ jest.mock("./CollectionForm", () => ({
       />
       <input
         data-testid="collection-value"
+        id="test-collection-value"
+        name="collectionValue"
         value={form?.value ?? ""}
         onChange={(event) =>
           onChange({ ...(form ?? { name: "", value: "" }), value: event.target.value })

--- a/apps/web/src/pages/Settings/CollectionsPage.tsx
+++ b/apps/web/src/pages/Settings/CollectionsPage.tsx
@@ -1120,6 +1120,8 @@ export default function CollectionsPage() {
                     <label className="flex flex-col gap-1 sm:w-64 lg:w-full lg:min-w-0">
                       <span className="text-sm font-medium">Поиск</span>
                       <input
+                        id="settings-users-search"
+                        name="userSearch"
                         className="h-10 w-full rounded border px-3 text-sm lg:h-9 lg:text-xs"
                         value={userSearchDraft}
                         onChange={(event) => setUserSearchDraft(event.target.value)}
@@ -1166,6 +1168,8 @@ export default function CollectionsPage() {
                     <label className="flex flex-col gap-1 sm:w-64 lg:w-full lg:min-w-0">
                       <span className="text-sm font-medium">Поиск</span>
                       <input
+                        id="settings-employees-search"
+                        name="employeeSearch"
                         className="h-10 w-full rounded border px-3 text-sm lg:h-9 lg:text-xs"
                         value={userSearchDraft}
                         onChange={(event) => setUserSearchDraft(event.target.value)}
@@ -1214,6 +1218,8 @@ export default function CollectionsPage() {
                     <label className="flex flex-col gap-1 sm:w-64 lg:w-full lg:min-w-0">
                       <span className="text-sm font-medium">Поиск</span>
                       <input
+                        id="settings-collections-search"
+                        name="collectionSearch"
                         className="h-10 w-full rounded border px-3 text-sm lg:h-9 lg:text-xs"
                         value={currentSearchDraft}
                         onChange={(event) =>

--- a/apps/web/src/pages/Settings/FleetVehicleDialog.tsx
+++ b/apps/web/src/pages/Settings/FleetVehicleDialog.tsx
@@ -172,6 +172,8 @@ export default function FleetVehicleDialog({
         <label className="flex flex-col gap-1">
           <span className="text-sm font-medium">Название</span>
           <input
+            id="fleet-vehicle-name"
+            name="name"
             className="h-10 w-full rounded border px-3"
             value={form.name}
             onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
@@ -182,6 +184,8 @@ export default function FleetVehicleDialog({
         <label className="flex flex-col gap-1">
           <span className="text-sm font-medium">Регистрационный номер</span>
           <input
+            id="fleet-vehicle-registration"
+            name="registrationNumber"
             className="h-10 w-full rounded border px-3 uppercase"
             value={form.registrationNumber}
             onChange={(event) =>
@@ -195,6 +199,8 @@ export default function FleetVehicleDialog({
         <label className="flex flex-col gap-1">
           <span className="text-sm font-medium">Тип транспорта</span>
           <select
+            id="fleet-vehicle-transport-type"
+            name="transportType"
             className="h-10 w-full rounded border px-3"
             value={form.transportType}
             onChange={(event) =>
@@ -212,6 +218,8 @@ export default function FleetVehicleDialog({
           <input
             type="number"
             min="0"
+            id="fleet-vehicle-odometer-initial"
+            name="odometerInitial"
             className="h-10 w-full rounded border px-3"
             value={form.odometerInitial}
             onChange={(event) =>
@@ -226,6 +234,8 @@ export default function FleetVehicleDialog({
           <input
             type="number"
             min="0"
+            id="fleet-vehicle-odometer-current"
+            name="odometerCurrent"
             className="h-10 w-full rounded border px-3"
             value={form.odometerCurrent}
             onChange={(event) =>
@@ -240,6 +250,8 @@ export default function FleetVehicleDialog({
           <input
             type="number"
             min="0"
+            id="fleet-vehicle-mileage-total"
+            name="mileageTotal"
             className="h-10 w-full rounded border px-3"
             value={form.mileageTotal}
             onChange={(event) =>
@@ -252,6 +264,8 @@ export default function FleetVehicleDialog({
         <label className="flex flex-col gap-1">
           <span className="text-sm font-medium">Вид топлива</span>
           <select
+            id="fleet-vehicle-fuel-type"
+            name="fuelType"
             className="h-10 w-full rounded border px-3"
             value={form.fuelType}
             onChange={(event) =>
@@ -268,6 +282,8 @@ export default function FleetVehicleDialog({
           <input
             type="number"
             min="0"
+            id="fleet-vehicle-fuel-refilled"
+            name="fuelRefilled"
             className="h-10 w-full rounded border px-3"
             value={form.fuelRefilled}
             onChange={(event) =>
@@ -283,6 +299,8 @@ export default function FleetVehicleDialog({
             type="number"
             min="0"
             step="0.01"
+            id="fleet-vehicle-fuel-average"
+            name="fuelAverageConsumption"
             className="h-10 w-full rounded border px-3"
             value={form.fuelAverageConsumption}
             onChange={(event) =>
@@ -297,6 +315,8 @@ export default function FleetVehicleDialog({
           <input
             type="number"
             min="0"
+            id="fleet-vehicle-fuel-spent"
+            name="fuelSpentTotal"
             className="h-10 w-full rounded border px-3"
             value={form.fuelSpentTotal}
             onChange={(event) =>
@@ -310,6 +330,8 @@ export default function FleetVehicleDialog({
       <label className="flex flex-col gap-1">
         <span className="text-sm font-medium">Текущие задачи (ID через запятую или перенос строки)</span>
         <textarea
+          id="fleet-vehicle-current-tasks"
+          name="currentTasks"
           className="min-h-[5rem] w-full rounded border px-3 py-2"
           value={form.currentTasks}
           onChange={(event) =>

--- a/apps/web/src/pages/Settings/FleetVehiclesTab.tsx
+++ b/apps/web/src/pages/Settings/FleetVehiclesTab.tsx
@@ -255,6 +255,8 @@ export default function FleetVehiclesTab() {
           <label className="flex w-full flex-col gap-1 sm:w-64 lg:w-full lg:min-w-0">
             <span className="text-sm font-medium">Поиск</span>
             <input
+              id="fleet-vehicles-search"
+              name="fleetVehicleSearch"
               className="h-10 w-full rounded border px-3 text-sm lg:h-9 lg:text-xs"
               value={search}
               onChange={(event) => setSearch(event.target.value)}

--- a/apps/web/src/pages/Settings/UserForm.tsx
+++ b/apps/web/src/pages/Settings/UserForm.tsx
@@ -78,6 +78,8 @@ export default function UserForm({ form, onChange, onSubmit, onReset }: Props) {
       <div>
         <label className="block text-sm font-medium">ID</label>
         <input
+          id="settings-user-telegram-id"
+          name="telegramId"
           className="h-10 w-full rounded border px-3"
           value={form.telegram_id ?? ""}
           onChange={(e) =>
@@ -93,6 +95,8 @@ export default function UserForm({ form, onChange, onSubmit, onReset }: Props) {
       <div>
         <label className="block text-sm font-medium">Username</label>
         <input
+          id="settings-user-username"
+          name="username"
           className="h-10 w-full rounded border px-3"
           value={form.username || ""}
           onChange={(e) => onChange({ ...form, username: e.target.value })}
@@ -102,6 +106,8 @@ export default function UserForm({ form, onChange, onSubmit, onReset }: Props) {
       <div>
         <label className="block text-sm font-medium">Имя</label>
         <input
+          id="settings-user-name"
+          name="name"
           className="h-10 w-full rounded border px-3"
           value={form.name || ""}
           onChange={(e) => onChange({ ...form, name: e.target.value })}
@@ -110,6 +116,8 @@ export default function UserForm({ form, onChange, onSubmit, onReset }: Props) {
       <div>
         <label className="block text-sm font-medium">Телефон</label>
         <input
+          id="settings-user-phone"
+          name="phone"
           className="h-10 w-full rounded border px-3"
           value={form.phone || ""}
           onChange={(e) => onChange({ ...form, phone: e.target.value })}
@@ -118,6 +126,8 @@ export default function UserForm({ form, onChange, onSubmit, onReset }: Props) {
       <div>
         <label className="block text-sm font-medium">Доп. телефон</label>
         <input
+          id="settings-user-mob"
+          name="mobNumber"
           className="h-10 w-full rounded border px-3"
           value={form.mobNumber || ""}
           onChange={(e) => onChange({ ...form, mobNumber: e.target.value })}
@@ -126,6 +136,8 @@ export default function UserForm({ form, onChange, onSubmit, onReset }: Props) {
       <div>
         <label className="block text-sm font-medium">Email</label>
         <input
+          id="settings-user-email"
+          name="email"
           className="h-10 w-full rounded border px-3"
           value={form.email || ""}
           onChange={(e) => onChange({ ...form, email: e.target.value })}

--- a/apps/web/src/pages/Storage.tsx
+++ b/apps/web/src/pages/Storage.tsx
@@ -134,6 +134,16 @@ export default function StoragePage() {
     return Array.from(types).sort((a, b) => a.localeCompare(b));
   }, [files]);
 
+  const sanitizeId = React.useCallback(
+    (value: string) =>
+      value
+        .toLowerCase()
+        .replace(/[^a-z0-9а-яё]+/gi, "-")
+        .replace(/-+/g, "-")
+        .replace(/^-|-$/g, ""),
+    [],
+  );
+
   const applyFilters = React.useCallback(() => {
     setPageIndex(0);
     setFilters({ ...draftFilters });
@@ -332,9 +342,16 @@ export default function StoragePage() {
               )}
               {userOptions.map((id) => {
                 const checked = draftFilters.userId === id;
+                const fieldId = `storage-user-${sanitizeId(String(id))}`;
                 return (
-                  <label key={id} className="flex items-center gap-2 text-sm">
+                  <label
+                    key={id}
+                    className="flex items-center gap-2 text-sm"
+                    htmlFor={fieldId}
+                  >
                     <input
+                      id={fieldId}
+                      name="storageUser"
                       type="checkbox"
                       checked={checked}
                       onChange={() =>
@@ -362,9 +379,16 @@ export default function StoragePage() {
               )}
               {typeOptions.map((type) => {
                 const checked = draftFilters.type === type;
+                const fieldId = `storage-type-${sanitizeId(type)}`;
                 return (
-                  <label key={type} className="flex items-center gap-2 text-sm">
+                  <label
+                    key={type}
+                    className="flex items-center gap-2 text-sm"
+                    htmlFor={fieldId}
+                  >
                     <input
+                      id={fieldId}
+                      name="storageType"
                       type="checkbox"
                       checked={checked}
                       onChange={() =>

--- a/apps/web/src/pages/Tasks.tsx
+++ b/apps/web/src/pages/Tasks.tsx
@@ -63,6 +63,8 @@ export default function Tasks() {
       )}
       <form onSubmit={add} className="flex flex-wrap gap-2">
         <input
+          id="task-create-description"
+          name="taskDescription"
           value={text}
           onChange={(e) => setText(e.target.value)}
           required


### PR DESCRIPTION
## Что сделано
- добавлены гарантированные `id` и `name` в базовый компонент `<Input>` и большинство формовых полей, чтобы браузеры корректно распознавали элементы
- обновлены сложные формы (диалог задачи, фильтры логов, поиск по коллекциям и хранилищу) с уникальными идентификаторами и атрибутами для чекбоксов, радиокнопок и текстовых полей
- внедрена очистка значений для составных идентификаторов в динамических списках (поиск и фильтры) во избежание некорректных `id`

## Почему
- аудиты выявляли многочисленные поля без `id`/`name`, что мешало автозаполнению и ухудшало доступность; явные атрибуты устраняют проблему

## Чек-лист
- [x] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm run dev`

## Логи
- `pnpm lint`

## Самопроверка
- [x] Проверены уникальные идентификаторы в динамических списках
- [x] Подтверждено отсутствие конфликтов `name`/`id` в ключевых формах
- [x] Просмотрены основные пользовательские сценарии на предмет регрессий атрибутов

------
https://chatgpt.com/codex/tasks/task_b_68e4d944051c8320bbfb1f8b466b0d03