### PR TITLE
feat: add task settings tab with telegram topics

### DIFF
--- a/apps/api/src/controllers/taskSync.controller.ts
+++ b/apps/api/src/controllers/taskSync.controller.ts
@@ -16,6 +16,7 @@ import {
   updateTaskHistoryMessageId,
 } from '../tasks/taskHistory.service';
 import type { Task as SharedTask, User } from 'shared';
+import { resolveTaskTypeTopicId } from '../services/taskTypeSettings';
 
 type UsersIndex = Record<number | string, Pick<User, 'name' | 'username'>>;
 
@@ -153,7 +154,10 @@ export default class TaskSyncController {
     if (!task) return;
 
     const messageId = toNumericId(task.telegram_message_id);
-    const topicId = toNumericId(task.telegram_topic_id);
+    const configuredTopicId = await resolveTaskTypeTopicId(task.task_type);
+    const topicId =
+      toNumericId(task.telegram_topic_id) ??
+      (typeof configuredTopicId === 'number' ? configuredTopicId : null);
     const status =
       typeof task.status === 'string'
         ? (task.status as SharedTask['status'])

--- a/apps/api/src/db/repos/collectionRepo.ts
+++ b/apps/api/src/db/repos/collectionRepo.ts
@@ -54,7 +54,46 @@ export async function update(
   id: string,
   data: Partial<CollectionItemAttrs>,
 ): Promise<CollectionItemDocument | null> {
-  return CollectionItem.findByIdAndUpdate(id, data, { new: true });
+  const set: Record<string, unknown> = {};
+  const unset: Record<string, unknown> = {};
+  if (Object.prototype.hasOwnProperty.call(data, 'type') && data.type !== undefined) {
+    set.type = data.type;
+  }
+  if (Object.prototype.hasOwnProperty.call(data, 'name')) {
+    if (data.name !== undefined) {
+      set.name = data.name;
+    } else {
+      unset.name = '';
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(data, 'value')) {
+    if (data.value !== undefined) {
+      set.value = data.value;
+    } else {
+      unset.value = '';
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(data, 'meta')) {
+    if (data.meta === undefined) {
+      unset.meta = '';
+    } else {
+      set.meta = data.meta;
+    }
+  }
+  const updatePayload: Record<string, unknown> = {};
+  if (Object.keys(set).length) {
+    updatePayload.$set = set;
+  }
+  if (Object.keys(unset).length) {
+    updatePayload.$unset = unset;
+  }
+  if (!Object.keys(updatePayload).length) {
+    return CollectionItem.findById(id);
+  }
+  return CollectionItem.findByIdAndUpdate(id, updatePayload, {
+    new: true,
+    runValidators: true,
+  });
 }
 
 export async function remove(

--- a/apps/api/src/services/taskTypeSettings.ts
+++ b/apps/api/src/services/taskTypeSettings.ts
@@ -1,0 +1,97 @@
+// Назначение файла: кеширование настроек типов задач и вычисление тем Telegram.
+// Основные модули: CollectionItem, parseTelegramTopicUrl.
+
+import { CollectionItem } from '../db/models/CollectionItem';
+import { parseTelegramTopicUrl } from '../utils/telegramTopics';
+
+type TaskTypeSetting = {
+  type: string;
+  displayName: string;
+  tg_theme_url?: string;
+  tg_chat_id?: string;
+  tg_topic_id?: number;
+};
+
+const CACHE_TTL_MS = 60_000;
+
+let cache: {
+  updatedAt: number;
+  data: Map<string, TaskTypeSetting>;
+} = { updatedAt: 0, data: new Map() };
+
+const normalizeTypeName = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  return trimmed;
+};
+
+const buildSetting = (doc: {
+  name?: unknown;
+  value?: unknown;
+  meta?: Record<string, unknown>;
+}): TaskTypeSetting | null => {
+  const type = normalizeTypeName(doc.name);
+  if (!type) {
+    return null;
+  }
+  const displayName = normalizeTypeName(doc.value) || type;
+  const rawUrl = doc.meta?.tg_theme_url;
+  const url = typeof rawUrl === 'string' ? rawUrl.trim() : '';
+  const parsed = url ? parseTelegramTopicUrl(url) : null;
+  return {
+    type,
+    displayName,
+    tg_theme_url: url || undefined,
+    tg_chat_id: parsed?.chatId,
+    tg_topic_id: parsed?.topicId,
+  };
+};
+
+const loadFromDatabase = async (): Promise<Map<string, TaskTypeSetting>> => {
+  const docs = await CollectionItem.find({ type: 'task_types' }).lean();
+  const pairs = docs
+    .map((doc) => buildSetting(doc))
+    .filter((value): value is TaskTypeSetting => Boolean(value))
+    .map((setting) => [setting.type, setting] as const);
+  return new Map(pairs);
+};
+
+export const invalidateTaskTypeSettingsCache = (): void => {
+  cache = { updatedAt: 0, data: new Map() };
+};
+
+const loadSettings = async (): Promise<Map<string, TaskTypeSetting>> => {
+  const now = Date.now();
+  if (now - cache.updatedAt < CACHE_TTL_MS && cache.data.size) {
+    return cache.data;
+  }
+  const data = await loadFromDatabase();
+  cache = { updatedAt: now, data };
+  return data;
+};
+
+export const resolveTaskTypeSetting = async (
+  taskType: unknown,
+): Promise<TaskTypeSetting | null> => {
+  const type = normalizeTypeName(taskType);
+  if (!type) {
+    return null;
+  }
+  const settings = await loadSettings();
+  return settings.get(type) ?? null;
+};
+
+export const resolveTaskTypeTopicId = async (
+  taskType: unknown,
+): Promise<number | undefined> => {
+  const setting = await resolveTaskTypeSetting(taskType);
+  return setting?.tg_topic_id;
+};
+
+export default {
+  resolveTaskTypeSetting,
+  resolveTaskTypeTopicId,
+  invalidateTaskTypeSettingsCache,
+};

--- a/apps/api/src/utils/telegramTopics.ts
+++ b/apps/api/src/utils/telegramTopics.ts
@@ -1,0 +1,61 @@
+// Назначение файла: парсинг ссылок на темы Telegram.
+// Основные модули: URL.
+
+const TELEGRAM_DOMAINS = new Set([
+  't.me',
+  'telegram.me',
+  'telegram.dog',
+]);
+
+const TOPIC_PATH_REGEXP = /^\/c\/(\d{1,20})\/(\d{1,20})(?:\/?|$)/;
+
+export interface TelegramTopicInfo {
+  chatId: string;
+  topicId: number;
+}
+
+const ensureUrl = (raw: string): URL | null => {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const hasProtocol = /^[a-z][a-z0-9+.-]*:/.test(trimmed);
+  const candidate = hasProtocol ? trimmed : `https://${trimmed}`;
+  try {
+    return new URL(candidate);
+  } catch {
+    return null;
+  }
+};
+
+export const parseTelegramTopicUrl = (
+  raw: unknown,
+): TelegramTopicInfo | null => {
+  if (typeof raw !== 'string') {
+    return null;
+  }
+  const url = ensureUrl(raw);
+  if (!url) {
+    return null;
+  }
+  const hostname = url.hostname.toLowerCase();
+  if (!TELEGRAM_DOMAINS.has(hostname)) {
+    return null;
+  }
+  const match = TOPIC_PATH_REGEXP.exec(url.pathname);
+  if (!match) {
+    return null;
+  }
+  const [, chatComponent, topicComponent] = match;
+  const topicId = Number(topicComponent);
+  if (!Number.isFinite(topicId)) {
+    return null;
+  }
+  const chatId = `-100${chatComponent}`;
+  if (!/^(-?\d{5,})$/.test(chatId)) {
+    return null;
+  }
+  return { chatId, topicId };
+};
+
+export default { parseTelegramTopicUrl };

--- a/apps/api/tests/telegramTopics.test.ts
+++ b/apps/api/tests/telegramTopics.test.ts
@@ -1,0 +1,26 @@
+// Назначение файла: проверка парсинга ссылок на темы Telegram.
+// Основные модули: parseTelegramTopicUrl.
+
+import { parseTelegramTopicUrl } from '../src/utils/telegramTopics';
+
+describe('parseTelegramTopicUrl', () => {
+  it('возвращает идентификаторы для корректной ссылки', () => {
+    const result = parseTelegramTopicUrl('https://t.me/c/2705661520/627');
+    expect(result).toEqual({ chatId: '-1002705661520', topicId: 627 });
+  });
+
+  it('игнорирует неизвестные домены', () => {
+    expect(parseTelegramTopicUrl('https://example.com/c/1/2')).toBeNull();
+  });
+
+  it('обрабатывает ссылки без протокола', () => {
+    const result = parseTelegramTopicUrl('t.me/c/123/456');
+    expect(result).toEqual({ chatId: '-100123', topicId: 456 });
+  });
+
+  it('возвращает null для некорректного формата', () => {
+    expect(parseTelegramTopicUrl('https://t.me/example')).toBeNull();
+    expect(parseTelegramTopicUrl('')).toBeNull();
+    expect(parseTelegramTopicUrl(null as unknown as string)).toBeNull();
+  });
+});

--- a/apps/web/src/locales/en/translation.json
+++ b/apps/web/src/locales/en/translation.json
@@ -16,6 +16,7 @@
       "invalidName": "Invalid item name",
       "invalidType": "Invalid collection type",
       "invalidValue": "Invalid item value",
+      "invalidTelegramTopicUrl": "Enter a topic link in the format https://t.me/c/<id>/<topic>",
       "nameRequired": "Item name is required",
       "typeRequired": "Collection type is required",
       "valueRequired": "Item value is required"

--- a/apps/web/src/locales/ru/translation.json
+++ b/apps/web/src/locales/ru/translation.json
@@ -16,6 +16,7 @@
       "invalidName": "Некорректное название элемента",
       "invalidType": "Некорректный тип коллекции",
       "invalidValue": "Некорректное значение элемента",
+      "invalidTelegramTopicUrl": "Введите ссылку на тему в формате https://t.me/c/<id>/<topic>",
       "nameRequired": "Название элемента обязательно",
       "typeRequired": "Тип коллекции обязателен",
       "valueRequired": "Заполните значение элемента"

--- a/apps/web/src/pages/Settings/CollectionsPage.test.tsx
+++ b/apps/web/src/pages/Settings/CollectionsPage.test.tsx
@@ -594,6 +594,65 @@ describe("CollectionsPage", () => {
     expect(headerTexts).toEqual(expectedHeaders);
   });
 
+  it("отображает настройки задач во вкладке 'Задачи'", async () => {
+    const fieldItems: CollectionItem[] = [
+      {
+        _id: "task-field-title",
+        type: "task_fields",
+        name: "title",
+        value: "Название",
+        meta: {
+          defaultLabel: "Название",
+          fieldType: "text",
+          order: 0,
+          virtual: false,
+        },
+      },
+    ];
+    const typeItems: CollectionItem[] = [
+      {
+        _id: "task-type-perform",
+        type: "task_types",
+        name: "Выполнить",
+        value: "Выполнить",
+        meta: {
+          defaultLabel: "Выполнить",
+          order: 0,
+          tg_theme_url: "https://t.me/c/2705661520/627",
+          tg_chat_id: "-1002705661520",
+          tg_topic_id: 627,
+          virtual: false,
+        },
+      },
+    ];
+
+    mockedFetchAll.mockImplementation(async (type: string) => {
+      if (type === "task_fields") return fieldItems;
+      if (type === "task_types") return typeItems;
+      const byType = dataset[type] ?? {};
+      const defaultEntry = byType[""] ?? { items: [] };
+      return (defaultEntry.items ?? []) as CollectionItem[];
+    });
+
+    render(<CollectionsPage />);
+
+    await screen.findByText("Главный департамент");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Задачи" }));
+
+    await waitFor(() =>
+      expect(mockedFetchAll).toHaveBeenCalledWith("task_fields"),
+    );
+
+    const tasksPanel = await screen.findByTestId("tab-content-tasks");
+    expect(
+      within(tasksPanel).getByLabelText("Название типа Выполнить"),
+    ).toBeInTheDocument();
+    expect(
+      within(tasksPanel).getByPlaceholderText("https://t.me/c/..."),
+    ).toBeInTheDocument();
+  });
+
   it("показывает фактический логин в таблице и карточке пользователя", async () => {
     const user: User = {
       telegram_id: 101,

--- a/apps/web/src/pages/Settings/TaskSettingsTab.tsx
+++ b/apps/web/src/pages/Settings/TaskSettingsTab.tsx
@@ -1,0 +1,532 @@
+// Назначение файла: вкладка настроек задач в разделе настроек.
+// Основные модули: React, Spinner, Button, Input.
+
+import React from "react";
+
+import Spinner from "../../components/Spinner";
+import { Button } from "../../components/ui/button";
+import { Input } from "../../components/ui/input";
+import type { CollectionItem } from "../../services/collections";
+
+type TaskFieldItem = CollectionItem & {
+  meta?: CollectionItem["meta"] & {
+    defaultLabel?: string;
+    fieldType?: string;
+    required?: boolean;
+    order?: number;
+    virtual?: boolean;
+  };
+};
+
+type TaskTypeItem = CollectionItem & {
+  meta?: CollectionItem["meta"] & {
+    defaultLabel?: string;
+    order?: number;
+    virtual?: boolean;
+    tg_theme_url?: string;
+    tg_chat_id?: string;
+    tg_topic_id?: number;
+  };
+};
+
+interface TaskSettingsTabProps {
+  fields: TaskFieldItem[];
+  types: TaskTypeItem[];
+  loading: boolean;
+  onRefresh: () => void;
+  onSaveField: (item: TaskFieldItem, label: string) => Promise<void>;
+  onResetField: (item: TaskFieldItem) => Promise<void>;
+  onSaveType: (
+    item: TaskTypeItem,
+    payload: { label: string; tg_theme_url: string },
+  ) => Promise<void>;
+  onResetType: (item: TaskTypeItem) => Promise<void>;
+}
+
+const CARD_CLASS =
+  "rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900";
+
+const SECTION_GAP = "space-y-4";
+
+const FieldCard: React.FC<{
+  item: TaskFieldItem;
+  value: string;
+  onChange: (value: string) => void;
+  onSave: () => Promise<void>;
+  onReset: () => Promise<void>;
+  saving: boolean;
+  error?: string;
+}> = ({ item, value, onChange, onSave, onReset, saving, error }) => {
+  const [localError, setLocalError] = React.useState<string | undefined>(
+    error,
+  );
+
+  React.useEffect(() => {
+    setLocalError(error);
+  }, [error]);
+
+  const defaultLabel = item.meta?.defaultLabel ?? item.name;
+  const storedLabel = item.value?.trim() || defaultLabel;
+  const trimmedValue = value.trim();
+  const dirty = trimmedValue !== storedLabel;
+
+  const handleSave = async () => {
+    setLocalError(undefined);
+    try {
+      await onSave();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setLocalError(message);
+    }
+  };
+
+  const handleReset = async () => {
+    setLocalError(undefined);
+    try {
+      await onReset();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setLocalError(message);
+    }
+  };
+
+  return (
+    <article className={CARD_CLASS}>
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <h4 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+              {defaultLabel}
+              {item.meta?.required ? " *" : ""}
+            </h4>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              Поле: <span className="font-mono">{item.name}</span>
+              {item.meta?.fieldType ? ` • Тип: ${item.meta.fieldType}` : ""}
+            </p>
+          </div>
+        </div>
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+            Отображаемое название
+          </span>
+          <Input
+            value={value}
+            onChange={(event) => onChange(event.target.value)}
+            placeholder={defaultLabel}
+            aria-label={`Название поля ${defaultLabel}`}
+          />
+        </label>
+        {localError ? (
+          <p className="text-sm text-rose-600" role="alert">
+            {localError}
+          </p>
+        ) : null}
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            size="sm"
+            onClick={handleSave}
+            disabled={saving || !dirty || !trimmedValue}
+          >
+            {saving ? <Spinner /> : "Сохранить"}
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={handleReset}
+            disabled={saving || Boolean(item.meta?.virtual)}
+          >
+            Сбросить
+          </Button>
+        </div>
+      </div>
+    </article>
+  );
+};
+
+const TypeCard: React.FC<{
+  item: TaskTypeItem;
+  label: string;
+  url: string;
+  onChangeLabel: (value: string) => void;
+  onChangeUrl: (value: string) => void;
+  onSave: () => Promise<void>;
+  onReset: () => Promise<void>;
+  saving: boolean;
+  error?: string;
+}> = ({
+  item,
+  label,
+  url,
+  onChangeLabel,
+  onChangeUrl,
+  onSave,
+  onReset,
+  saving,
+  error,
+}) => {
+  const [localError, setLocalError] = React.useState<string | undefined>(
+    error,
+  );
+
+  React.useEffect(() => {
+    setLocalError(error);
+  }, [error]);
+
+  const defaultLabel = item.meta?.defaultLabel ?? item.name;
+  const storedLabel = item.value?.trim() || defaultLabel;
+  const storedUrl = typeof item.meta?.tg_theme_url === "string"
+    ? item.meta.tg_theme_url
+    : "";
+  const trimmedLabel = label.trim();
+  const trimmedUrl = url.trim();
+  const dirty =
+    trimmedLabel !== storedLabel || trimmedUrl !== (storedUrl || "");
+
+  const handleSave = async () => {
+    setLocalError(undefined);
+    try {
+      await onSave();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setLocalError(message);
+    }
+  };
+
+  const handleReset = async () => {
+    setLocalError(undefined);
+    try {
+      await onReset();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setLocalError(message);
+    }
+  };
+
+  return (
+    <article className={CARD_CLASS}>
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <h4 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+              {defaultLabel}
+            </h4>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              Тип задачи: <span className="font-mono">{item.name}</span>
+            </p>
+          </div>
+          {typeof item.meta?.tg_topic_id === "number" ? (
+            <span className="text-xs text-slate-500 dark:text-slate-400">
+              Тема: {item.meta.tg_topic_id}
+            </span>
+          ) : null}
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label className="flex flex-col gap-1">
+            <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+              Отображаемое название
+            </span>
+            <Input
+              value={label}
+              onChange={(event) => onChangeLabel(event.target.value)}
+              placeholder={defaultLabel}
+              aria-label={`Название типа ${defaultLabel}`}
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+              Ссылка на тему Telegram
+            </span>
+            <Input
+              value={url}
+              onChange={(event) => onChangeUrl(event.target.value)}
+              placeholder="https://t.me/c/..."
+              aria-label={`Ссылка темы для типа ${defaultLabel}`}
+            />
+          </label>
+        </div>
+        {item.meta?.tg_chat_id ? (
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Чат: {item.meta.tg_chat_id}
+          </p>
+        ) : null}
+        {localError ? (
+          <p className="text-sm text-rose-600" role="alert">
+            {localError}
+          </p>
+        ) : null}
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            size="sm"
+            onClick={handleSave}
+            disabled={saving || !trimmedLabel || !dirty}
+          >
+            {saving ? <Spinner /> : "Сохранить"}
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={handleReset}
+            disabled={saving || Boolean(item.meta?.virtual)}
+          >
+            Сбросить
+          </Button>
+        </div>
+      </div>
+    </article>
+  );
+};
+
+const sortByOrder = <T extends { meta?: { order?: number } }>(items: T[]): T[] =>
+  [...items].sort((a, b) => {
+    const left = typeof a.meta?.order === "number" ? a.meta.order : 0;
+    const right = typeof b.meta?.order === "number" ? b.meta.order : 0;
+    return left - right;
+  });
+
+const useDraftMap = <TItem extends CollectionItem, TDraft>(
+  items: TItem[],
+  selector: (item: TItem) => TDraft,
+) => {
+  const [draft, setDraft] = React.useState<Record<string, TDraft>>({});
+
+  React.useEffect(() => {
+    setDraft((prev) => {
+      let changed = false;
+      const next: Record<string, TDraft> = { ...prev };
+      const itemNames = new Set(items.map((item) => item.name));
+
+      items.forEach((item) => {
+        const key = item.name;
+        if (!(key in prev)) {
+          next[key] = selector(item);
+          changed = true;
+        }
+      });
+
+      Object.keys(prev).forEach((key) => {
+        if (!itemNames.has(key)) {
+          delete next[key];
+          changed = true;
+        }
+      });
+
+      return changed ? next : prev;
+    });
+  }, [items, selector]);
+
+  return [draft, setDraft] as const;
+};
+
+const TaskSettingsTab: React.FC<TaskSettingsTabProps> = ({
+  fields,
+  types,
+  loading,
+  onRefresh,
+  onSaveField,
+  onResetField,
+  onSaveType,
+  onResetType,
+}) => {
+  const selectFieldDraft = React.useCallback(
+    (item: TaskFieldItem) =>
+      item.value?.trim() || item.meta?.defaultLabel || item.name,
+    [],
+  );
+  const selectTypeDraft = React.useCallback(
+    (item: TaskTypeItem) => ({
+      label: item.value?.trim() || item.meta?.defaultLabel || item.name,
+      url:
+        typeof item.meta?.tg_theme_url === "string"
+          ? item.meta.tg_theme_url
+          : "",
+    }),
+    [],
+  );
+
+  const [fieldDrafts, setFieldDrafts] = useDraftMap(fields, selectFieldDraft);
+  const [typeDrafts, setTypeDrafts] = useDraftMap(types, selectTypeDraft);
+  const [savingField, setSavingField] = React.useState<string | null>(null);
+  const [savingType, setSavingType] = React.useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = React.useState<Record<string, string>>({});
+  const [typeErrors, setTypeErrors] = React.useState<Record<string, string>>({});
+
+  React.useEffect(() => {
+    onRefresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const sortedFields = React.useMemo(() => sortByOrder(fields), [fields]);
+  const sortedTypes = React.useMemo(() => sortByOrder(types), [types]);
+
+  const handleFieldChange = (name: string, value: string) => {
+    setFieldDrafts((prev) => ({ ...prev, [name]: value }));
+    setFieldErrors((prev) => ({ ...prev, [name]: "" }));
+  };
+
+  const handleTypeChange = (
+    name: string,
+    patch: Partial<{ label: string; url: string }>,
+  ) => {
+    setTypeDrafts((prev) => ({
+      ...prev,
+      [name]: { ...prev[name], ...patch },
+    }));
+    setTypeErrors((prev) => ({ ...prev, [name]: "" }));
+  };
+
+  const saveField = async (item: TaskFieldItem) => {
+    const value = fieldDrafts[item.name] ?? "";
+    setSavingField(item.name);
+    setFieldErrors((prev) => ({ ...prev, [item.name]: "" }));
+    try {
+      await onSaveField(item, value);
+      setFieldDrafts((prev) => ({
+        ...prev,
+        [item.name]: value,
+      }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setFieldErrors((prev) => ({ ...prev, [item.name]: message }));
+      throw err;
+    } finally {
+      setSavingField((prev) => (prev === item.name ? null : prev));
+    }
+  };
+
+  const resetField = async (item: TaskFieldItem) => {
+    setSavingField(item.name);
+    setFieldErrors((prev) => ({ ...prev, [item.name]: "" }));
+    try {
+      await onResetField(item);
+      setFieldDrafts((prev) => ({
+        ...prev,
+        [item.name]: item.meta?.defaultLabel ?? item.name,
+      }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setFieldErrors((prev) => ({ ...prev, [item.name]: message }));
+      throw err;
+    } finally {
+      setSavingField((prev) => (prev === item.name ? null : prev));
+    }
+  };
+
+  const saveType = async (item: TaskTypeItem) => {
+    const draft = typeDrafts[item.name] ?? { label: "", url: "" };
+    setSavingType(item.name);
+    setTypeErrors((prev) => ({ ...prev, [item.name]: "" }));
+    try {
+      await onSaveType(item, { label: draft.label, tg_theme_url: draft.url });
+      setTypeDrafts((prev) => ({
+        ...prev,
+        [item.name]: { label: draft.label, url: draft.url },
+      }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setTypeErrors((prev) => ({ ...prev, [item.name]: message }));
+      throw err;
+    } finally {
+      setSavingType((prev) => (prev === item.name ? null : prev));
+    }
+  };
+
+  const resetType = async (item: TaskTypeItem) => {
+    setSavingType(item.name);
+    setTypeErrors((prev) => ({ ...prev, [item.name]: "" }));
+    try {
+      await onResetType(item);
+      setTypeDrafts((prev) => ({
+        ...prev,
+        [item.name]: {
+          label: item.meta?.defaultLabel ?? item.name,
+          url: "",
+        },
+      }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setTypeErrors((prev) => ({ ...prev, [item.name]: message }));
+      throw err;
+    } finally {
+      setSavingType((prev) => (prev === item.name ? null : prev));
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <section className={SECTION_GAP}>
+        <header className="space-y-1">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            Поля задачи
+          </h3>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Настройте названия полей, которые видят пользователи в карточке
+            задачи.
+          </p>
+        </header>
+        {loading && !sortedFields.length ? (
+          <div className="flex items-center justify-center py-6">
+            <Spinner />
+          </div>
+        ) : (
+          <div className="grid gap-4 lg:grid-cols-2">
+            {sortedFields.map((item) => (
+              <FieldCard
+                key={item._id}
+                item={item}
+                value={fieldDrafts[item.name] ?? ""}
+                onChange={(value) => handleFieldChange(item.name, value)}
+                onSave={() => saveField(item)}
+                onReset={() => resetField(item)}
+                saving={savingField === item.name}
+                error={fieldErrors[item.name]}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+      <section className={SECTION_GAP}>
+        <header className="space-y-1">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            Типы задач и темы Telegram
+          </h3>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Для каждого типа задачи можно задать отображаемое название и тему
+            чата Telegram, куда будут публиковаться сообщения.
+          </p>
+        </header>
+        {loading && !sortedTypes.length ? (
+          <div className="flex items-center justify-center py-6">
+            <Spinner />
+          </div>
+        ) : (
+          <div className="grid gap-4 lg:grid-cols-2">
+            {sortedTypes.map((item) => (
+              <TypeCard
+                key={item._id}
+                item={item}
+                label={typeDrafts[item.name]?.label ?? ""}
+                url={typeDrafts[item.name]?.url ?? ""}
+                onChangeLabel={(value) =>
+                  handleTypeChange(item.name, { label: value })
+                }
+                onChangeUrl={(value) =>
+                  handleTypeChange(item.name, { url: value })
+                }
+                onSave={() => saveType(item)}
+                onReset={() => resetType(item)}
+                saving={savingType === item.name}
+                error={typeErrors[item.name]}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default TaskSettingsTab;

--- a/apps/web/src/services/collections.ts
+++ b/apps/web/src/services/collections.ts
@@ -21,6 +21,14 @@ export interface CollectionItemMeta {
   departmentId?: string;
   divisionId?: string;
   positionId?: string;
+  defaultLabel?: string;
+  fieldType?: string;
+  required?: boolean;
+  order?: number;
+  virtual?: boolean;
+  tg_theme_url?: string;
+  tg_chat_id?: string;
+  tg_topic_id?: number;
   [key: string]: unknown;
 }
 
@@ -58,6 +66,8 @@ const validationMessageKeys: Record<string, string> = {
   "Значение элемента обязательно": "collections.errors.valueRequired",
   "Значение элемента не может быть пустым": "collections.errors.valueRequired",
   "Ошибка валидации": "collections.errors.generalValidation",
+  "Ссылка на тему Telegram должна иметь формат https://t.me/c/<id>/<topic>":
+    "collections.errors.invalidTelegramTopicUrl",
 };
 
 const typeSpecificValidationKeys: Record<string, Record<string, string>> = {
@@ -242,7 +252,7 @@ export const fetchAllCollectionItems = async (
 
 export const createCollectionItem = (
   type: string,
-  data: { name: string; value: string },
+  data: { name: string; value: string; meta?: Record<string, unknown> },
 ) =>
   authFetch("/api/v1/collections", {
     method: "POST",
@@ -259,7 +269,7 @@ export const createCollectionItem = (
 
 export const updateCollectionItem = (
   id: string,
-  data: { name: string; value: string },
+  data: { name?: string; value?: string; meta?: Record<string, unknown> },
   options?: ParseErrorOptions,
 ) =>
   authFetch(`/api/v1/collections/${id}`, {


### PR DESCRIPTION
## Summary
- add backend utilities for parsing Telegram topic links and caching task type settings
- expose task fields and types metadata in collections with Telegram topic support
- extend control panel settings with a new "Задачи" tab for editing task labels and topic URLs

## Testing
- pnpm test:unit -- CollectionsPage
- pnpm test:unit
- pnpm lint
- pnpm build


------
https://chatgpt.com/codex/tasks/task_b_68e5732067bc8320a7be1c3c81106d54