### PR TITLE
fix: remove unused updateTaskHistoryMessageId import

### DIFF
--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -36,7 +36,6 @@ import buildChatMessageLink from '../utils/messageLink';
 import { uploadsDir } from '../config/storage';
 import {
   getTaskHistoryMessage,
-  updateTaskHistoryMessageId,
   updateTaskSummaryMessageId,
 } from './taskHistory.service';
 import escapeMarkdownV2 from '../utils/mdEscape';


### PR DESCRIPTION
## Summary
- remove the unused updateTaskHistoryMessageId import from the tasks controller to satisfy eslint

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68e53b7172808320ba09c4cfb47023b6