### PR TITLE
fix: ignore Telegram not modified errors in bot sync

### DIFF
--- a/apps/api/src/bot/bot.ts
+++ b/apps/api/src/bot/bot.ts
@@ -588,13 +588,19 @@ const syncTaskPresentation = async (
         link_preview_options: { is_disabled: true },
         ...(keyboard.reply_markup ? { reply_markup: keyboard.reply_markup } : {}),
       };
-      await bot.telegram.editMessageText(
-        chatId,
-        messageId,
-        undefined,
-        formatted.text,
-        options,
-      );
+      try {
+        await bot.telegram.editMessageText(
+          chatId,
+          messageId,
+          undefined,
+          formatted.text,
+          options,
+        );
+      } catch (error) {
+        if (!isMessageNotModifiedError(error)) {
+          throw error;
+        }
+      }
     }
     if (!TELEGRAM_SINGLE_HISTORY_MESSAGE) {
       const summaryId = toNumericId(
@@ -608,13 +614,19 @@ const syncTaskPresentation = async (
           const options: Parameters<typeof bot.telegram.editMessageText>[4] = {
             link_preview_options: { is_disabled: true },
           };
-          await bot.telegram.editMessageText(
-            chatId,
-            summaryId,
-            undefined,
-            summary,
-            options,
-          );
+          try {
+            await bot.telegram.editMessageText(
+              chatId,
+              summaryId,
+              undefined,
+              summary,
+              options,
+            );
+          } catch (error) {
+            if (!isMessageNotModifiedError(error)) {
+              throw error;
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Что сделано
- обернул обновление основного и сводного сообщений задачи в Telegram в обработчик ошибок
- игнорирую ответ API "message is not modified", чтобы не засорять логи без необходимости

## Почему
- платформа Telegram возвращает ошибку 400 при попытке повторно отправить тот же текст и клавиатуру, что ломает синхронизацию и зашумляет мониторинг

## Чек-лист
- [x] `pnpm lint`
- [x] `pnpm test -- --runTestsByPath tests/tasks.summaryMessage.spec.ts` (unit и API тесты прошли; pretest:e2e прерван вручную по таймауту в контейнере)
- [ ] `pnpm build` (не запускался)
- [x] Обратная совместимость сохранена

## Логи
- `pnpm lint`
- `pnpm test -- --runTestsByPath tests/tasks.summaryMessage.spec.ts`

## Самопроверка
- [x] Проверил, что ошибки Telegram 400 с текстом "message is not modified" глушатся
- [x] Убедился, что остальные ошибки по-прежнему логируются
- [x] Проверил отсутствие лишних изменений в репозитории

## Risk notes
- e2e прогон не завершён: pretest:e2e остановлен вручную, требуется повторить в CI или локально при необходимости


------
https://chatgpt.com/codex/tasks/task_b_68e5692bae48832095dcc23c62ba710b