### PR TITLE
feat: improve task save error feedback

### DIFF
--- a/apps/web/src/components/TaskDialog.test.tsx
+++ b/apps/web/src/components/TaskDialog.test.tsx
@@ -107,12 +107,16 @@ const updateTaskMock = jest.fn().mockResolvedValue({
   json: async () => ({ ...taskData, _id: "1" }),
 });
 
-jest.mock("../services/tasks", () => ({
-  createTask: (...args: any[]) => createTaskMock(...args),
-  updateTask: (...args: any[]) => updateTaskMock(...args),
-  deleteTask: jest.fn(),
-  updateTaskStatus: jest.fn(),
-}));
+jest.mock("../services/tasks", () => {
+  const actual = jest.requireActual("../services/tasks");
+  return {
+    ...actual,
+    createTask: (...args: any[]) => createTaskMock(...args),
+    updateTask: (...args: any[]) => updateTaskMock(...args),
+    deleteTask: jest.fn(),
+    updateTaskStatus: jest.fn(),
+  };
+});
 
 describe("TaskDialog", () => {
   beforeEach(() => {

--- a/apps/web/src/components/TaskDialog.tsx
+++ b/apps/web/src/components/TaskDialog.tsx
@@ -17,6 +17,7 @@ import {
   updateTask,
   deleteTask,
   updateTaskStatus,
+  TaskRequestError,
 } from "../services/tasks";
 import authFetch from "../utils/authFetch";
 import parseGoogleAddress from "../utils/parseGoogleAddress";
@@ -994,12 +995,13 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
           const startMinutes = Math.floor(parsedStart.getTime() / 60000);
           const createdMinutes = Math.floor(creationDate.getTime() / 60000);
           if (startMinutes < createdMinutes) {
-          setError("startDate", {
-            type: "validate",
-            message: t("startBeforeCreated"),
-          });
-          return;
-        }
+            setError("startDate", {
+              type: "validate",
+              message: t("startBeforeCreated"),
+            });
+            setAlertMsg(t("startBeforeCreated"));
+            return;
+          }
         }
       }
       const initialValues = initialRef.current;
@@ -1093,6 +1095,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
           type: "required",
           message: t("assigneeRequiredError"),
         });
+        setAlertMsg(t("assigneeRequiredError"));
         return;
       }
       const assignedNumeric = toNumericValue(assignedRaw);
@@ -1220,7 +1223,18 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
       if (taskData && onSave) onSave(taskData as Task);
     } catch (e) {
       console.error(e);
-      setAlertMsg(t("taskSaveFailed"));
+      if (e instanceof TaskRequestError) {
+        const reason = e.message.trim();
+        setAlertMsg(
+          reason
+            ? t("taskSaveFailedWithReason", { reason })
+            : t("taskSaveFailed"),
+        );
+      } else if (e instanceof Error && e.message) {
+        setAlertMsg(t("taskSaveFailedWithReason", { reason: e.message }));
+      } else {
+        setAlertMsg(t("taskSaveFailed"));
+      }
     } finally {
       setIsSubmitting(false);
     }
@@ -2000,6 +2014,7 @@ export default function TaskDialog({ onClose, onSave, id }: Props) {
                           });
                         }
                       });
+                      setAlertMsg(t("taskValidationFailed"));
                     }
                     console.warn("Не удалось сохранить задачу", error);
                     setIsSubmitting(false);

--- a/apps/web/src/locales/en/translation.json
+++ b/apps/web/src/locales/en/translation.json
@@ -85,6 +85,8 @@
   "taskDeleted": "Task deleted",
   "taskNumber": "Task number",
   "taskSaveFailed": "Failed to save task",
+  "taskSaveFailedWithReason": "Failed to save task: {{reason}}",
+  "taskValidationFailed": "Check required fields before saving",
   "taskSection": "\uD83D\uDD28 Task",
   "taskTitle": "Task title",
   "taskType": "Task type",

--- a/apps/web/src/locales/ru/translation.json
+++ b/apps/web/src/locales/ru/translation.json
@@ -89,6 +89,8 @@
   "taskDeleted": "Задача удалена",
   "taskNumber": "Номер задачи",
   "taskSaveFailed": "Не удалось сохранить задачу",
+  "taskSaveFailedWithReason": "Не удалось сохранить задачу: {{reason}}",
+  "taskValidationFailed": "Проверьте заполнение обязательных полей",
   "taskSection": "\uD83D\uDD28 Задача",
   "taskTitle": "Название задачи",
   "taskType": "Тип задачи",

--- a/apps/web/src/pages/Tasks.tsx
+++ b/apps/web/src/pages/Tasks.tsx
@@ -9,7 +9,7 @@ import SkeletonCard from "../components/SkeletonCard";
 import Spinner from "../components/Spinner";
 import { useAuth } from "../context/useAuth";
 import { useToast } from "../context/useToast";
-import { createTask } from "../services/tasks";
+import { createTask, TaskRequestError } from "../services/tasks";
 import authFetch from "../utils/authFetch";
 import type { Task } from "shared";
 
@@ -38,13 +38,24 @@ export default function Tasks() {
   const add = async (e: React.FormEvent) => {
     e.preventDefault();
     setPosting(true);
-    const res = await createTask({ title: text, task_description: text });
-    if (res) {
-      setText("");
-      addToast("Задача создана");
-      setTasks([...tasks, res]);
+    try {
+      const res = await createTask({ title: text, task_description: text });
+      if (res) {
+        setText("");
+        addToast("Задача создана");
+        setTasks([...tasks, res]);
+      }
+    } catch (error) {
+      if (error instanceof TaskRequestError) {
+        addToast(`Не удалось создать задачу: ${error.message}`);
+      } else if (error instanceof Error) {
+        addToast(`Не удалось создать задачу: ${error.message}`);
+      } else {
+        addToast("Не удалось создать задачу");
+      }
+    } finally {
+      setPosting(false);
     }
-    setPosting(false);
   };
 
   const totalPages = Math.ceil(tasks.length / perPage);


### PR DESCRIPTION
## Summary
- add a dedicated TaskRequestError to surface API failure reasons when creating or updating tasks
- show explicit alert popups for validation issues on the task dialog and include localized messages
- update the tasks list page toast handling to report creation failures and extend locale strings

## Testing
- pnpm test:unit -- TaskDialog
- pnpm --dir apps/web lint

------
https://chatgpt.com/codex/tasks/task_b_68e610371000832080a25293efb6a8db