### PR TITLE
feat: add requests management ui

### DIFF
--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -561,8 +561,16 @@ router.get(
     query('to').optional().isISO8601(),
     query('page').optional().isInt({ min: 1 }),
     query('limit').optional().isInt({ min: 1 }),
+    query('kind').optional().isIn(['task', 'request']),
   ] as RequestHandler[],
   ctrl.list as RequestHandler,
+);
+
+router.get(
+  '/executors',
+  authMiddleware(),
+  [query('kind').optional().isIn(['task', 'request'])] as RequestHandler[],
+  ctrl.executors as RequestHandler,
 );
 
 router.get('/mentioned', authMiddleware(), ctrl.mentioned);
@@ -570,7 +578,11 @@ router.get('/mentioned', authMiddleware(), ctrl.mentioned);
 router.get(
   '/report/summary',
   authMiddleware(),
-  [query('from').optional().isISO8601(), query('to').optional().isISO8601()],
+  [
+    query('from').optional().isISO8601(),
+    query('to').optional().isISO8601(),
+    query('kind').optional().isIn(['task', 'request']),
+  ],
   ctrl.summary as RequestHandler,
 );
 
@@ -581,6 +593,17 @@ router.get(
   detailLimiter as unknown as RequestHandler,
   param('id').isMongoId(),
   ctrl.detail as RequestHandler,
+);
+
+router.post(
+  '/requests',
+  authMiddleware(),
+  upload.any(),
+  processUploads,
+  normalizeArrays,
+  ...(taskFormValidators as unknown as RequestHandler[]),
+  ...(validateDto(CreateTaskDto) as RequestHandler[]),
+  ...(ctrl.createRequest as RequestHandler[]),
 );
 
 router.post(

--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -269,6 +269,9 @@ class TasksService {
 
   async bulk(ids: string[], data: Partial<TaskDocument>) {
     const payload = { ...(data ?? {}) } as Partial<TaskDocument>;
+    if (Object.prototype.hasOwnProperty.call(payload, 'kind')) {
+      delete (payload as Record<string, unknown>).kind;
+    }
     if (Object.prototype.hasOwnProperty.call(payload, 'status')) {
       const status = payload.status;
       const isCompleted = status === 'Выполнена' || status === 'Отменена';

--- a/apps/web/src/AuthenticatedApp.tsx
+++ b/apps/web/src/AuthenticatedApp.tsx
@@ -18,6 +18,7 @@ import ErrorBoundary from "./components/ErrorBoundary";
 import ArchiveRoute from "./components/ArchiveRoute";
 
 const TasksPage = lazy(() => import("./pages/TasksPage"));
+const RequestsPage = lazy(() => import("./pages/RequestsPage"));
 const Reports = lazy(() => import("./pages/Reports"));
 const LogsPage = lazy(() => import("./pages/Logs"));
 const Profile = lazy(() => import("./pages/Profile"));
@@ -71,6 +72,14 @@ function AppShell() {
                 element={
                   <ProtectedRoute>
                     <TasksPage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/requests"
+                element={
+                  <ProtectedRoute>
+                    <RequestsPage />
                   </ProtectedRoute>
                 }
               />

--- a/apps/web/src/components/TaskDialogRoute.tsx
+++ b/apps/web/src/components/TaskDialogRoute.tsx
@@ -14,10 +14,12 @@ export default function TaskDialogRoute() {
   const { refresh } = useTasks();
   const id = coerceTaskId(params.get("task"));
   const create = params.get("newTask");
-  if (!id && !create) return null;
+  const createRequest = params.get("newRequest");
+  if (!id && !create && !createRequest) return null;
   const close = () => {
     params.delete("task");
     params.delete("newTask");
+    params.delete("newRequest");
     navigate({ search: params.toString() }, { replace: true });
   };
   return (
@@ -29,6 +31,7 @@ export default function TaskDialogRoute() {
           onSave={() => {
             refresh();
           }}
+          kind={createRequest ? "request" : undefined}
         />
       </Suspense>
     </Modal>

--- a/apps/web/src/components/TaskTable.tsx
+++ b/apps/web/src/components/TaskTable.tsx
@@ -6,12 +6,15 @@ import taskColumns, { TaskRow } from "../columns/taskColumns";
 import useTasks from "../context/useTasks";
 import coerceTaskId from "../utils/coerceTaskId";
 
+type EntityKind = "task" | "request";
+
 interface TaskTableProps {
   tasks: TaskRow[];
   users?: Record<number, any>;
   page: number;
   pageCount?: number;
   mine?: boolean;
+  entityKind?: EntityKind;
   onPageChange: (p: number) => void;
   onMineChange?: (v: boolean) => void;
   onRowClick?: (id: string) => void;
@@ -25,6 +28,7 @@ export default function TaskTable({
   page,
   pageCount,
   mine = false,
+  entityKind = "task",
   onPageChange,
   onMineChange,
   onRowClick,
@@ -32,7 +36,10 @@ export default function TaskTable({
   onDataChange,
 }: TaskTableProps) {
   const { query, filters } = useTasks();
-  const columns = React.useMemo(() => taskColumns(users), [users]);
+  const columns = React.useMemo(
+    () => taskColumns(users, entityKind),
+    [users, entityKind],
+  );
 
   React.useEffect(() => {
     onDataChange?.(tasks);

--- a/apps/web/src/layouts/Sidebar.tsx
+++ b/apps/web/src/layouts/Sidebar.tsx
@@ -5,6 +5,7 @@ import { useSidebar } from "../context/useSidebar";
 import { useAuth } from "../context/useAuth";
 import {
   ClipboardDocumentListIcon,
+  InboxArrowDownIcon,
   RectangleStackIcon,
   ChartPieIcon,
   MapIcon,
@@ -18,6 +19,7 @@ import { ARCHIVE_ACCESS, hasAccess } from "../utils/access";
 
 const baseItems = [
   { to: "/tasks", label: "Задачи", icon: ClipboardDocumentListIcon },
+  { to: "/requests", label: "Заявки", icon: InboxArrowDownIcon },
   { to: "/profile", label: "Профиль", icon: UserCircleIcon },
 ];
 

--- a/apps/web/src/pages/RequestsPage.tsx
+++ b/apps/web/src/pages/RequestsPage.tsx
@@ -1,0 +1,136 @@
+// Назначение файла: список заявок с таблицей DataTable
+// Модули: React, контексты, сервисы задач, shared
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import TaskTable from "../components/TaskTable";
+import useTasks from "../context/useTasks";
+import { fetchTasks } from "../services/tasks";
+import authFetch from "../utils/authFetch";
+import { type Task, type User } from "shared";
+import { useAuth } from "../context/useAuth";
+
+interface RequestRow extends Task {
+  assigned_user_id?: number;
+  [key: string]: unknown;
+}
+
+export default function RequestsPage() {
+  const [items, setItems] = React.useState<RequestRow[]>([]);
+  const [page, setPage] = React.useState(0);
+  const [total, setTotal] = React.useState(0);
+  const [users, setUsers] = React.useState<User[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [params, setParams] = useSearchParams();
+  const [mine, setMine] = React.useState(params.get("mine") === "1");
+  const { version, refresh } = useTasks();
+  const { user, loading: authLoading } = useAuth();
+  const isAdmin = user?.role === "admin";
+  const isManager = user?.role === "manager";
+  const isPrivileged = isAdmin || isManager;
+
+  const load = React.useCallback(() => {
+    if (!user?.telegram_id) return;
+    setLoading(true);
+    fetchTasks(
+      {
+        page: page + 1,
+        limit: 25,
+        mine: mine ? 1 : undefined,
+        kind: "request",
+      },
+      user.telegram_id,
+      true,
+    )
+      .then((data) => {
+        const tasks = data.tasks as RequestRow[];
+        const filtered = isPrivileged
+          ? tasks
+          : tasks.filter((t) => {
+              const assigned =
+                t.assignees || (t.assigned_user_id ? [t.assigned_user_id] : []);
+              const uid = user.telegram_id;
+              return assigned.includes(uid) || t.created_by === uid;
+            });
+        setItems(filtered);
+        setTotal(data.total || filtered.length);
+        const list = Array.isArray(data.users)
+          ? (data.users as User[])
+          : (Object.values(data.users || {}) as User[]);
+        setUsers(list);
+      })
+      .finally(() => setLoading(false));
+    if (isPrivileged) {
+      authFetch("/api/v1/users")
+        .then((r) => (r.ok ? r.json() : []))
+        .then((list) =>
+          setUsers(Array.isArray(list) ? list : Object.values(list || {})),
+        )
+        .catch(() => undefined);
+    }
+  }, [isPrivileged, mine, page, user]);
+
+  React.useEffect(() => {
+    if (authLoading) return;
+    if (!user?.telegram_id) return;
+    load();
+  }, [authLoading, user, load, version, page, mine]);
+
+  const map = React.useMemo(() => {
+    const registry: Record<number, User> = {};
+    users.forEach((candidate) => {
+      registry[candidate.telegram_id] = candidate;
+    });
+    return registry;
+  }, [users]);
+
+  if (authLoading) {
+    return <div>Загрузка...</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+        Панель заявок
+      </h2>
+      {loading && <div>Загрузка...</div>}
+      <TaskTable
+        tasks={items}
+        users={map}
+        page={page}
+        pageCount={Math.ceil(total / 25)}
+        mine={mine}
+        entityKind="request"
+        onPageChange={setPage}
+        onMineChange={(value) => {
+          setMine(value);
+          if (value) params.set("mine", "1");
+          else params.delete("mine");
+          setParams(params);
+        }}
+        onRowClick={(id) => {
+          params.set("task", id);
+          setParams(params);
+        }}
+        toolbarChildren={
+          <>
+            <button
+              onClick={refresh}
+              className="rounded bg-blue-600 px-2 py-1 text-sm text-white hover:bg-blue-700"
+            >
+              Обновить
+            </button>
+            <button
+              onClick={() => {
+                params.set("newRequest", "1");
+                setParams(params);
+              }}
+              className="rounded bg-blue-600 px-2 py-1 text-sm text-white hover:bg-blue-700"
+            >
+              Новая заявка
+            </button>
+          </>
+        }
+      />
+    </div>
+  );
+}

--- a/apps/web/src/services/tasks.ts
+++ b/apps/web/src/services/tasks.ts
@@ -131,13 +131,14 @@ export const updateTaskStatus = (id: string, status: string) =>
     body: JSON.stringify({ status }),
   });
 
-export const createTask = async (
+const submitTask = async (
+  endpoint: string,
   data: Record<string, unknown>,
   files?: FileList | File[],
   onProgress?: (e: ProgressEvent) => void,
 ) => {
   const body = buildTaskFormData(data, files);
-  const response = await authFetch("/api/v1/tasks", {
+  const response = await authFetch(endpoint, {
     method: "POST",
     body,
     onProgress,
@@ -157,6 +158,18 @@ export const createTask = async (
   clearTasksCache();
   return result;
 };
+
+export const createTask = async (
+  data: Record<string, unknown>,
+  files?: FileList | File[],
+  onProgress?: (e: ProgressEvent) => void,
+) => submitTask("/api/v1/tasks", data, files, onProgress);
+
+export const createRequest = async (
+  data: Record<string, unknown>,
+  files?: FileList | File[],
+  onProgress?: (e: ProgressEvent) => void,
+) => submitTask("/api/v1/tasks/requests", data, files, onProgress);
 
 export const deleteTask = (id: string) =>
   authFetch(`/api/v1/tasks/${id}`, {
@@ -188,6 +201,23 @@ export const updateTask = async (
 
 export const fetchMentioned = () =>
   authFetch("/api/v1/tasks/mentioned").then((r) => (r.ok ? r.json() : []));
+
+export const fetchRequestExecutors = (): Promise<User[]> =>
+  authFetch("/api/v1/tasks/executors?kind=request")
+    .then((r) => (r.ok ? r.json() : []))
+    .then((list) =>
+      Array.isArray(list)
+        ? (list as User[]).map((item) => ({
+            telegram_id: item.telegram_id,
+            name: item.name,
+            username: item.username,
+            telegram_username:
+              (item as User & { telegram_username?: string }).telegram_username ??
+              item.username ??
+              null,
+          }))
+        : [],
+    );
 
 export interface TasksResponse {
   tasks: Task[];

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -7,6 +7,7 @@ export const TASK_TYPES = [
   'Выполнить',
   'Построить',
   'Починить',
+  'Заявка',
 ] as const;
 
 export const PRIORITIES = ['Срочно', 'В течение дня', 'До выполнения'] as const;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -11,6 +11,9 @@ export interface Task {
   _id: string;
   title: string;
   status: 'Новая' | 'В работе' | 'Выполнена' | 'Отменена';
+  kind?: 'task' | 'request';
+  request_id?: string;
+  task_number?: string;
   completed_at?: string | null;
   in_progress_at?: string | null;
   assignees?: number[];


### PR DESCRIPTION
## Summary
- add a dedicated Requests page with routing and navigation entry for end users
- update shared task table/columns to adapt terminology and numbering for request kind
- relax backend request detection and surface new request APIs to the web client

## Testing
- pnpm lint
- pnpm test:unit -- --runTestsByPath apps/web/src/columns/__tests__/taskColumns.test.tsx --runInBand

------
https://chatgpt.com/codex/tasks/task_b_68e64b27f4d88320ab32eb3ced5e03a6