### PR TITLE
fix: stabilize task summary test typing

### DIFF
--- a/tests/tasks.summaryMessage.spec.ts
+++ b/tests/tasks.summaryMessage.spec.ts
@@ -53,7 +53,22 @@ describe('updateTaskStatusSummary', () => {
 
   it('не создаёт новое сообщение при ответе message is not modified', async () => {
     const controller = new TasksController({} as any);
-    const task = {
+    type TaskStub = {
+      _id: string;
+      task_number: string;
+      telegram_summary_message_id: number;
+      telegram_message_id: number;
+      history: Array<{
+        changed_at: string;
+        changed_by: number;
+        changes: {
+          from: { status: string };
+          to: { status: string };
+        };
+      }>;
+    };
+
+    const task: TaskStub = {
       _id: '507f1f77bcf86cd799439011',
       task_number: 'ERM-100',
       telegram_summary_message_id: 321,
@@ -77,7 +92,7 @@ describe('updateTaskStatusSummary', () => {
     editMessageTextMock.mockRejectedValueOnce(notModifiedError);
 
     await (controller as unknown as {
-      updateTaskStatusSummary(task: typeof task): Promise<void>;
+      updateTaskStatusSummary(task: TaskStub): Promise<void>;
     }).updateTaskStatusSummary(task);
 
     expect(editMessageTextMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Что изменено
- добавил явный тип `TaskStub` в тест `tests/tasks.summaryMessage.spec.ts`
- обновил обращение к приватному методу контроллера так, чтобы не ссылаться на переменную `task` в типе

## Почему
- TypeScript-тайпчекер падал из-за самоссылки `typeof task`

## Чек-лист
- [x] Тесты
- [ ] Линтер
- [ ] Сборка
- [x] Обратная совместимость сохранена

## Логи
- `pnpm test:unit -- tests/tasks.summaryMessage.spec.ts`

## Самопроверка
- [x] Убедился, что новый тип не конфликтует с ожидаемыми полями метода
- [x] Проверил, что мок-объект соответствует сигнатуре контроллера

## Примечания по рискам
- минимальные: изменение касается только теста

------
https://chatgpt.com/codex/tasks/task_b_68e5053623948320815dbe16df0854dd