### PR TITLE
Wait for Redis connect in RefreshStore and normalize env vars

### DIFF
--- a/apps/api/src/services/refreshStore.ts
+++ b/apps/api/src/services/refreshStore.ts
@@ -33,6 +33,19 @@ interface RefreshStore {
 
 type RedisCommandResult<T> = { ok: true; value: T } | { ok: false };
 
+const normalizeEnvValue = (value: string | undefined): string => {
+  if (!value) {
+    return '';
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  return trimmed.replace(/^(['"])(.*)\1$/, '$2').trim();
+};
+
 const isRedisUnavailableError = (error: unknown): boolean => {
   if (!(error instanceof Error)) {
     return false;
@@ -132,6 +145,8 @@ class MemoryRefreshStore implements RefreshStore {
 }
 
 class RedisRefreshStore implements RefreshStore {
+  private connectPromise: Promise<void> | null = null;
+
   constructor(
     private readonly redis: Redis,
     private readonly prefix: string,
@@ -153,6 +168,7 @@ class RedisRefreshStore implements RefreshStore {
     action: () => Promise<T>,
   ): Promise<RedisCommandResult<T>> {
     try {
+      await this.ensureReady();
       return { ok: true, value: await action() };
     } catch (error) {
       if (isRedisUnavailableError(error)) {
@@ -160,6 +176,20 @@ class RedisRefreshStore implements RefreshStore {
       }
       throw error;
     }
+  }
+
+  private async ensureReady(): Promise<void> {
+    if (this.redis.status === 'ready') {
+      return;
+    }
+
+    if (!this.connectPromise) {
+      this.connectPromise = this.redis.connect().finally(() => {
+        this.connectPromise = null;
+      });
+    }
+
+    await this.connectPromise;
   }
 
   async save(
@@ -374,7 +404,9 @@ class ResilientRefreshStore implements RefreshStore {
 let cachedStore: RefreshStore | null = null;
 
 function buildStore(): RefreshStore {
-  const redisUrl = process.env.REDIS_URL || process.env.QUEUE_REDIS_URL;
+  const redisUrl =
+    normalizeEnvValue(process.env.REDIS_URL) ||
+    normalizeEnvValue(process.env.QUEUE_REDIS_URL);
   if (!redisUrl) {
     return new MemoryRefreshStore();
   }
@@ -394,11 +426,11 @@ function buildStore(): RefreshStore {
       maxRetriesPerRequest: 1,
       enableOfflineQueue: false,
     });
-    redis.connect().catch(() => undefined);
     return new ResilientRefreshStore(
       new RedisRefreshStore(
         redis,
-        process.env.REFRESH_REDIS_PREFIX || 'erm:auth:refresh',
+        normalizeEnvValue(process.env.REFRESH_REDIS_PREFIX) ||
+          'erm:auth:refresh',
       ),
       fallbackStore,
     );

--- a/apps/api/tests/refreshStore.redisFallback.test.ts
+++ b/apps/api/tests/refreshStore.redisFallback.test.ts
@@ -15,8 +15,77 @@ describe('refresh store Redis fallback', () => {
   afterEach(() => {
     delete process.env.REDIS_URL;
     delete process.env.QUEUE_REDIS_URL;
+    delete process.env.REFRESH_REDIS_PREFIX;
     jest.restoreAllMocks();
     jest.unmock('ioredis');
+  });
+
+  test('issueSession waits for Redis connect before using the store', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.REDIS_URL = ' "redis://127.0.0.1:6379" ';
+    process.env.REFRESH_REDIS_PREFIX = ' "custom:refresh" ';
+
+    jest.doMock('ioredis', () => {
+      const state = { status: 'wait' };
+      const connect = jest.fn().mockImplementation(async () => {
+        state.status = 'ready';
+      });
+      const createMulti = () => {
+        const chain = {
+          set: jest.fn(() => chain),
+          sadd: jest.fn(() => chain),
+          expire: jest.fn(() => chain),
+          srem: jest.fn(() => chain),
+          del: jest.fn(() => chain),
+          exec: jest.fn().mockResolvedValue([]),
+        };
+        return chain;
+      };
+      const redisMock = {
+        connect,
+        multi: jest.fn(() => createMulti()),
+        get: jest.fn().mockResolvedValue(
+          JSON.stringify({
+            userId: '1',
+            createdAt: Date.now(),
+            expiresAt: Date.now() + 60_000,
+          }),
+        ),
+        smembers: jest.fn().mockResolvedValue([]),
+      };
+
+      const RedisMock = jest.fn().mockImplementation(() =>
+        Object.defineProperty(redisMock, 'status', {
+          configurable: true,
+          enumerable: true,
+          get: () => state.status,
+        }),
+      );
+
+      return {
+        __esModule: true,
+        default: RedisMock,
+      };
+    });
+
+    const { __resetRefreshStoreForTests, getRefreshStore } = await import(
+      '../src/services/refreshStore'
+    );
+
+    __resetRefreshStoreForTests();
+
+    const store = getRefreshStore();
+    await store.save(
+      'hash-old',
+      {
+        userId: '1',
+        createdAt: Date.now(),
+        expiresAt: Date.now() + 60_000,
+      },
+      60,
+    );
+
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   test('issueSession falls back to memory when Redis stream is not writeable', async () => {
@@ -42,6 +111,7 @@ describe('refresh store Redis fallback', () => {
       };
 
       const RedisMock = jest.fn().mockImplementation(() => ({
+        status: 'wait',
         connect: jest.fn().mockRejectedValue(new Error('connect ECONNREFUSED')),
         multi: jest.fn(() => createMulti()),
         get: jest


### PR DESCRIPTION
### Motivation
- Ensure the Redis-backed refresh store waits for the client to become `ready` before issuing commands to avoid accidental fallback to in-memory storage on lazy connections. 
- Make environment variable handling robust against surrounding whitespace and quotes so `REDIS_URL`, `QUEUE_REDIS_URL`, and `REFRESH_REDIS_PREFIX` are parsed correctly.

### Description
- Add `normalizeEnvValue` to trim values and strip surrounding single/double quotes and apply it to `REDIS_URL`, `QUEUE_REDIS_URL`, and `REFRESH_REDIS_PREFIX` in `apps/api/src/services/refreshStore.ts`.
- Add `connectPromise` and `ensureReady` to `RedisRefreshStore` and call `ensureReady` from `runRedisCommand` so Redis commands await `redis.connect()` when the client is not yet `ready`.
- Remove the previous eager `redis.connect().catch(...)` in favor of the new on-demand connect handling.
- Update `apps/api/tests/refreshStore.redisFallback.test.ts` to add a new test `issueSession waits for Redis connect before using the store`, adjust Redis mocks to expose `status` transitions, and clean up `REFRESH_REDIS_PREFIX` in test teardown.

### Testing
- Ran the updated unit tests in `apps/api/tests/refreshStore.redisFallback.test.ts` which include the new connection-waiting test, and they passed.
- Ran the project test suite (`yarn test`) after changes and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c147bf5f948320919bd0513250dbf2)