### PR TITLE
fix: normalize TaskDialog translation helper invocation

### DIFF
--- a/apps/web/src/components/TaskDialog.tsx
+++ b/apps/web/src/components/TaskDialog.tsx
@@ -333,8 +333,8 @@ export default function TaskDialog({ onClose, onSave, id, kind }: Props) {
     [entityKind],
   );
   const t = React.useCallback(
-    (key: string, options?: Parameters<typeof rawT>[1]) =>
-      adaptTaskText(String(rawT(key, options))),
+    (...args: Parameters<typeof rawT>): string =>
+      adaptTaskText(String(rawT(...args))),
     [rawT, adaptTaskText],
   );
   React.useEffect(() => {


### PR DESCRIPTION
## Что сделано
- Исправил обёртку над `useTranslation` в `TaskDialog`, чтобы корректно прокидывать параметры и избегать ошибок типов.
- Сохранил текущую логику адаптации текста для заявок, возвращая строки без изменения поведения.

## Почему
- TypeScript-ошибка в CI блокировала сборку: обёртка передавала второй аргумент как объединение строк и опций, что не удовлетворяет сигнатуре `rawT`.

## Чек-лист
- [x] Линтер (`pnpm lint`)
- [x] Юнит-тесты (`pnpm jest apps/web/src/components/TaskDialog.test.tsx`)
- [x] Сборка (`pnpm build`)
- [ ] Dev-сервер (`pnpm run dev`) — падает при запуске API в изолированной среде

## Логи
- `pnpm lint`
- `pnpm jest apps/web/src/components/TaskDialog.test.tsx`
- `pnpm build`
- `pnpm run dev`

## Самопроверка
- [x] Изменения точечные и не затрагивают логику вне переводов.
- [x] CI-ошибка воспроизводилась и устранена локально.
- [x] Проверил, что функция возвращает строки и остаётся совместимой с i18next.
- [ ] Dev-сервер не стартует из-за отсутствия доступной MongoDB/окружения Telegram.


------
https://chatgpt.com/codex/tasks/task_b_68e65998bb4483209fa48dc1c82f4c93