### PR TITLE
fix(bot): avoid duplicating history messages

### DIFF
--- a/apps/api/src/bot/bot.ts
+++ b/apps/api/src/bot/bot.ts
@@ -855,23 +855,11 @@ async function processStatusAction(
               }
             }
           } else {
-            const options: NonNullable<
-              Parameters<typeof bot.telegram.sendMessage>[2]
-            > = {
-              parse_mode: 'MarkdownV2',
-              link_preview_options: { is_disabled: true },
-            };
-            if (typeof topicId === 'number') {
-              options.message_thread_id = topicId;
-            }
-            const statusMessage = await bot.telegram.sendMessage(
-              chatId,
-              text,
-              options,
+            console.warn(
+              'Пропущено обновление истории статусов: отсутствует message_id для задачи',
+              docId,
+              topicId,
             );
-            if (statusMessage?.message_id) {
-              await updateTaskHistoryMessageId(docId, statusMessage.message_id);
-            }
           }
         }
       } catch (error) {

--- a/tests/bot.status-history.spec.ts
+++ b/tests/bot.status-history.spec.ts
@@ -244,7 +244,7 @@ test('редактирует существующее сообщение ист�
   expect(updateTaskHistoryMessageIdMock).toHaveBeenCalledWith('task123', 777);
 });
 
-test('создаёт новое сообщение истории и сохраняет идентификатор', async () => {
+test('пропускает отправку истории без сохранённого идентификатора', async () => {
   updateTaskStatusMock.mockResolvedValue({ _id: 'task999' });
   getTaskHistoryMessageMock.mockResolvedValue({
     taskId: 'task999',
@@ -252,23 +252,14 @@ test('создаёт новое сообщение истории и сохра�
     topicId: 55,
     text: '*История изменений*\n• новое событие',
   });
-  sendMessageMock.mockResolvedValue({ message_id: 31337 });
   const ctx = createContext('task_accept_confirm:task999') as Parameters<
     typeof processStatusAction
   >[0];
 
   await processStatusAction(ctx, 'В работе', 'Принято');
 
-  expect(sendMessageMock).toHaveBeenCalledWith(
-    -1001234567890,
-    '*История изменений*\n• новое событие',
-    {
-      parse_mode: 'MarkdownV2',
-      message_thread_id: 55,
-      link_preview_options: { is_disabled: true },
-    },
-  );
-  expect(updateTaskHistoryMessageIdMock).toHaveBeenCalledWith('task999', 31337);
+  expect(sendMessageMock).not.toHaveBeenCalled();
+  expect(updateTaskHistoryMessageIdMock).not.toHaveBeenCalled();
   expect(editMessageTextMock).not.toHaveBeenCalled();
 });
 
@@ -314,23 +305,22 @@ test('не редактирует клавиатуру при повторном
   expect(updateTaskStatusMock).toHaveBeenCalledWith('task123', 'В работе', 42);
 });
 
-test('при завершении задачи отправляет только обновлённую историю', async () => {
+test('при завершении задачи пропускает отправку истории без message_id', async () => {
   updateTaskStatusMock.mockResolvedValue({ _id: 'task777' });
   getTaskHistoryMessageMock.mockResolvedValue({
     taskId: 'task777',
     messageId: null,
     text: '*История изменений*\\n• завершение',
   });
-  sendMessageMock.mockResolvedValue({ message_id: 451 });
   const ctx = createContext('task_done_confirm:task777') as Parameters<
     typeof processStatusAction
   >[0];
 
   await processStatusAction(ctx, 'Выполнена', 'Сделано');
 
-  expect(sendMessageMock).toHaveBeenCalledTimes(1);
+  expect(sendMessageMock).not.toHaveBeenCalled();
   expect(editMessageTextMock).not.toHaveBeenCalled();
-  expect(updateTaskHistoryMessageIdMock).toHaveBeenCalledWith('task777', 451);
+  expect(updateTaskHistoryMessageIdMock).not.toHaveBeenCalled();
 });
 
 describe('обработка завершения задачи', () => {


### PR DESCRIPTION
## Что сделано
- Убрана отправка нового сообщения истории при отсутствии сохранённого message_id в чат-боте.
- Обновлены модульные тесты бота, чтобы покрыть новый сценарий без fallback на sendMessage.

## Почему
- Первое обновление статуса создавало лишнее сообщение в общем чате, которое дублировало карточку задачи и отвлекало пользователей.

## Чек-лист
- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Обратная совместимость сохранена

## Логи
- `pnpm lint`
- `pnpm test`

## Самопроверка
- [x] Бот не создаёт новые сообщения истории без message_id
- [x] Консольное предупреждение покрывает пропуск обновления
- [x] Тесты отражают новую логику

## Риски и откат
- Риск: пропуск обновления истории при отсутствии message_id. Откат: вернуть sendMessage и выполнить миграцию message_id для задач без него.


------
https://chatgpt.com/codex/tasks/task_b_68e52dc76108832098ad2e5711dac285