### PR TITLE
Codex GPT-5.2: fix tasks topic-move Telegram cleanup

### DIFF
--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -1814,12 +1814,11 @@ export default class TasksController {
       return 'failed';
     }
     if (!this.areTopicsEqual(expectedTopic, actualTopic)) {
-      console.warn('Пропускаем удаление сообщения задачи из другой темы', {
+      console.info('Удаляем сообщение задачи после смены темы', {
         expectedTopic,
         actualTopic,
         messageId,
       });
-      return 'skipped';
     }
     try {
       await bot.telegram.deleteMessage(chat, messageId);
@@ -4279,7 +4278,7 @@ export default class TasksController {
             groupChatId,
             messageId,
             typeof plain.title === 'string' ? plain.title : undefined,
-            meta.actual ?? meta.expected,
+            meta.expected ?? meta.actual,
           );
         }
       }

--- a/tests/tasks.notifyAttachments.spec.ts
+++ b/tests/tasks.notifyAttachments.spec.ts
@@ -545,6 +545,71 @@ describe('notifyTaskCreated вложения', () => {
     });
   });
 
+  it('удаляет старое сообщение задачи при переносе в другую тему', async () => {
+    const previousMessageId = 611;
+    const nextMessageId = 612;
+    const nextCommentMessageId = 613;
+    const nextDirectMessageId = 614;
+
+    sendMessageMock.mockResolvedValueOnce({ message_id: nextMessageId });
+    sendMessageMock.mockResolvedValueOnce({ message_id: nextCommentMessageId });
+    sendMessageMock.mockResolvedValueOnce({ message_id: nextDirectMessageId });
+
+    const previousTask = {
+      _id: '507f1f77bcf86cd799439014',
+      task_number: 'TOPIC-1',
+      title: 'Смена темы',
+      attachments: [],
+      telegram_message_id: previousMessageId,
+      telegram_topic_id: 111,
+      assignees: [42],
+      assigned_user_id: 42,
+      created_by: 10,
+      history: [],
+      status: 'Новая',
+      toObject() {
+        return this;
+      },
+    } as unknown as TaskDocument & { toObject(): unknown };
+
+    const updatedTask = {
+      ...previousTask,
+      telegram_topic_id: 7777,
+      toObject() {
+        return this;
+      },
+    } as unknown as TaskDocument & { toObject(): unknown };
+
+    taskFindByIdMock.mockResolvedValue(updatedTask);
+
+    const controller = createController();
+    await (
+      controller as unknown as {
+        broadcastTaskSnapshot(
+          task: TaskDocument,
+          actorId: number,
+          options?: {
+            previous?: TaskDocument | null;
+            action?: 'создана' | 'обновлена';
+            note?: string | null;
+          },
+        ): Promise<void>;
+      }
+    ).broadcastTaskSnapshot(updatedTask, 99, {
+      previous: previousTask,
+      action: 'обновлена',
+    });
+
+    expect(deleteMessageMock).toHaveBeenCalledWith(
+      expect.any(String),
+      previousMessageId,
+    );
+    const groupCall = sendMessageMock.mock.calls.find(
+      (call) => call?.[1] && !String(call[1]).includes('💬 *Комментарий*'),
+    );
+    expect(groupCall?.[2]?.message_thread_id).toBe(7777);
+  });
+
   it('для ошибки wrong type of the web page content отправляет изображение как документ', async () => {
     resolvePhotosTargetMock.mockResolvedValueOnce(null);
 


### PR DESCRIPTION
Mode: Standard; Timezone: Europe/Kyiv

### Motivation
- При переносе задачи между Telegram topics старые сообщения оставались в предыдущей теме из-за логики, которая прерывала удаление по несоответствию topic id. 22 Mar 2026.
- Это приводило к дублирующим/устаревшим сообщениям в Telegram и нарушению консистентности уведомлений.
- Нужен минимальный и безопасный фикс, который удаляет stale-сообщение и корректно обрабатывает fallback-редактирование при ошибках доступа.

### Description
- Изменена логика `deleteTaskMessageSafely` в `apps/api/src/tasks/tasks.controller.ts`, теперь при смене темы логируется факт смены и выполняется попытка удаления старого сообщения вместо немедленного пропуска.
- Исправлен порядок аргументов при fallback-редактировании в том же контроллере, чтобы использовать исходную (expected) тему при попытке отредактировать сообщение, если удаление запрещено.
- Добавлен regression-тест `удаляет старое сообщение задачи при переносе в другую тему` в `tests/tasks.notifyAttachments.spec.ts`, проверяющий удаление старого сообщения и публикацию нового в новой теме.

### Testing
- Запущен таргетный набор тестов: `pnpm --filter apps/api test -- tests/tasks.notifyAttachments.spec.ts --runInBand`, все тесты в файле прошли успешно.
- Верифицировано статическое качество: `pnpm --filter apps/api lint` и `pnpm --filter apps/api typecheck` прошли без ошибок, а `pretest` автоматически выполнил `shared` build как часть пайплайна теста.
- Не запускался полный монорепо билд (`pnpm -r --filter '!shared' build`) и глобальные тесты `pnpm -w test` как избыточные для локализованного исправления; эти шаги можно выполнить в CI при необходимости.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c16b0fe91c8320b7ef8cc4be5905fe)