### PR TITLE
test: align Task mocks with findOneAndUpdate

### DIFF
--- a/apps/api/tests/tasks.test.ts
+++ b/apps/api/tests/tasks.test.ts
@@ -28,8 +28,9 @@ jest.mock('../src/db/model', () => ({
       status: 'Новая',
       time_spent: 0,
     })),
-    findByIdAndUpdate: jest.fn(async (_id, d) => ({ _id, ...(d.$set || d) })),
+    findOneAndUpdate: jest.fn(async (query, d) => ({ _id: query._id, ...(d.$set || d) })),
     findById: jest.fn(async () => ({
+      _id: '1',
       time_spent: 0,
       save: jest.fn(),
       history: [],
@@ -176,7 +177,7 @@ test('обновление с очисткой габаритов проходи
     .patch(`/api/v1/tasks/${id}`)
     .send({ cargo_length_m: '', cargo_weight_kg: '   ' });
   expect(res.status).toBe(200);
-  const [, update] = Task.findByIdAndUpdate.mock.calls.at(-1);
+  const [, update] = Task.findOneAndUpdate.mock.calls.at(-1);
   expect(update.$set).not.toHaveProperty('cargo_length_m', '');
   expect(update.$set).not.toHaveProperty('cargo_weight_kg', '   ');
 });

--- a/tests/task.history.spec.ts
+++ b/tests/task.history.spec.ts
@@ -4,19 +4,23 @@ import { updateTask } from '../apps/api/src/db/queries';
 import { Types } from 'mongoose';
 
 jest.mock('../apps/api/src/db/model', () => ({
-  Task: { findById: jest.fn(), findByIdAndUpdate: jest.fn() },
+  Task: { findById: jest.fn(), findOneAndUpdate: jest.fn() },
 }));
 
 const { Task } = require('../apps/api/src/db/model');
 
 test('сохраняет diff и пользователя', async () => {
   const id = String(new Types.ObjectId());
-  (Task.findById as jest.Mock).mockResolvedValue({ status: 'Новая' });
-  (Task.findByIdAndUpdate as jest.Mock).mockResolvedValue({});
+  const objectId = new Types.ObjectId(id);
+  (Task.findById as jest.Mock).mockResolvedValue({
+    _id: objectId,
+    status: 'Новая',
+  });
+  (Task.findOneAndUpdate as jest.Mock).mockResolvedValue({});
   await updateTask(id, { status: 'В работе' }, 42);
   expect(Task.findById).toHaveBeenCalledWith(id);
-  expect(Task.findByIdAndUpdate).toHaveBeenCalledWith(
-    id,
+  expect(Task.findOneAndUpdate).toHaveBeenCalledWith(
+    { _id: objectId, status: 'Новая' },
     expect.objectContaining({
       $set: {
         status: 'В работе',

--- a/tests/taskHistory.service.spec.ts
+++ b/tests/taskHistory.service.spec.ts
@@ -5,7 +5,7 @@ import { getTaskHistoryMessage } from '../apps/api/src/tasks/taskHistory.service
 jest.mock('../apps/api/src/db/model', () => ({
   Task: {
     findById: jest.fn(),
-    findByIdAndUpdate: jest.fn(),
+    findOneAndUpdate: jest.fn(),
   },
 }));
 

--- a/tests/tasks.notifyAttachments.spec.ts
+++ b/tests/tasks.notifyAttachments.spec.ts
@@ -94,6 +94,7 @@ jest.mock('../apps/api/src/db/model', () => {
   }));
   return {
     Task: {
+      findOneAndUpdate: updateTaskMock,
       findByIdAndUpdate: updateTaskMock,
       findById: taskFindByIdMock,
       updateOne: updateOneMock,


### PR DESCRIPTION
## Что сделано
- обновил jest-моки задач в API-тестах, подставляя `findOneAndUpdate` и `_id` предыдущей записи
- синхронизировал вспомогательные юнит-тесты истории задач с новым методом модели
- оставил совместимость уведомлений по вложениям, добавив алиас `findOneAndUpdate`

## Почему
- `updateTask` теперь использует `Task.findOneAndUpdate`, поэтому старые моки без метода падали с `TypeError`
- тесты истории ожидали строковый `id`, что не совпадало с новым запросом с `_id`

## Чек-лист
- [x] Тесты проходят локально
- [ ] Линтер / форматирование (без изменений)
- [ ] Сборка (не запускалась для PR)
- [x] Обратная совместимость сохранена

## Логи
- `pnpm exec jest tests/task.history.spec.ts tests/taskHistory.service.spec.ts tests/tasks.notifyAttachments.spec.ts apps/api/tests/tasks.test.ts`

## Самопроверка
- убедился, что все изменённые моки покрывают новые вызовы
- проверил, что история задач фиксирует ObjectId и статус
- убедился, что уведомления по вложениям продолжают использовать общий мок
- просмотрел diff на отсутствие посторонних файлов

------
https://chatgpt.com/codex/tasks/task_b_68e6068816688320b960e902363b81ca