### PR TITLE
fix(web): fallback to token cookie for bearer auth

### DIFF
--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -2,6 +2,24 @@
 
 let accessToken: string | null = null;
 
+const readCookie = (name: string): string | null => {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = document.cookie.match(
+    new RegExp(`(?:^|;\\s*)${escapedName}=([^;]*)`),
+  );
+  if (!match?.[1]) {
+    return null;
+  }
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
+};
+
 const readEnv = (key: string): string | undefined => {
   const fromProcess =
     typeof process !== 'undefined' ? process.env?.[key] : undefined;
@@ -20,6 +38,14 @@ export const shouldUseBearerAuth = (): boolean => {
 
 export const getAccessToken = (): string | null => accessToken;
 
+export const getAccessTokenFromCookie = (): string | null => {
+  const tokenFromCookie = readCookie('token');
+  if (!tokenFromCookie) {
+    return null;
+  }
+  return tokenFromCookie.trim() || null;
+};
+
 export const setAccessToken = (token: string | null | undefined): void => {
   accessToken = token ? token.trim() : null;
 };
@@ -31,6 +57,7 @@ export const clearAccessToken = (): void => {
 export default {
   shouldUseBearerAuth,
   getAccessToken,
+  getAccessTokenFromCookie,
   setAccessToken,
   clearAccessToken,
 };

--- a/apps/web/src/utils/authFetch.ts
+++ b/apps/web/src/utils/authFetch.ts
@@ -6,6 +6,7 @@ import { showToast } from './toast';
 import {
   clearAccessToken,
   getAccessToken,
+  getAccessTokenFromCookie,
   setAccessToken,
   shouldUseBearerAuth,
 } from '../lib/auth';
@@ -326,8 +327,13 @@ export default async function authFetch(
   }
 
   const accessToken = getAccessToken();
-  if (accessToken) {
-    headers.Authorization = `Bearer ${accessToken}`;
+  const accessTokenFromCookie = getAccessTokenFromCookie();
+  const resolvedAccessToken = accessToken || accessTokenFromCookie;
+  if (resolvedAccessToken) {
+    if (!accessToken && accessTokenFromCookie) {
+      setAccessToken(accessTokenFromCookie);
+    }
+    headers.Authorization = `Bearer ${resolvedAccessToken}`;
   } else if (useBearer && isProfileRequest) {
     const refreshedToken = await refreshAccessToken();
     if (refreshedToken) {


### PR DESCRIPTION
Mode: Standard; Timezone: Europe/Kyiv

### Motivation
- The frontend sometimes received `401 Unauthorized` from `GET /api/v1/auth/profile` when a valid `token` cookie existed but the in-memory access token was empty. 
- Make the client resilient to runtime mismatches between cookie-based and in-memory bearer token storage to avoid unnecessary redirects to login.

### Description
- Added a safe cookie reader and `getAccessTokenFromCookie()` in `apps/web/src/lib/auth.ts` to extract the `token` cookie. 
- Updated `apps/web/src/utils/authFetch.ts` to import `getAccessTokenFromCookie()` and resolve `resolvedAccessToken = in-memory || cookie` before protected requests. 
- When token is recovered from cookie, it is synchronized into the in-memory token via `setAccessToken()` and used to set `Authorization: Bearer ...`. 
- Minimal, focused changes only to the web client auth helpers to preserve behavior in other environments.

### Testing
- Ran `pnpm --filter web exec tsc --noEmit` and it completed successfully. 
- Ran `pnpm --filter web exec eslint src/lib/auth.ts src/utils/authFetch.ts` and lint passed with fixes applied by pre-commit hooks. 
- Pre-commit hooks executed `prettier`, `eslint --fix` and related `jest` checks for touched files and completed successfully; full monorepo build/tests were intentionally not executed for this targeted fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c47128d36c8320a54aa7151bfcbd25)