### PR TITLE
fix: register bot instance for task sync controller

### DIFF
--- a/apps/api/src/controllers/taskSync.controller.ts
+++ b/apps/api/src/controllers/taskSync.controller.ts
@@ -1,9 +1,10 @@
 // Назначение: синхронизация задач между вебом и Telegram
 // Основные модули: bot, config, db/model, db/queries, services/service, tasks/taskHistory.service, utils/formatTask, utils/taskButtons
 import 'reflect-metadata';
-import { injectable } from 'tsyringe';
+import { injectable, inject } from 'tsyringe';
 import type { Context, Telegraf } from 'telegraf';
 import type { TaskDocument } from '../db/model';
+import { TOKENS } from '../di/tokens';
 import { Task } from '../db/model';
 import { chatId } from '../config';
 import { getTask, updateTaskStatus } from '../services/service';
@@ -109,7 +110,9 @@ const loadTaskPlain = async (
 
 @injectable()
 export default class TaskSyncController {
-  constructor(private readonly bot: Telegraf<Context>) {}
+  constructor(
+    @inject(TOKENS.BotInstance) private readonly bot: Telegraf<Context>,
+  ) {}
 
   async onWebTaskUpdate(
     taskId: string,

--- a/apps/api/src/di/index.ts
+++ b/apps/api/src/di/index.ts
@@ -39,9 +39,8 @@ container.register(TOKENS.MapsService, { useValue: maps });
 container.register(TOKENS.TelegramApi, { useValue: telegram });
 container.register(TOKENS.SchedulerService, { useValue: scheduler });
 container.register(TOKENS.TmaAuthGuard, { useValue: tmaAuthGuard });
-container.register(TOKENS.TaskSyncController, {
-  useFactory: () => new TaskSyncController(bot),
-});
+container.register(TOKENS.BotInstance, { useValue: bot });
+container.registerSingleton(TOKENS.TaskSyncController, TaskSyncController);
 
 export { container };
 export default container;

--- a/apps/api/src/di/tokens.ts
+++ b/apps/api/src/di/tokens.ts
@@ -12,6 +12,7 @@ export const TOKENS = {
   TelegramApi: Symbol('TelegramApi'),
   SchedulerService: Symbol('SchedulerService'),
   TmaAuthGuard: Symbol('TmaAuthGuard'),
+  BotInstance: Symbol('BotInstance'),
   TaskSyncController: Symbol('TaskSyncController'),
 } as const;
 


### PR DESCRIPTION
## Что сделано и зачем
- Добавил отдельный DI-токен для экземпляра бота и зарегистрировал его, чтобы `TaskSyncController` получал зависимость из контейнера.
- Перевёл `TaskSyncController` на явный `@inject`, чтобы tsyringe не пытался выводить тип Telegraf и не падал в тестах.

## Чек-лист
- [ ] Тесты `pnpm test` (прервано из-за длительности в контейнере)
- [x] Линтер `pnpm lint`
- [ ] Сборка `pnpm build` (запускался частично; фронтенд сборка была остановлена из-за длительности)
- [x] Обратная совместимость сохранена

## Логи команд
- `pnpm lint`
- `pnpm --filter shared build`
- `pnpm --filter telegram-task-bot build`
- `pnpm --filter web build` (прервано из-за длительной сборки)
- `pnpm test -- --runTestsByPath tests/loginTasksFlow.test.ts tests/tasks.test.ts tests/rateLimit.test.ts tests/processUploads.test.ts` (прервано после части прогонов)

## Самопроверка
- [x] DI контейнер запускается без циклических зависимостей.
- [x] Контроллер задач получает синхронизатор через DI.
- [x] Бот по-прежнему создаёт синхронизатор напрямую при старте.
- [ ] Полный прогон тестов подтвердил изменения (не успел выполнить в контейнере).

------
https://chatgpt.com/codex/tasks/task_b_68e55d98346083208f567bdb1631d7d4